### PR TITLE
Added subsegments in flat-mode.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -129,6 +129,8 @@ case $POWERLEVEL9K_MODE in
   'flat')
     icons[LEFT_SEGMENT_SEPARATOR]=''
     icons[RIGHT_SEGMENT_SEPARATOR]=''
+    icons[LEFT_SUBSEGMENT_SEPARATOR]='|'
+    icons[RIGHT_SUBSEGMENT_SEPARATOR]='|'
   ;;
   'compatible')
     local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters


### PR DESCRIPTION
We introduced separators for same-color segments, but we missed them in the `flat` variant. Here they are.