### PR TITLE
Remove the leading whitespace from the left prompt.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -52,9 +52,9 @@ left_prompt_segment() {
   [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
   [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
   if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
-    echo -n " %{$bg%F{$CURRENT_BG}%}$LEFT_SEGMENT_SEPARATOR%{$fg%} "
+    echo -n "%{$bg%F{$CURRENT_BG}%}$LEFT_SEGMENT_SEPARATOR%{$fg%} "
   else
-    echo -n " %{$bg%}%{$fg%} "
+    echo -n "%{$bg%}%{$fg%} "
   fi
   CURRENT_BG=$1
   [[ -n $3 ]] && echo -n $3


### PR DESCRIPTION
There is a leading whitespace on the left prompt. Seems like it shouldn't be there, so this fixes that.
Maybe this is how you like it though? Personally, it annoys me :)
![image](http://i.imgur.com/bIdAm3z.png)