### PR TITLE
status vs longstatus cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ currently available are:
 * **rbenv** - Ruby environment information (if one is active).
 * **rspec_stats** - Show a ratio of test classes vs code classes for RSpec.
 * **status** - The return code of the previous command, and status of background jobs.
-* **longstatus** - Same as previous, except this creates a status segment for the *right* prompt.
 * **symfony2_tests** - Show a ratio of test classes vs code classes for Symfony2.
 * **symfony2_version** - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * **time** - System time.
@@ -255,7 +254,7 @@ To specify which segments you want, just add the following variables to your
 `~/.zshrc`. If you don't customize this, the below configuration is the default:
 
     POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
-    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(longstatus history time)
+    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
 
 #### The AWS Profile Segment
 
@@ -320,6 +319,13 @@ segment, as well:
 
     # Output time, date, and a symbol from the "Awesome Powerline Font" set
     POWERLEVEL9K_TIME_FORMAT="%D{%H:%M:%S \uE868  %d.%m.%y}"
+
+#### Showing Status
+
+Usually we display always the status, and in case a command failed, the return
+code of the last executed program. In case you want to display the status only
+if something special happend, you can set `POWERLEVEL9K_STATUS_VERBOSE=false`
+in your `~/.zshrc`.
 
 #### Unit Test Ratios
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -41,6 +41,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SEGMENT_SEPARATOR        $'\UE0B2' # 
       LEFT_SUBSEGMENT_SEPARATOR      $'\UE0B1' # 
       RIGHT_SUBSEGMENT_SEPARATOR     $'\UE0B3' # 
+      CARRIAGE_RETURN_ICON           $'\U21B5' # ↵
       ROOT_ICON                      $'\UE801' # 
       RUBY_ICON                      $'\UE847' # 
       AWS_ICON                       $'\UE895' # 
@@ -88,6 +89,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SEGMENT_SEPARATOR        $'\uE0B2' # 
       LEFT_SUBSEGMENT_SEPARATOR      $'\UE0B1' # 
       RIGHT_SUBSEGMENT_SEPARATOR     $'\UE0B3' # 
+      CARRIAGE_RETURN_ICON           $'\U21B5' # ↵
       ROOT_ICON                      $'\u26A1' # ⚡
       RUBY_ICON                      ''
       AWS_ICON                       'AWS:'
@@ -692,27 +694,6 @@ prompt_load() {
   fi
 }
 
-# Right Status: (return code, root status, background jobs)
-# This creates a status segment for the *right* prompt. Exact same thing as
-# above - just other side.
-prompt_longstatus() {
-  local symbols bg
-  symbols=()
-
-  if [[ "$RETVAL" -ne 0 ]]; then
-    symbols+="%F{226}$RETVAL ↵%f"
-    bg="009"
-  else
-    symbols+="%F{046}$(print_icon 'OK_ICON')%f"
-    bg="008"
-  fi
-
-  [[ "$UID" -eq 0 ]] && symbols+="%F{yellow} $(print_icon 'ROOT_ICON')%f"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%F{cyan}$(print_icon 'BACKGROUND_JOBS_ICON')%f"
-
-  [[ -n "$symbols" ]] && "$1_prompt_segment" "$0" "$bg" "white" "$symbols"
-}
-
 # Node version
 prompt_node_version() {
   local nvm_prompt
@@ -724,7 +705,7 @@ prompt_node_version() {
 
 # print a little OS icon
 prompt_os_icon() {
-  "$1_prompt_segment" "$0" "008" "255" "$OS_ICON"
+  "$1_prompt_segment" "$0" "black" "255" "$OS_ICON"
 }
 
 # print PHP version number
@@ -764,16 +745,29 @@ prompt_rvm() {
   fi
 }
 
-# Left Status: (return code, root status, background jobs)
-# This creates a status segment for the *left* prompt
+# Status: (return code, root status, background jobs)
+set_default POWERLEVEL9K_STATUS_VERBOSE true
 prompt_status() {
-  local symbols
+  local symbols bg
   symbols=()
-  [[ "$RETVAL" -ne 0 ]] && symbols+="%{%F{red}%}$(print_icon 'FAIL_ICON')"
-  [[ "$UID" -eq 0 ]] && symbols+="%{%F{yellow}%} $(print_icon 'ROOT_ICON')"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}$(print_icon 'BACKGROUND_JOBS_ICON')"
 
-  [[ -n "$symbols" ]] && "$1_prompt_segment" "$0" "$DEFAULT_COLOR" "default" "$symbols"
+  if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
+    if [[ "$RETVAL" -ne 0 ]]; then
+      symbols+="%F{226}$RETVAL $(print_icon 'CARRIAGE_RETURN_ICON')%f"
+      bg="red"
+    else
+      symbols+="%F{046}$(print_icon 'OK_ICON')%f"
+      bg="black"
+    fi
+  else
+    [[ "$RETVAL" -ne 0 ]] && symbols+="%{%F{red}%}$(print_icon 'FAIL_ICON')%f"
+    bg="$DEFAULT_COLOR"
+  fi
+
+  [[ "$UID" -eq 0 ]] && symbols+="%{%F{yellow}%} $(print_icon 'ROOT_ICON')%f"
+  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}$(print_icon 'BACKGROUND_JOBS_ICON')%f"
+
+  [[ -n "$symbols" ]] && "$1_prompt_segment" "$0" "$bg" "white" "$symbols"
 }
 
 # Symfony2-PHPUnit test ratio
@@ -848,7 +842,7 @@ build_left_prompt() {
 
 # Right prompt
 build_right_prompt() {
-  defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(longstatus history time)
+  defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
 
   for element in "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
     "prompt_$element" "right"


### PR DESCRIPTION
There is now no `longstatus`-segment any more. It had the same intent as the `status` segment and the codebase was almost equal. Now users should use `status` only. To get the behavior of the old status segement, users can set POWERLEVEL9K_STATUS_VERBOSE=false.

Also here I unified the use of named color codes to make the subsegment-display work.