### PR TITLE
Fix issue #60: Don't show as dirty in clean git repo

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -337,7 +337,7 @@ prompt_vcs() {
 
 function +vi-git-untracked() {
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
-            $(git ls-files --others --exclude-standard | sed q | wc -l) != 0 ]]; then
+      $(git ls-files --others --exclude-standard | sed q | wc -l | tr -d ' ') != 0 ]]; then
         hook_com[unstaged]+=" %F{$VCS_FOREGROUND_COLOR}$VCS_UNTRACKED_ICON%f"
     fi
 }


### PR DESCRIPTION
After commmit 10c5b28859d372f480c1352d4b7a74672e77b430, the git vcs segment always showed a question mark even if the repo wasn't dirty. This fixes that.

`wc -l` returns `\t0` which when compared to `0` in
`[[ "\t0" != 0 ]]` will always return true. This bug was causing the git repo to always show as dirty.