### PR TITLE
Correct interpretation of boolean variables.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -52,7 +52,7 @@ autoload -Uz vcs_info
 
 local VCS_WORKDIR_DIRTY=false
 local VCS_CHANGESET_PREFIX=''
-if [ $POWERLEVEL9K_SHOW_CHANGESET ]; then
+if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
   # Just display the first 12 characters of our changeset-ID.
   VCS_CHANGESET_PREFIX="%F{$DEFAULT_COLOR_DARK}%12.12i@%f"
 fi
@@ -73,7 +73,7 @@ zstyle ':vcs_info:hg*:*' branchformat "%b"
 # The `get-revision` function must be turned on for dirty-check to work for Hg
 zstyle ':vcs_info:hg*:*' get-revision true
 
-if [ $POWERLEVEL9K_SHOW_CHANGESET ]; then
+if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
   zstyle ':vcs_info:*' get-revision true
 else
   # A little performance-boost for large repositories (especially Hg). If we
@@ -144,7 +144,7 @@ prompt_vcs() {
   local vcs_prompt="${vcs_info_msg_0_}"
 
   if [[ -n $vcs_prompt ]]; then
-    if ( $VCS_WORKDIR_DIRTY ); then
+    if [[ "$VCS_WORKDIR_DIRTY" == true ]]; then
       $1_prompt_segment yellow $DEFAULT_COLOR
     else
       $1_prompt_segment green $DEFAULT_COLOR
@@ -296,7 +296,7 @@ prompt_aws() {
 
 # Main prompt
 build_left_prompt() {
-  if (( ${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS} == 0 )); then
+  if [[ ${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS} == 0 ]]; then
     POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
   fi
 
@@ -311,7 +311,7 @@ build_left_prompt() {
 build_right_prompt() {
   RETVAL=$?
 
-  if (( ${#POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS} == 0 )); then
+  if [[ ${#POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS} == 0 ]]; then
     POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(longstatus history time)
   fi
 
@@ -328,7 +328,7 @@ precmd() {
   vcs_info_hookadd set-message vcs-detect-changes
 }
 
-if [ $POWERLEVEL9K_PROMPT_ON_NEWLINE ] ; then
+if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
   PROMPT='╭─%{%f%b%k%}$(build_left_prompt) 
 ╰─ '
 else


### PR DESCRIPTION
Just a little internal change.
I stumbled upon setting variables in my `~/.zshrc` to false to affect nothing. I had to comment them out, to disable a specific setting..
With this change e.g. `POWERLEVEL9K_SHOW_CHANGESET=false` will work (disable). Before that, it didn't.