### PR TITLE
Display Changeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ To specify which segments you want, just add the following variables to your
     POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
     POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
 
+If you want to show the current changeset, enable `POWERLEVEL9K_SHOW_CHANGESET` 
+in your `~/.zshrc`:
+
+    POWERLEVEL9K_SHOW_CHANGESET=true
+
 #### Conditional 'context'
 
 The `context` segment (user@host string) is conditional. This lets you enable it, but only display
@@ -87,7 +92,6 @@ To use this feature, make sure the `context` segment is enabled in your prompt
 elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 
     export DEFAULT_USER=<your username>
-
 
 ### Bugs / Contact
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -172,12 +172,12 @@ function +vi-git-remotebranch() {
     remote=${$(git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
     branch_name=${$(git symbolic-ref --short HEAD 2>/dev/null)}
 
-    hook_com[branch]=" %F{black}${hook_com[branch]}%f"
+    hook_com[branch]="%F{black}${hook_com[branch]}%f"
     # Always show the remote
     #if [[ -n ${remote} ]] ; then
     # Only show the remote if it differs from the local
     if [[ -n ${remote} && ${remote#*/} != ${branch_name} ]] ; then
-        hook_com[branch]+=" %F{black}→%f%F{black}${remote}%f"
+        hook_com[branch]+="%F{black}→%f%F{black}${remote}%f"
     fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -38,6 +38,7 @@ autoload -Uz vcs_info
 local VCS_WORKDIR_DIRTY=false
 local VCS_CHANGESET_PREFIX=''
 if ( $POWERLEVEL9K_SHOW_CHANGESET ); then
+  # Just display the first 12 characters of our changeset-ID.
   VCS_CHANGESET_PREFIX='%12.12i@'
 fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -32,16 +32,21 @@ VCS_STAGED_ICON='✚'
 # vcs_info settings for git
 ################################################################
 
-local VCS_WORKDIR_DIRTY=false
 setopt prompt_subst
 autoload -Uz vcs_info
+
+local VCS_WORKDIR_DIRTY=false
+local VCS_CHANGESET_PREFIX=''
+if ( $POWERLEVEL9K_SHOW_CHANGESET ); then
+  VCS_CHANGESET_PREFIX='%12.12i@'
+fi
 
 zstyle ':vcs_info:*' enable git hg
 # The `get-revision` function must be turned on for dirty-check to work for Hg
 zstyle ':vcs_info:*' get-revision true
 zstyle ':vcs_info:*' check-for-changes true
 
-zstyle ':vcs_info:*' formats "%b%c%u%m"
+zstyle ':vcs_info:*' formats " $VCS_CHANGESET_PREFIX%b%c%u%m"
 zstyle ':vcs_info:*' actionformats "%b %F{red}| %a%f"
 
 zstyle ':vcs_info:*' stagedstr " %F{black}$VCS_STAGED_ICON%f"
@@ -51,6 +56,14 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-untracked git-aheadbehind git-re
 
 # For Hg, only show the branch name (as opposed to the rev)
 zstyle ':vcs_info:hg*:*' branchformat "%b"
+
+if ( $POWERLEVEL9K_SHOW_CHANGESET ); then
+  zstyle ':vcs_info:*' get-revision true # If false, the dirty-check won't work in mercurial
+else
+  # A little performance-boost (at least for mercurial). If we don't show 
+  # the changeset, we can switch to simple mode.
+  zstyle ':vcs_info:*' use-simple true
+fi
 
 ## Debugging
 #zstyle ':vcs_info:*+*:*' debug true


### PR DESCRIPTION
... And the next one ;)

I'd like to display the current changeset-ID in the prompt. Because this is IMHO quite controversial I've added a new switch `POWERLEVEL9K_SHOW_CHANGESET`, which must be enabled.

As an extra, `use-simple` is enabled, if we don't show the changeset. This boosts performance, at least when mercurial is used (as the zsh-documentation says, it affects `bzr` and `hg` only).