### PR TITLE
Add a prompt for rbenv ruby version

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -227,6 +227,13 @@ prompt_rvm() {
   fi
 }
 
+# rbenv information
+prompt_rbenv() {
+  if [[ -n "$RBENV_VERSION" ]]; then
+    $1_prompt_segment red black "$RBENV_VERSION"
+  fi
+}
+
 # Main prompt
 build_left_prompt() {
   if (( ${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS} == 0 )); then


### PR DESCRIPTION
Check for the $RBENV_VERSION environment variable and, if present,  show a prompt with the ruby version being used.