### PR TITLE
New segments for system stats and current IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ this theme focus on four primary goals:
   - [The AWS Profile Segment](#the-aws-profile-segment)
   - [The 'context' Segment](#the-context-segment)
   - [The 'dir' segment](#the-dir-segment)
+  - [The 'ip' segment](#the-ip-segment)
   - [The 'time' segment](#the-time-segment)
   - [Unit Test Ratios](#unit-test-ratios)
   - [The 'vcs' Segment](#the-vcs-segment)
@@ -292,6 +293,15 @@ To change the way how the current working directory is truncated, just set:
 In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
 others whole directories.
+
+#### The 'ip' segment
+
+This segment shows you your current internal IP address. It tries to examine
+all currently used network interfaces and prints the first address it finds.
+In the case that this is not the right IP address you can specify the correct
+network interface by setting:
+
+    POWERLEVEL9K_IP_INTERFACE="eth0"
 
 #### The 'time' segment
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ currently available are:
 * **context** - Your username and host (more info below)
 * **dir** - Your current working directory.
 * **history** - The command number for the current line.
+* **ip** - Shows the current IP address.
+* **load** - Your machines 5 minute load average and free RAM.
 * **node_version** - Show the version number of the installed Node.js.
 * **os_icon** - Display a nice little icon, depending on your operating system.
 * **rbenv** - Ruby environment information (if one is active).

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -579,28 +579,28 @@ prompt_icons_test() {
 
 prompt_ip() {
   if [[ "$OS" == "OSX" ]]; then
-    if [[ -z "$POWERLEVEL9K_IP_INTERFACE" ]]; then
+    if defined POWERLEVEL9K_IP_INTERFACE; then
+      # Get the IP address of the specified interface.
+      ip=$(ipconfig getifaddr $POWERLEVEL9K_IP_INTERFACE)
+    else
       local interfaces callback
       # Get network interface names ordered by service precedence.
       interfaces=$(networksetup -listnetworkserviceorder | grep -o "Device:\s*[a-z0-9]*" | grep -o -E '[a-z0-9]*$')
       callback='ipconfig getifaddr $item'
 
       ip=$(getRelevantItem $interfaces $callback)
-    else
-      # Get the IP address of the specified interface.
-      ip=$(ipconfig getifaddr $POWERLEVEL9K_IP_INTERFACE)
     fi
   else
-    if [[ -z "$POWERLEVEL9K_IP_INTERFACE" ]]; then
+    if defined POWERLEVEL9K_IP_INTERFACE; then
+      # Get the IP address of the specified interface.
+      ip=$(ip -4 a show $POWERLEVEL9K_IP_INTERFACE | grep -o "inet\s*[0-9.]*" | grep -o "[0-9.]*")
+    else
       local interfaces callback
       # Get all network interface names that are up
       interfaces=$(ip link ls up | grep -o -E ":\s+[a-z0-9]+:" | grep -v "lo" | grep -o "[a-z0-9]*")
       callback='ip -4 a show $item | grep -o "inet\s*[0-9.]*" | grep -o "[0-9.]*"'
 
       ip=$(getRelevantItem $interfaces $callback)
-    else
-      # Get the IP address of the specified interface.
-      ip=$(ip -4 a show $POWERLEVEL9K_IP_INTERFACE | grep -o "inet\s*[0-9.]*" | grep -o "[0-9.]*")
     fi
   fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -45,6 +45,21 @@
 #set -o xtrace
 
 ################################################################
+# Utility functions
+################################################################
+
+function print_icon() {
+  local icon_name=$1
+  local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
+  local USER_ICON=${(P)ICON_USER_VARIABLE}
+  if [[ -n "$USER_ICON" ]]; then
+    echo -n $USER_ICON
+  else
+    echo -n ${icons[$icon_name]}
+  fi
+}
+
+################################################################
 # Icons
 ################################################################
 
@@ -189,17 +204,6 @@ if [[ "$OS" == 'OSX' ]]; then
     SED_EXTENDED_REGEX_PARAMETER="-E"
   fi
 fi
-
-function print_icon() {
-  local icon_name=$1
-  local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
-  local USER_ICON=${(P)ICON_USER_VARIABLE}
-  if [[ -n "$USER_ICON" ]]; then
-    echo -n $USER_ICON
-  else
-    echo -n ${icons[$icon_name]}
-  fi
-}
 
 ################################################################
 # color scheme

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -71,9 +71,9 @@ case $POWERLEVEL9K_MODE in
       NODE_ICON                      $'\U2B22' # ⬢
       MULTILINE_FIRST_PROMPT_PREFIX  $'\U256D'$'\U2500'
       MULTILINE_SECOND_PROMPT_PREFIX $'\U2570'$'\U2500 '
-      APPLE_ICON                     $'\UF8FF' # 
+      APPLE_ICON                     $'\UE26E' # 
       FREEBSD_ICON                   $'\U1F608 ' # 😈
-      LINUX_ICON                     $'\U1F427 ' # 🐧
+      LINUX_ICON                     $'\UE271' # 
       SUNOS_ICON                     $'\U1F31E ' # 🌞
       VCS_UNTRACKED_ICON             "\UE16C" # 
       VCS_UNSTAGED_ICON              "\UE17C" # 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -558,15 +558,16 @@ prompt_icons_test() {
 }
 
 prompt_ip() {
-  # TODO: Specify Interface by variable!
-  if [[ "$OS" == "OSX" ]]; then
-    # Try to get IP addresses from common interfaces.
-    ip=$(ipconfig getifaddr en0 || ipconfig getifaddr en1)
-  else
-    # Take the first IP that `hostname -I` gives us.
-    ip=$(hostname -I | grep -o "[0-9.]*" | head -n 1)
+  if [[ -z "$POWERLEVEL9K_IP_INTERFACE" ]]; then
+    if [[ "$OS" == "OSX" ]]; then
+      POWERLEVEL9K_IP_INTERFACE="en1"
+    else
+      POWERLEVEL9K_IP_INTERFACE="eth0"
+    fi
   fi
-  $1_prompt_segment "$0" "cyan" "$DEFAULT_COLOR" "$(print_icon 'NETWORK_ICON') $ip"
+
+  ip=$(ifconfig $POWERLEVEL9K_IP_INTERFACE 2> /dev/null | grep -o "inet\s[0-9.]*")
+  $1_prompt_segment "$0" "cyan" "$DEFAULT_COLOR" "$(print_icon 'NETWORK_ICON') ${ip#inet }"
 }
 
 prompt_load() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -607,17 +607,22 @@ prompt_ip() {
   $1_prompt_segment "$0" "cyan" "$DEFAULT_COLOR" "$(print_icon 'NETWORK_ICON') $ip"
 }
 
+set_default POWERLEVEL9K_LOAD_SHOW_FREE_RAM true
 prompt_load() {
   if [[ "$OS" == "OSX" ]]; then
     load_avg_5min=$(sysctl vm.loadavg | grep -o -E '[0-9]+(\.|,)[0-9]+' | head -n 1)
-    ramfree=$(vm_stat | grep "Pages free" | grep -o -E '[0-9]+')
-    # Convert pages into Bytes
-    ramfree=$(( $ramfree * 4096 ))
-    base=''
+    if [[ "$POWERLEVEL9K_LOAD_SHOW_FREE_RAM" == true ]]; then
+      ramfree=$(vm_stat | grep "Pages free" | grep -o -E '[0-9]+')
+      # Convert pages into Bytes
+      ramfree=$(( $ramfree * 4096 ))
+      base=''
+    fi
   else
     load_avg_5min=$(grep -o "[0-9.]*" /proc/loadavg | head -n 1)
-    ramfree=$(grep -o -E "MemFree:\s+[0-9]+" /proc/meminfo | grep -o "[0-9]*")
-    base=K
+    if [[ "$POWERLEVEL9K_LOAD_SHOW_FREE_RAM" == true ]]; then
+      ramfree=$(grep -o -E "MemFree:\s+[0-9]+" /proc/meminfo | grep -o "[0-9]*")
+      base=K
+    fi
   fi
 
   # Replace comma
@@ -634,7 +639,11 @@ prompt_load() {
     FUNCTION_SUFFIX="_NORMAL"
   fi
 
-  $1_prompt_segment "$0$FUNCTION_SUFFIX" $BACKGROUND_COLOR "$DEFAULT_COLOR" "$(print_icon 'LOAD_ICON') $load_avg_5min $(print_icon 'RAM_ICON') $(printSizeHumanReadable $ramfree $base)"
+  $1_prompt_segment "$0$FUNCTION_SUFFIX" $BACKGROUND_COLOR "$DEFAULT_COLOR" "$(print_icon 'LOAD_ICON') $load_avg_5min"
+
+  if [[ "$POWERLEVEL9K_LOAD_SHOW_FREE_RAM" == true ]]; then
+    echo -n "$(print_icon 'RAM_ICON') $(printSizeHumanReadable $ramfree $base) "
+  fi
 }
 
 # Right Status: (return code, root status, background jobs)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -115,6 +115,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     $'\UE271' # 
       SUNOS_ICON                     $'\U1F31E ' # 🌞
       HOME_ICON                      $'\UE12C' # 
+      NETWORK_ICON                   $'\UE1AD' # 
       LOAD_ICON                      $'\UE190 ' # 
       #RAM_ICON                       $'\UE87D' # 
       RAM_ICON                       $'\UE1E2 ' # 
@@ -159,6 +160,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
       HOME_ICON                      ''
+      NETWORK_ICON                   ''
       LOAD_ICON                      ''
       RAM_ICON                       ''
       VCS_UNTRACKED_ICON             '?'
@@ -553,6 +555,18 @@ prompt_icons_test() {
     local next_color=$((random_color+1))
     $1_prompt_segment "$0" "$random_color" "$next_color" "$key: ${icons[$key]}"
   done
+}
+
+prompt_ip() {
+  # TODO: Specify Interface by variable!
+  if [[ "$OS" == "OSX" ]]; then
+    # Try to get IP addresses from common interfaces.
+    ip=$(ipconfig getifaddr en0 || ipconfig getifaddr en1)
+  else
+    # Take the first IP that `hostname -I` gives us.
+    ip=$(hostname -I | grep -o "[0-9.]*" | head -n 1)
+  fi
+  $1_prompt_segment "$0" "cyan" "$DEFAULT_COLOR" "$(print_icon 'NETWORK_ICON') $ip"
 }
 
 prompt_load() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -583,15 +583,18 @@ prompt_load() {
     base=K
   fi
 
-  if [[ "$5min_load_avg" -gt 10 ]]; then
-    BACKGROUND_COLOR="001"
-  elif [[ "$5min_load_avg" -gt 3 ]]; then
-    BACKGROUND_COLOR="003"
+  if [[ "$load_avg_5min" -gt 10 ]]; then
+    BACKGROUND_COLOR="red"
+    FUNCTION_SUFFIX="_CRITICAL"
+  elif [[ "$load_avg_5min" -gt 3 ]]; then
+    BACKGROUND_COLOR="yellow"
+    FUNCTION_SUFFIX="_WARNING"
   else
-    BACKGROUND_COLOR="002"
+    BACKGROUND_COLOR="green"
+    FUNCTION_SUFFIX="_NORMAL"
   fi
 
-  $1_prompt_segment "$0" $BACKGROUND_COLOR "$DEFAULT_COLOR" "$(print_icon 'LOAD_ICON') $load_avg_5min $(print_icon 'RAM_ICON') $(printSizeHumanReadable $ramfree $base)"
+  $1_prompt_segment "$0$FUNCTION_SUFFIX" $BACKGROUND_COLOR "$DEFAULT_COLOR" "$(print_icon 'LOAD_ICON') $load_avg_5min $(print_icon 'RAM_ICON') $(printSizeHumanReadable $ramfree $base)"
 }
 
 # Right Status: (return code, root status, background jobs)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -114,6 +114,7 @@ case $POWERLEVEL9K_MODE in
       FREEBSD_ICON                   $'\U1F608 ' # 😈
       LINUX_ICON                     $'\UE271' # 
       SUNOS_ICON                     $'\U1F31E ' # 🌞
+      HOME_ICON                      $'\UE12C' # 
       LOAD_ICON                      $'\UE190 ' # 
       #RAM_ICON                       $'\UE87D' # 
       RAM_ICON                       $'\UE1E2 ' # 
@@ -157,6 +158,7 @@ case $POWERLEVEL9K_MODE in
       FREEBSD_ICON                   'BSD'
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
+      HOME_ICON                      ''
       LOAD_ICON                      ''
       RAM_ICON                       ''
       VCS_UNTRACKED_ICON             '?'
@@ -535,7 +537,7 @@ prompt_dir() {
 
   fi
 
-  $1_prompt_segment "$0" "blue" "$DEFAULT_COLOR" "$current_path"
+  $1_prompt_segment "$0" "blue" "$DEFAULT_COLOR" "$(print_icon 'HOME_ICON') $current_path"
 }
 
 # Command number (in local history)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -613,7 +613,7 @@ prompt_ip() {
 
 prompt_load() {
   if [[ "$OS" == "OSX" ]]; then
-    load_avg_5min=$(sysctl vm.loadavg | grep -o -E '[0-9]+\.[0-9]+' | head -n 1)
+    load_avg_5min=$(sysctl vm.loadavg | grep -o -E '[0-9]+(\.|,)[0-9]+' | head -n 1)
     ramfree=$(vm_stat | grep "Pages free" | grep -o -E '[0-9]+')
     # Convert pages into Bytes
     ramfree=$(( $ramfree * 4096 ))
@@ -623,6 +623,9 @@ prompt_load() {
     ramfree=$(grep -o -E "MemFree:\s+[0-9]+" /proc/meminfo | grep -o "[0-9]*")
     base=K
   fi
+
+  # Replace comma
+  load_avg_5min=${load_avg_5min//,/.}
 
   if [[ "$load_avg_5min" -gt 10 ]]; then
     BACKGROUND_COLOR="red"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -160,9 +160,9 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
       HOME_ICON                      ''
-      NETWORK_ICON                   ''
-      LOAD_ICON                      ''
-      RAM_ICON                       ''
+      NETWORK_ICON                   'IP'
+      LOAD_ICON                      'L'
+      RAM_ICON                       'RAM'
       VCS_UNTRACKED_ICON             '?'
       VCS_UNSTAGED_ICON              "\u25CF" # ●
       VCS_STAGED_ICON                "\u271A" # ✚

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -571,7 +571,7 @@ prompt_ip() {
 
 prompt_load() {
   if [[ "$OS" == "OSX" ]]; then
-    load_avg_5min=$(sysctl vm.loadavg | grep -o -E -e '[0-9]+\.[0-9]+' | head -n 1)
+    load_avg_5min=$(sysctl vm.loadavg | grep -o -E '[0-9]+\.[0-9]+' | head -n 1)
     ramfree=$(vm_stat | grep "Pages free" | grep -o -E '[0-9]+')
     # Convert pages into Bytes
     ramfree=$(( $ramfree * 4096 ))


### PR DESCRIPTION
I was inspired by @Illizian blogpost [here](https://www.alexscotton.com/post/a-modular-responsive-zsh-theme-and-some-bonus-unix-commands) and thought that it would be nice to have such segments as well..
The new segments worked for me in OMZ, Antigen, Prezto, plain ZSH (all vagrant) and a native Linux system.

What comes in this pull request as well is that I changed the Icons for Apple and Linux to glyphs from font-awesome.