### PR TITLE
Mercurial: show bookmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ information in configurable prompt segments.
     * being behind / ahead of your remote by some number of commits
     * number of stashes (git only)
     * conditionally shows remote tracking branch if the name differs from local
+    * current active bookmark (mercurial only)
     * various working tree statuses (e.g., unstaged, staged, etc.,)
 * Shows return-code of the last command if it is an error code
 * Indicates background jobs with a gear icon
@@ -142,6 +143,7 @@ The `vcs` segment uses various symbols to tell you the state of your repository:
 * `✚`  - There are staged changes in your working copy
 * `?`  - There are files in your working copy, that are unknown to your repository
 * `→`  - The name of your branch differs from its tracking branch.
+* `☿`  - A mercurial bookmark is active.
 
 ### Styling
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -104,6 +104,8 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-untracked git-aheadbehind git-st
 zstyle ':vcs_info:hg*:*' branchformat "%b"
 # The `get-revision` function must be turned on for dirty-check to work for Hg
 zstyle ':vcs_info:hg*:*' get-revision true
+zstyle ':vcs_info:hg*:*' get-bookmarks true
+zstyle ':vcs_info:hg*+gen-hg-bookmark-string:*' hooks hg-bookmarks
 
 if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
   zstyle ':vcs_info:*' get-revision true
@@ -234,6 +236,18 @@ function +vi-git-stash() {
     stashes=$(git stash list 2>/dev/null | wc -l)
     hook_com[misc]+=" %F{$DEFAULT_COLOR}⍟${stashes}%f"
   fi
+}
+
+function +vi-hg-bookmarks() {
+	if [[ -n "${hgbmarks[@]}" ]]; then
+		hook_com[hg-bookmark-string]=" ☿ ${hgbmarks[@]}"
+
+		# And to signal, that we want to use the sting we just generated,
+		# set the special variable `ret' to something other than the default
+		# zero:
+		ret=1
+		return 0
+	fi
 }
 
 function +vi-vcs-detect-changes() {


### PR DESCRIPTION
Here is a little port of https://github.com/robbyrussell/oh-my-zsh/pull/3365 . It shows the current active mercurial bookmark if any.

Also this patch contains a nice learning: If you want to override a substring of `hook_com[misc]` just set `ret=1` (from http://www.zsh.org/mla/workers/2010/msg00163.html).