### PR TITLE
Test ratio documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 
     export DEFAULT_USER=<your username>
 
+#### Test ratio
+
+The `symfony2_tests` and `rspec_tests` segments show both a ratio of code classes
+vs test classes. This is just a very simple ratio, and does not show your code
+coverage or any sophisticated stats. All this does is just to count your files
+and test files and calculate the ratio between them. Not more, but is may give
+a quick overview about the test situation of the project you are dealing with.
+
 #### The VCS Information Segment
 
 By default, the `vcs` segment will provide quite a bit of information. If you


### PR DESCRIPTION
Just wanted to add some documentation on how the test-ratio helper function works. This documentation applies for `rspec_stats` and `symfony2_tests`-functions.