### PR TITLE
added battery prompt segment usable on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ configuration is the default:
 The segments that are currently available are:
 
 * [aws](#aws) - The current AWS profile, if active.
+* [battery](#battery) - Current battery status(OS X only).
 * [context](#context) - Your username and host.
 * [dir](#dir) - Your current working directory.
 * **history** - The command number for the current line.
@@ -100,6 +101,22 @@ the `aws` segment to one of the prompts, and define `AWS_DEFAULT_PROFILE` in
 your `~/.zshrc`:
 
     export AWS_DEFAULT_PROFILE=<profile_name>
+
+##### battery
+
+This segment will display your current battery status on an OS X system(fails gracefully
+on systems without a battery and non OS X systems). It can be customized in your .zshrc
+with the environment variables detailed below with their default values.
+
+    POWERLEVEL9K_BATTERY_CHARGING="yellow"
+    POWERLEVEL9K_BATTERY_CHARGED="green"
+    POWERLEVEL9K_BATTERY_DISCONNECTED=$DEFAULT_COLOR
+    POWERLEVEL9K_BATTERY_LOW_THRESHOLD=10
+    POWERLEVEL9K_BATTERY_LOW_COLOR="red"
+
+In addition to the above it supports standard _FOREGROUND value without affecting the icon color
+
+
 
 ##### context
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1010,7 +1010,7 @@ powerlevel9k_init() {
   fi
 
   setopt prompt_subst
-
+  
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
   setopt PROMPT_CR PROMPT_PERCENT PROMPT_SUBST MULTIBYTE

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -652,7 +652,7 @@ prompt_battery() {
     fi
 
     # display prompt_segment
-    [[ ! -z $bat_percent ]] && "$1_prompt_segment" "$0" "black" "$DEFAULT_COLOR" "$conn$(print_icon 'BATTERY_ICON'){$fg_color} $bat_percent%% $remain"
+    [[ ! -z $bat_percent ]] && "$1_prompt_segment" "$0" "black" "$DEFAULT_COLOR" "$conn$(print_icon 'BATTERY_ICON')%F{$fg_color} $bat_percent%% $remain"
   fi
 }
 


### PR DESCRIPTION
Added a new prompt segment that can show you battery status on OS X machines. Will fail gracefully on any non OS X system or an OS X system without a battery.

<img width="863" alt="screen shot 2015-10-18 at 11 02 52 am" src="https://github-cloud.s3.amazonaws.com/assets/44096/10565549/e6a8f1e0-7587-11e5-92c3-988a136d2306.png">
