### PR TITLE
Add NVM prompt segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The segments that are currently available are:
 * [ip](#ip) - Shows the current IP address.
 * **load** - Your machines 5 minute load average and free RAM.
 * **node_version** - Show the version number of the installed Node.js.
+* **nvm** - Show the version of Node that is currently active, if it differs from the version used by NVM
 * **os_icon** - Display a nice little icon, depending on your operating system.
 * **php_version** - Show the current PHP version.
 * [rbenv](#rbenv) - Ruby environment information (if one is active).

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -752,6 +752,17 @@ prompt_php_version() {
   fi
 }
 
+# Node version from NVM
+# Only prints the segment if different than the default value
+prompt_nvm() {
+  local node_version=$(nvm current)
+  local nvm_default=$(cat $NVM_DIR/alias/default)
+  [[ -z "${node_version}" ]] && return
+  [[ "$node_version" =~ "$nvm_default" ]] && return
+  NODE_ICON=$'\u2B22' # ⬢
+  $1_prompt_segment "$0" "green" "011" "${node_version:1} $NODE_ICON"
+}
+
 # rbenv information
 prompt_rbenv() {
   if [[ -n "$RBENV_VERSION" ]]; then


### PR DESCRIPTION
Prints out the Node version that is currently active if it is different than the default version specified by NVM