### PR TITLE
Add prompt segment for todo.txt tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The segments that are currently available are:
 * [symphony2_tests](#symphony2_tests) - Show a ratio of test classes vs code classes for Symfony2.
 * **symphony2_version** - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * [time](#time) - System time.
+* [todo.txt](http://todotxt.com/) - Shows the number of tasks in your todo.txt tasks file.
 * [vi_mode](#vi_mode)- Vi editing mode (NORMAL|INSERT).
 * **virtualenv** - Your Python [VirtualEnv](https://virtualenv.pypa.io/en/latest/).
 * [vcs](#vcs) - Information about this `git` or `hg` repository (if you are in one).
@@ -127,7 +128,7 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
 
 ##### ip

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
 others whole directories.
 
 ##### ip

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -45,6 +45,7 @@ case $POWERLEVEL9K_MODE in
       AWS_ICON                       $'\UE895'              # 
       BACKGROUND_JOBS_ICON           $'\UE82F '             # 
       TEST_ICON                      $'\UE891'              # 
+      TODO_ICON                      $'\U2611'              # ☑
       OK_ICON                        $'\U2713'              # ✓
       FAIL_ICON                      $'\U2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -93,6 +94,7 @@ case $POWERLEVEL9K_MODE in
       AWS_ICON                       $'\UF296'              # 
       BACKGROUND_JOBS_ICON           $'\UF013 '             # 
       TEST_ICON                      $'\UF291'              # 
+      TODO_ICON                      $'\U2611'              # ☑
       OK_ICON                        $'\UF23A'              # 
       FAIL_ICON                      $'\UF281'              # 
       SYMFONY_ICON                   'SF'
@@ -136,6 +138,7 @@ case $POWERLEVEL9K_MODE in
       AWS_ICON                       'AWS:'
       BACKGROUND_JOBS_ICON           $'\u2699'              # ⚙
       TEST_ICON                      ''
+      TODO_ICON                      $'\U2611'              # ☑
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -847,6 +850,16 @@ prompt_time() {
   fi
 
   "$1_prompt_segment" "$0" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "$time_format"
+}
+
+# todo.sh: shows the number of tasks in your todo.sh file
+prompt_todo() {
+  if $(hash todo.sh 2>&-); then
+    count=$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }')
+    if [[ "$count" = <-> ]]; then
+      "$1_prompt_segment" "$0" "244" "$DEFAULT_COLOR" "$(print_icon 'TODO_ICON') $count"
+    fi
+  fi
 }
 
 # Vi Mode: show editing mode (NORMAL|INSERT)


### PR DESCRIPTION
This prompt segment outputs the current number of tasks in your [todo.txt](http://todotxt.com/) file. Fails gracefully if todo.txt is not installed or not configured properly. Here it is in a screenshot, it is the 3rd segment in RPROMPT.

<img width="655" alt="screen shot 2015-10-17 at 11 37 56 am" src="https://cloud.githubusercontent.com/assets/44096/10560566/9362a5e0-74c3-11e5-984b-8bc9b9ca750e.png">
