### PR TITLE
Added option to shorten dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 
     export DEFAULT_USER=<your username>
 
+#### The `dir` segment
+
+The `dir` segment shows the current working directory. You can limit the output
+to a certain length:
+
+    # Limit to 20 characters
+    POWERLEVEL9K_SHORTEN_PWD_LENGTH=20
+
 #### The 'time' segment
 
 By default the time is show in 'H:M:S' format. If you want to change it, 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 The `dir` segment shows the current working directory. You can limit the output
 to a certain length:
 
-    # Limit to 20 characters
-    POWERLEVEL9K_SHORTEN_PWD_LENGTH=20
+    # Limit to the last two folders
+    POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
 
 #### The 'time' segment
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -318,7 +318,13 @@ prompt_context() {
 
 # Dir: current working directory
 prompt_dir() {
-  $1_prompt_segment $0 blue $DEFAULT_COLOR '%~'
+  local current_path='%~'
+  if [[ -n "$POWERLEVEL9K_SHORTEN_PWD_LENGTH" ]]; then
+    # shorten path to $POWERLEVEL9K_SHORTEN_PWD_LENGTH characters
+    local current_path="%${POWERLEVEL9K_SHORTEN_PWD_LENGTH}<..<%~%<<"
+  fi
+
+  $1_prompt_segment $0 blue $DEFAULT_COLOR $current_path
 }
 
 # Command number (in local history)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -319,9 +319,9 @@ prompt_context() {
 # Dir: current working directory
 prompt_dir() {
   local current_path='%~'
-  if [[ -n "$POWERLEVEL9K_SHORTEN_PWD_LENGTH" ]]; then
-    # shorten path to $POWERLEVEL9K_SHORTEN_PWD_LENGTH characters
-    local current_path="%${POWERLEVEL9K_SHORTEN_PWD_LENGTH}<..<%~%<<"
+  if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
+    # shorten path to $POWERLEVEL9K_SHORTEN_DIR_LENGTH
+    current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:.../:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
   fi
 
   $1_prompt_segment $0 blue $DEFAULT_COLOR $current_path


### PR DESCRIPTION
With this option you can shorten the output of the `dir` segment by specifying 

    POWERLEVEL9K_SHORTEN_DIR_LENGTH=2