### PR TITLE
Quote value of IS_BSD_SED.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -317,8 +317,7 @@ esac
 # `sed` is unfortunately not consistent across OSes when it comes to flags.
 SED_EXTENDED_REGEX_PARAMETER="-r"
 if [[ "$OS" == 'OSX' ]]; then
-  local IS_BSD_SED
-  IS_BSD_SED=$(sed --version &>> /dev/null || echo "BSD sed")
+  local IS_BSD_SED="$(sed --version &>> /dev/null || echo "BSD sed")"
   if [[ -n "$IS_BSD_SED" ]]; then
     SED_EXTENDED_REGEX_PARAMETER="-E"
   fi


### PR DESCRIPTION
If this isn't quoted, in can bleed through to stdout in certain circumstances.
This one is pretty weird, haven't dug in to figure out exactly why it is bleeding through. I know that removing "local" fixes it, but quoting the value also seems to fix it.

It also only occurs if I invoke oh-my-zsh from both my zshrc AND zprofile. Super weird. /shrug