### PR TITLE
Correctly set VCS dirty status on first invocation.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -221,7 +221,8 @@ zstyle ':vcs_info:*' actionformats " %b %F{red}| %a%f"
 zstyle ':vcs_info:*' stagedstr " %F{$VCS_FOREGROUND_COLOR}$VCS_STAGED_ICON%f"
 zstyle ':vcs_info:*' unstagedstr " %F{$VCS_FOREGROUND_COLOR}$VCS_UNSTAGED_ICON%f"
 
-zstyle ':vcs_info:git*+set-message:*' hooks git-untracked git-aheadbehind git-stash git-remotebranch git-tagname
+zstyle ':vcs_info:git*+set-message:*' hooks vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname
+zstyle ':vcs_info:hg*+set-message:*' hooks vcs-detect-changes
 
 # For Hg, only show the branch name
 zstyle ':vcs_info:hg*:*' branchformat "$VCS_BRANCH_ICON%b"
@@ -575,13 +576,6 @@ build_right_prompt() {
   done
 }
 
-prompt_powerlevel9k_precmd() {
-  vcs_info
-
-  # Add a static hook to examine staged/unstaged changes.
-  vcs_info_hookadd set-message vcs-detect-changes
-}
-
 powerlevel9k_init() {
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
@@ -593,7 +587,7 @@ powerlevel9k_init() {
   # initialize VCS
   autoload -Uz add-zsh-hook
 
-  add-zsh-hook precmd prompt_powerlevel9k_precmd
+  add-zsh-hook precmd vcs_info
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
     PROMPT="╭─%{%f%b%k%}"'$(build_left_prompt)'" 


### PR DESCRIPTION
When using [last-working-dir](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/last-working-dir) the problem becomes obvious. When first opening the terminal the prompt suggests the project is not dirty. Refreshing the prompt (simply hitting enter) updates the status accordingly. 

I took a stab at fixing the problem, and put an echo statement in [powerlevel9k.zsh-theme#L401](https://github.com/bhilburn/powerlevel9k/blob/558d137bfaf3b64c5e1b6b1091b0c066cb5f5cce/powerlevel9k.zsh-theme#L401), to see if it was getting called. The echo seemed to get compounded (0 calls on first prompt, 1 on second prompt, 2 on third prompt and so forth). It looks like on each invocation, an additional call was being added to the precmd via the hook. This might cause problems for zsh sessions spanning many commands, but I haven't experienced a problem like that. 

I would rate my zsh scripting experience as somewhere between -1 and 0, so I'm likely both wrong and doing this inefficiently, but here it is anyway. 