### PR TITLE
Added a possibility to not show a specific icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,12 @@ This special prompt does not work on the right side, as it would be too long,
 and ZSH hides it automatically. Also have in mind, that the output depends on
 your `POWERLEVEL9K_MODE` settings.
 
+You can prevent rendering of an icon by setting the according icon variable to
+`false`. E.g. if you use a multiline prompt and do not want a special icon
+before the first line, just set:
+
+    POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX=false
+
 #### Segment Color Customization
 
 For each segment in your prompt, you can specify a foreground and background

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -52,8 +52,10 @@ function print_icon() {
   local icon_name=$1
   local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
   local USER_ICON=${(P)ICON_USER_VARIABLE}
-  if [[ -n "$USER_ICON" ]]; then
+  if [[ -n "$USER_ICON" && "$USER_ICON" != false ]]; then
     echo -n $USER_ICON
+  elif [[ -n "$USER_ICON" && "$USER_ICON" == false ]]; then
+    # Do nothing! Icon disabled.
   else
     echo -n ${icons[$icon_name]}
   fi


### PR DESCRIPTION
A couple of forks use multiline-prompts and removed the prefix of the first line (e.g. @jkoelndorfer 's fork). This is the main motivation for this.