### PR TITLE
simple-mode deactivated. With that option on, vcs_info doesn't detect…

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -237,10 +237,6 @@ zstyle ':vcs_info:hg*+gen-hg-bookmark-string:*' hooks hg-bookmarks
 
 if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
   zstyle ':vcs_info:*' get-revision true
-else
-  # A little performance-boost for large repositories (especially Hg). If we
-  # don't show the changeset, we can switch to simple mode.
-  zstyle ':vcs_info:*' use-simple true
 fi
 
 ################################################################


### PR DESCRIPTION
… the repository state correctly.

That is sad, as the simple mode is a significant bit faster. But otherwise we have no chance to check the dirty-state of a repository in a quick way.. 

This fixes #51 