### PR TITLE
Implement defined, set_default utility functions

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -241,16 +241,8 @@ else
   DEFAULT_COLOR_DARK="236"
 fi
 
-VCS_FOREGROUND_COLOR=$DEFAULT_COLOR
-VCS_FOREGROUND_COLOR_DARK=$DEFAULT_COLOR_DARK
-
-# If user has defined custom colors for the `vcs` segment, override the defaults
-if [[ -n $POWERLEVEL9K_VCS_FOREGROUND ]]; then
-  VCS_FOREGROUND_COLOR=$POWERLEVEL9K_VCS_FOREGROUND
-fi
-if [[ -n $POWERLEVEL9K_VCS_DARK_FOREGROUND ]]; then
-  VCS_FOREGROUND_COLOR_DARK=$POWERLEVEL9K_VCS_DARK_FOREGROUND
-fi
+set_default POWERLEVEL9K_VCS_FOREGROUND "$DEFAULT_COLOR"
+set_default POWERLEVEL9K_VCS_DARK_FOREGROUND "$DEFAULT_COLOR_DARK"
 
 ################################################################
 # VCS Information Settings
@@ -268,20 +260,20 @@ if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
     VCS_CHANGESET_HASH_LENGTH="$POWERLEVEL9K_CHANGESET_HASH_LENGTH"
   fi
 
-  VCS_CHANGESET_PREFIX="%F{$VCS_FOREGROUND_COLOR_DARK}$(print_icon 'VCS_COMMIT_ICON')%0.$VCS_CHANGESET_HASH_LENGTH""i%f "
+  VCS_CHANGESET_PREFIX="%F{$POWERLEVEL9K_VCS_DARK_FOREGROUND}$(print_icon 'VCS_COMMIT_ICON')%0.$VCS_CHANGESET_HASH_LENGTH""i%f "
 fi
 
 zstyle ':vcs_info:*' enable git hg
 zstyle ':vcs_info:*' check-for-changes true
 
-VCS_DEFAULT_FORMAT="$VCS_CHANGESET_PREFIX%F{$VCS_FOREGROUND_COLOR}%b%c%u%m%f"
-zstyle ':vcs_info:git:*' formats "%F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_GIT_ICON')%f$VCS_DEFAULT_FORMAT"
-zstyle ':vcs_info:hg:*' formats "%F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_HG_ICON')%f$VCS_DEFAULT_FORMAT"
+VCS_DEFAULT_FORMAT="$VCS_CHANGESET_PREFIX%F{$POWERLEVEL9K_VCS_FOREGROUND}%b%c%u%m%f"
+zstyle ':vcs_info:git:*' formats "%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_GIT_ICON')%f$VCS_DEFAULT_FORMAT"
+zstyle ':vcs_info:hg:*' formats "%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_HG_ICON')%f$VCS_DEFAULT_FORMAT"
 
 zstyle ':vcs_info:*' actionformats " %b %F{red}| %a%f"
 
-zstyle ':vcs_info:*' stagedstr " %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_STAGED_ICON')%f"
-zstyle ':vcs_info:*' unstagedstr " %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_UNSTAGED_ICON')%f"
+zstyle ':vcs_info:*' stagedstr " %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_STAGED_ICON')%f"
+zstyle ':vcs_info:*' unstagedstr " %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_UNSTAGED_ICON')%f"
 
 zstyle ':vcs_info:git*+set-message:*' hooks vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname
 zstyle ':vcs_info:hg*+set-message:*' hooks vcs-detect-changes
@@ -394,14 +386,14 @@ prompt_vcs() {
       $1_prompt_segment "$0" "green" "$DEFAULT_COLOR"
     fi
 
-    echo -n "%F{$VCS_FOREGROUND_COLOR}%f$vcs_prompt "
+    echo -n "%F{$POWERLEVEL9K_VCS_FOREGROUND}%f$vcs_prompt "
   fi
 }
 
 function +vi-git-untracked() {
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
             -n $(git ls-files --others --exclude-standard | sed q) ]]; then
-        hook_com[unstaged]+=" %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_UNTRACKED_ICON')%f"
+        hook_com[unstaged]+=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_UNTRACKED_ICON')%f"
     fi
 }
 
@@ -414,12 +406,12 @@ function +vi-git-aheadbehind() {
     # for git prior to 1.7
     # ahead=$(git rev-list origin/${branch_name}..HEAD | wc -l)
     ahead=$(git rev-list ${branch_name}@{upstream}..HEAD 2>/dev/null | wc -l)
-    (( $ahead )) && gitstatus+=( " %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_OUTGOING_CHANGES_ICON')${ahead// /}%f" )
+    (( $ahead )) && gitstatus+=( " %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_OUTGOING_CHANGES_ICON')${ahead// /}%f" )
 
     # for git prior to 1.7
     # behind=$(git rev-list HEAD..origin/${branch_name} | wc -l)
     behind=$(git rev-list HEAD..${branch_name}@{upstream} 2>/dev/null | wc -l)
-    (( $behind )) && gitstatus+=( " %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_INCOMING_CHANGES_ICON')${behind// /}%f" )
+    (( $behind )) && gitstatus+=( " %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_INCOMING_CHANGES_ICON')${behind// /}%f" )
 
     hook_com[misc]+=${(j::)gitstatus}
 }
@@ -431,12 +423,12 @@ function +vi-git-remotebranch() {
     remote=${$(git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
     branch_name=${$(git symbolic-ref --short HEAD 2>/dev/null)}
 
-    hook_com[branch]="%F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_BRANCH_ICON')${hook_com[branch]}%f"
+    hook_com[branch]="%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_BRANCH_ICON')${hook_com[branch]}%f"
     # Always show the remote
     #if [[ -n ${remote} ]] ; then
     # Only show the remote if it differs from the local
     if [[ -n ${remote} && ${remote#*/} != ${branch_name} ]] ; then
-        hook_com[branch]+="%F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_REMOTE_BRANCH_ICON')%f%F{$VCS_FOREGROUND_COLOR}${remote// /}%f"
+        hook_com[branch]+="%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_REMOTE_BRANCH_ICON')%f%F{$POWERLEVEL9K_VCS_FOREGROUND}${remote// /}%f"
     fi
 }
 
@@ -444,7 +436,7 @@ function +vi-git-tagname() {
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
-    [[ -n "${tag}" ]] && hook_com[branch]=" %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_TAG_ICON')${tag}%f"
+    [[ -n "${tag}" ]] && hook_com[branch]=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_TAG_ICON')${tag}%f"
 }
 
 # Show count of stashed changes
@@ -454,13 +446,13 @@ function +vi-git-stash() {
 
   if [[ -s $(git rev-parse --git-dir)/refs/stash ]] ; then
     stashes=$(git stash list 2>/dev/null | wc -l)
-    hook_com[misc]+=" %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_STASH_ICON')${stashes// /}%f"
+    hook_com[misc]+=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_STASH_ICON')${stashes// /}%f"
   fi
 }
 
 function +vi-hg-bookmarks() {
   if [[ -n "${hgbmarks[@]}" ]]; then
-    hook_com[hg-bookmark-string]=" %F{$VCS_FOREGROUND_COLOR}$(print_icon 'VCS_BOOKMARK_ICON')${hgbmarks[@]}%f"
+    hook_com[hg-bookmark-string]=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_BOOKMARK_ICON')${hgbmarks[@]}%f"
 
     # And to signal, that we want to use the sting we just generated,
     # set the special variable `ret' to something other than the default

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -60,7 +60,7 @@ function print_icon() {
   local icon_name=$1
   local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
   local USER_ICON=${(P)ICON_USER_VARIABLE}
-  if [[ -n "$USER_ICON" ]]; then
+  if defined "$ICON_USER_VARIABLE"; then
     echo -n $USER_ICON
   else
     echo -n ${icons[$icon_name]}

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -669,9 +669,7 @@ prompt_virtualenv() {
 
 # Main prompt
 build_left_prompt() {
-  if [[ "${#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS}" == 0 ]]; then
-    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
-  fi
+  defined POWERLEVEL9K_LEFT_PROMPT_ELEMENTS || POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
 
   for element in $POWERLEVEL9K_LEFT_PROMPT_ELEMENTS; do
     prompt_$element "left"
@@ -684,9 +682,7 @@ build_left_prompt() {
 build_right_prompt() {
   RETVAL=$?
 
-  if [[ "${#POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS}" == 0 ]]; then
-    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(longstatus history time)
-  fi
+  defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(longstatus history time)
 
   for element in $POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS; do
     prompt_$element "right"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -48,6 +48,14 @@
 # Utility functions
 ################################################################
 
+# Exits with 0 if a variable has been previously defined (even if empty)
+# Takes the name of a variable that should be checked.
+function defined() {
+  local varname="$1"
+
+  typeset -p "$varname" > /dev/null 2>&1
+}
+
 function print_icon() {
   local icon_name=$1
   local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
@@ -57,6 +65,18 @@ function print_icon() {
   else
     echo -n ${icons[$icon_name]}
   fi
+}
+
+# Given the name of a variable and a default value, sets the variable
+# value to the default only if it has not been defined.
+#
+# typeset cannot set the value for an array, so this will only work
+# for scalar values.
+function set_default() {
+  local varname="$1"
+  local default_value="$2"
+
+  defined "$varname" || typeset -g "$varname"="$default_value"
 }
 
 ################################################################


### PR DESCRIPTION
Per my previous comment, whipped up a couple of utility functions to help set defaults for powerlevel9k configurables.

`defined` does what you think it does - except unlike `-n`, it also works if the variable is defined but empty. Very nifty!

`set_default` allows for a shorthand if your variable is a scalar, e.g: `set_default myvar hello` sets `myvar` to "hello" only if it has not been defined previously.

Unfortunately, `typeset` can't set a value for an array. For arrays, do something like `defined array || array=(1 2 3)`.

Also put in some work to get existing variable checks switched over to use `defined` or `set_default` as appropriate. I didn't go into great depth to see if we could do any refactoring, just grabbed the low hanging fruit for this PR. :-)