### PR TITLE
Show a ratio of test classes vs real classes (Ruby and Symfony2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ currently available are:
 * **dir** - Your current working directory.
 * **history** - The command number for the current line.
 * **rbenv** - Ruby environment information (if one is active).
-* **rspec** - Show a ratio of test classes vs code classes for RSpec.
+* **rspec_stats** - Show a ratio of test classes vs code classes for RSpec.
 * **status** - The return code of the previous command, and status of background jobs.
 * **symfony2_tests** - Show a ratio of test classes vs code classes for Symfony2.
 * **time** - System time.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ currently available are:
 * **dir** - Your current working directory.
 * **history** - The command number for the current line.
 * **rbenv** - Ruby environment information (if one is active).
+* **rspec** - Show a ratio of test classes vs code classes for RSpec.
 * **status** - The return code of the previous command, and status of background jobs.
+* **symfony2_tests** - Show a ratio of test classes vs code classes for Symfony2.
 * **time** - System time.
 * **vcs** - Information about this `git` or `hg` repository (if you are in one).
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -333,7 +333,7 @@ prompt_symfony2_tests() {
 # Show a ratio of tests vs code
 build_test_stats() {
   local code_amount=$2
-  local tests_amount=$3+0.01
+  local tests_amount=$3+0.00001
   local headline=$4
 
   # Set float precision to 2 digits:

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -336,9 +336,9 @@ build_test_stats() {
   local tests_amount=$3+0.01
   local headline=$4
 
-	# Set float precision to 2 digits:
-	typeset -F 2 ratio
-	local ratio=$(( (tests_amount/code_amount) * 100 ))
+  # Set float precision to 2 digits:
+  typeset -F 2 ratio
+  local ratio=$(( (tests_amount/code_amount) * 100 ))
 
   [[ ratio -ge 0.75 ]] && $1_prompt_segment cyan $DEFAULT_COLOR "$headline: $ratio%%"
   [[ ratio -ge 0.5 && ratio -lt 0.75 ]] && $1_prompt_segment yellow $DEFAULT_COLOR "$headline: $ratio%%"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -294,6 +294,41 @@ prompt_aws() {
   fi
 }
 
+# RSpec test ratio
+prompt_rspec_stats() {
+  if [[ (-d app && -d spec) ]]; then
+    local code_amount=$(wc -l app/**/*.rb | grep -oE "[0-9]+" | tail -n 1)
+    local tests_amount=$(wc -l spec/**/*.rb | grep -oE "[0-9]+" | tail -n 1)
+
+    build_test_stats $1 $code_amount $tests_amount "RSpec"
+  fi
+}
+
+# Symfony2-PHPUnit test ratio
+prompt_symfony2_tests() {
+  if [[ (-d src && -d app && -f app/AppKernel.php) ]]; then
+    local code_amount=$(ls -1 src/**/*.php | grep -v Tests | wc -l)
+    local tests_amount=$(ls -1 src/**/*.php | grep Tests | wc -l)
+
+    build_test_stats $1 $code_amount $tests_amount "SF2-Tests"
+  fi
+}
+
+# Show a ratio of tests vs code
+build_test_stats() {
+  local code_amount=$2
+  local tests_amount=$3+0.01
+  local headline=$4
+
+	# Set float precision to 2 digits:
+	typeset -F 2 ratio
+	local ratio=$(( (tests_amount/code_amount) * 100 ))
+
+  [[ ratio -ge 0.75 ]] && $1_prompt_segment cyan $DEFAULT_COLOR "$headline: $ratio%%"
+  [[ ratio -ge 0.5 && ratio -lt 0.75 ]] && $1_prompt_segment yellow $DEFAULT_COLOR "$headline: $ratio%%"
+  [[ ratio -lt 0.5 ]] && $1_prompt_segment red $DEFAULT_COLOR "$headline: $ratio%%"
+}
+
 # Main prompt
 build_left_prompt() {
   if [[ ${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS} == 0 ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -313,8 +313,8 @@ prompt_aws() {
 # RSpec test ratio
 prompt_rspec_stats() {
   if [[ (-d app && -d spec) ]]; then
-    local code_amount=$(wc -l app/**/*.rb | grep -oE "[0-9]+" | tail -n 1)
-    local tests_amount=$(wc -l spec/**/*.rb | grep -oE "[0-9]+" | tail -n 1)
+    local code_amount=$(ls -1 app/**/*.rb | wc -l)
+    local tests_amount=$(ls -1 spec/**/*.rb | wc -l)
 
     build_test_stats $1 $code_amount $tests_amount "RSpec"
   fi


### PR DESCRIPTION
Here we show a little ratio of test vs real classes.
This is a loose port of https://gist.github.com/sent-hil/4641437 . I rather do symfony2 than ruby at work, so I extracted a little base method to show the actual prompt. Now the code is quite lean.
It may has some performance issues on large projects, but for most cases it will do nice.

Best regards
:)