### PR TITLE
Added mercurial support

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -33,12 +33,12 @@ RIGHT_SEGMENT_SEPARATOR=''
 setopt prompt_subst
 autoload -Uz vcs_info
 zstyle ':vcs_info:*' stagedstr " %F{black}✚%f"
-zstyle ':vcs_info:git:*' unstagedstr " %F{black}●%f"
-zstyle ':vcs_info:git*' actionformats " %b %F{red}| %a%f"
-zstyle ':vcs_info:git*' formats " %b%c%u%m"
+zstyle ':vcs_info:*' unstagedstr " %F{black}●%f"
+zstyle ':vcs_info:*' actionformats " %b %F{red}| %a%f"
+zstyle ':vcs_info:*' formats " %b%c%u%m"
 zstyle ':vcs_info:*' check-for-changes true
 zstyle ':vcs_info:git*+set-message:*' hooks git-untracked git-aheadbehind git-remotebranch git-tagname
-zstyle ':vcs_info:*' enable git
+zstyle ':vcs_info:*' enable git hg
 
 ################################################################
 # Prompt Segment Constructors

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -103,7 +103,7 @@ prompt_context() {
   fi
 }
 
-# Git: branch/detached head, dirty status
+# branch/detached head, dirty status
 prompt_vcs() {
   local vcs_prompt="${vcs_info_msg_0_}"
 
@@ -168,9 +168,11 @@ function +vi-git-tagname() {
 }
 
 function +vi-vcs-detect-changes() {
-	if [[ -n ${hook_com[staged]} ]] || [[ -n ${hook_com[unstaged]} ]]; then
-		VCS_WORKDIR_DIRTY=true
-	fi
+  if [[ -n ${hook_com[staged]} ]] || [[ -n ${hook_com[unstaged]} ]]; then
+    VCS_WORKDIR_DIRTY=true
+  else
+    VCS_WORKDIR_DIRTY=false
+  fi
 }
 
 # Dir: current working directory
@@ -268,9 +270,9 @@ build_right_prompt() {
 
 # Create the prompts
 precmd() { 
-	vcs_info 
-	# Add a static hook to examine staged/unstaged changes.
-	vcs_info_hookadd set-message vcs-detect-changes
+  vcs_info 
+  # Add a static hook to examine staged/unstaged changes.
+  vcs_info_hookadd set-message vcs-detect-changes
 }
 
 PROMPT='%{%f%b%k%}$(build_left_prompt) '

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -45,6 +45,9 @@ zstyle ':vcs_info:hg*' get-revision true # If false, the dirty-check won't work 
 zstyle ':vcs_info:hg*:*' branchformat "%b" # only show branch
 zstyle ':vcs_info:*' enable git hg
 
+## Debugging
+#zstyle ':vcs_info:*+*:*' debug true
+
 ################################################################
 # Prompt Segment Constructors
 ################################################################


### PR DESCRIPTION
Now this theme also works with mercurial! :)

Only thing is:
I had to implement a very poor dirty check. Unfortunately I didn't find a better one that works with mercurial and git.. Now I just check, whether the main VCS_INFO-prompt contains a '●' or '✚'..