### PR TITLE
Make branch icon configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,17 @@ By default, the `vcs` segment will provide quite a bit of information. If you
 would also like for it to display the current hash / changeset, simply define
 `POWERLEVEL9K_SHOW_CHANGESET` in your `~/.zshrc`. If activated, it will show
 the first 12 characters of the changeset id. To change the amount of characters,
-set `POWERLEVEL9K_CHANGESET_HASH_LENTH` to any value you want.
+set `POWERLEVEL9K_CHANGESET_HASH_LENGTH` to any value you want.
+By setting `POWERLEVEL9K_SHOW_BRANCH_ICON` it shows a nice icon before the
+branch name.
 Example:
 
     # enable the vcs segment in general
     POWERLEVEL9K_SHOW_CHANGESET=true
     # just show the 6 first characters of changeset
     POWERLEVEL9K_CHANGESET_HASH_LENGTH=6
+    # Show an icon before the branch name
+    POWERLEVEL9K_SHOW_BRANCH_ICON=true
 
 ##### Symbols
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -74,8 +74,7 @@ case $POWERLEVEL9K_MODE in
     VCS_TAG_ICON="\uE817 " # 
     VCS_BOOKMARK_ICON="\uE87B" # 
     VCS_COMMIT_ICON="\uE821 " # 
-    #VCS_BRANCH_ICON=" \uE220" # 
-    VCS_BRANCH_ICON=''
+    VCS_BRANCH_ICON=" \uE220" # 
     VCS_REMOTE_BRANCH_ICON="\uE804" # 
     VCS_GIT_ICON="\uE20E " # 
     VCS_HG_ICON="\uE1C3 " # 
@@ -99,8 +98,7 @@ case $POWERLEVEL9K_MODE in
     VCS_TAG_ICON=''
     VCS_BOOKMARK_ICON="\u263F" # ☿
     VCS_COMMIT_ICON=''
-    #VCS_BRANCH_ICON='@'
-    VCS_BRANCH_ICON=''
+    VCS_BRANCH_ICON='@'
     VCS_REMOTE_BRANCH_ICON="\u2192" # →
     VCS_GIT_ICON='Git'
     VCS_HG_ICON='HG'
@@ -130,8 +128,7 @@ case $POWERLEVEL9K_MODE in
     VCS_TAG_ICON="\uE817 " # 
     VCS_BOOKMARK_ICON="\uE87B" # 
     VCS_COMMIT_ICON="\uE821 " # 
-    #VCS_BRANCH_ICON=" \uE220" # 
-    VCS_BRANCH_ICON=''
+    VCS_BRANCH_ICON=" \uE220" # 
     VCS_REMOTE_BRANCH_ICON="\uE804" # 
     VCS_GIT_ICON="\uE20E " # 
     VCS_HG_ICON="\uE1C3 " # 
@@ -157,13 +154,16 @@ case $POWERLEVEL9K_MODE in
     VCS_TAG_ICON=''
     VCS_BOOKMARK_ICON="\u263F" # ☿
     VCS_COMMIT_ICON=''
-    #VCS_BRANCH_ICON='@'
-    VCS_BRANCH_ICON=''
+    VCS_BRANCH_ICON='@'
     VCS_REMOTE_BRANCH_ICON="\u2192" # →
     VCS_GIT_ICON="\uE0A0" # 
     VCS_HG_ICON="\uE0A0" # 
   ;;
 esac
+
+if [[ "$POWERLEVEL9K_SHOW_BRANCH_ICON" != true ]]; then
+    VCS_BRANCH_ICON=''
+fi
 
 ################################################################
 # color scheme


### PR DESCRIPTION
Now the branch icon is configurable. If you want to display it, simply set `POWERLEVEL9K_SHOW_BRANCH_ICON` to `true`.

Defaults to false.