### PR TITLE
AWS segment added

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ currently available are:
 * **rbenv** - Ruby environment information (if one is active).
 * **status** - The return code of the previous command, and status of background jobs.
 * **history** - The command number for the current line.
+* **aws** - The current AWS profile, if you exported it with `export AWS_DEFAULT_PROFILE=<profile_name>`
 * **time** - System time.
 
 To specify which segments you want, just add the following variables to your

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -270,6 +270,16 @@ prompt_rbenv() {
   fi
 }
 
+# AWS Profile
+# See http://docs.aws.amazon.com/cli/latest/userguide/installing.html
+prompt_aws() {
+  local aws_profile=$AWS_DEFAULT_PROFILE
+  if [[ -n $aws_profile ]]; 
+  then
+    $1_prompt_segment red white "AWS: $aws_profile"
+  fi
+}
+
 # Main prompt
 build_left_prompt() {
   if (( ${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS} == 0 )); then


### PR DESCRIPTION
Just added a segment to display the current AWS profile. The profile has to be set in the .zshrc: `export AWS_DEFAULT_PROFILE=<aws_profile_name>`.

This is just a merge of the following pull request into this repo: https://github.com/robbyrussell/oh-my-zsh/pull/3228