### PR TITLE
To display the Segments correctly, we need a terminal capable of displaying 256 colors

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -43,6 +43,10 @@
 #   POWERLEVEL9K_COLOR_SCHEME='light'
 ################################################################
 
+# Fix: To display the correct colors, we need a terminal capable of displaying 
+# 256 colors.
+TERM=xterm-256color
+
 # The `CURRENT_BG` variable is used to remember what the last BG color used was
 # when building the left-hand prompt. Because the RPROMPT is created from
 # right-left but reads the opposite, this isn't necessary for the other side.


### PR DESCRIPTION
I had some Issues getting the right colors on my linux machine. After a while I figured out, that I was using `TERM=xterm`, wich can only display 8 colors. After changing that to `xterm-256colors`, the template worked as expected.
I am not 100% sure about this fix, as you can have `xterm-256colors` not installed because you use some other terminal editor (UXTerm, etc.). But it should do it in most cases. Unfortunately I didn't find a reliable way of determine whether xterm is installed or not..
What do you think?