### PR TITLE
Even less dependencies

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -337,7 +337,7 @@ prompt_vcs() {
 
 function +vi-git-untracked() {
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
-            -n $(git ls-files --others --exclude-standard) ]]; then
+            -n $(git ls-files --others --exclude-standard | sed q) ]]; then
         hook_com[unstaged]+=" %F{$VCS_FOREGROUND_COLOR}$VCS_UNTRACKED_ICON%f"
     fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -337,7 +337,7 @@ prompt_vcs() {
 
 function +vi-git-untracked() {
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
-            ${$(git ls-files --others --exclude-standard | sed q | wc -l)// /} != 0 ]]; then
+            -n $(git ls-files --others --exclude-standard) ]]; then
         hook_com[unstaged]+=" %F{$VCS_FOREGROUND_COLOR}$VCS_UNTRACKED_ICON%f"
     fi
 }


### PR DESCRIPTION
If `sed q | wc -l` is just for testing if the string is empty or not, we can do that with just ZSH. Trusting that the implentation of `test -n` is intelligent enough to abort if a character is found. Even that `sed q` might be super fast, the big amount of indirections seem quite slow to me.

This is an addition to #60 

I tested this with OSX and the vagrant-ubuntu.