### PR TITLE
Disable rprompt possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ this theme focus on three primary goals:
     - [Symbols](#symbols)
 - [Styling](#styling)
   - [Double-Lined Prompt](#double-lined-prompt)
+  - [Disable Right Prompt](#disable-right-prompt)
   - [Light Color Theme](#light-color-theme)
   - [Segment Color Customization](#segment-color-customization)
   - [Special Segment Colors](#special-segment-colors)
@@ -351,6 +352,12 @@ following variables in your `~/.zshrc`:
 
     POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX="↱"
     POWERLEVEL9K_MULTILINE_SECOND_PROMPT_PREFIX="↳ "
+
+#### Disable Right Prompt
+
+If you do not want a right prompt, you can disable it by setting:
+
+    POWERLEVEL9K_DISABLE_RPROMPT=true
 
 #### Light Color Theme
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -644,7 +644,10 @@ $POWERLEVEL9K_MULTILINE_SECOND_PROMPT_PREFIX"
     RPROMPT_PREFIX=''
     RPROMPT_SUFFIX=''
   fi
-  RPROMPT=$RPROMPT_PREFIX"%{%f%b%k%}"'$(build_right_prompt)'"%{$reset_color%}"$RPROMPT_SUFFIX
+
+  if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
+    RPROMPT=$RPROMPT_PREFIX"%{%f%b%k%}"'$(build_right_prompt)'"%{$reset_color%}"$RPROMPT_SUFFIX
+  fi
 
 }
 


### PR DESCRIPTION
Some folks want no right prompt, so here is the possibility for that. I think it would be nicer, if it would be disabled by setting an empty array as `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS`, but it seems there is no way in zsh to distinguish between an empty array and a not set variable (at least I didn't found one)..