### PR TITLE
added a prompt segment to display battery status on laptops

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ configuration is the default:
 The segments that are currently available are:
 
 * [aws](#aws) - The current AWS profile, if active.
+* [battery](#battery) - Current battery status(OS X only).
 * [context](#context) - Your username and host.
 * [dir](#dir) - Your current working directory.
 * **history** - The command number for the current line.
@@ -100,6 +101,22 @@ the `aws` segment to one of the prompts, and define `AWS_DEFAULT_PROFILE` in
 your `~/.zshrc`:
 
     export AWS_DEFAULT_PROFILE=<profile_name>
+
+##### battery
+
+This segment will display your current battery status on an OS X system(fails gracefully
+on systems without a battery and non OS X systems). It can be customized in your .zshrc
+with the environment variables detailed below with their default values.
+
+    POWERLEVEL9K_BATTERY_CHARGING="yellow"
+    POWERLEVEL9K_BATTERY_CHARGED="green"
+    POWERLEVEL9K_BATTERY_DISCONNECTED=$DEFAULT_COLOR
+    POWERLEVEL9K_BATTERY_LOW_THRESHOLD=10
+    POWERLEVEL9K_BATTERY_LOW_COLOR="red"
+
+In addition to the above it supports standard _FOREGROUND value without affecting the icon color
+
+
 
 ##### context
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ configuration is the default:
 The segments that are currently available are:
 
 * [aws](#aws) - The current AWS profile, if active.
-* [battery](#battery) - Current battery status(OS X only).
+* [battery](#battery) - Current battery status.
 * [context](#context) - Your username and host.
 * [dir](#dir) - Your current working directory.
 * **history** - The command number for the current line.
@@ -104,8 +104,8 @@ your `~/.zshrc`:
 
 ##### battery
 
-This segment will display your current battery status on an OS X system(fails gracefully
-on systems without a battery and non OS X systems). It can be customized in your .zshrc
+This segment will display your current battery status (fails gracefully
+on systems without a battery). It can be customized in your .zshrc
 with the environment variables detailed below with their default values.
 
     POWERLEVEL9K_BATTERY_CHARGING="yellow"
@@ -116,6 +116,7 @@ with the environment variables detailed below with their default values.
 
 In addition to the above it supports standard _FOREGROUND value without affecting the icon color
 
+Supports both OS X and Linux(time remaining is only output in OS X)
 
 
 ##### context
@@ -146,7 +147,7 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
 
 ##### ip

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with the environment variables detailed below with their default values.
 
 In addition to the above it supports standard _FOREGROUND value without affecting the icon color
 
-Supports both OS X and Linux(time remaining is only output in OS X)
+Supports both OS X and Linux(time remaining requires the acpi program on Linux)
 
 
 ##### context

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
 others whole directories.
 
 ##### ip

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -670,6 +670,10 @@ prompt_battery() {
     if [[ ! $connected =~ true ]]; then
       [[ $bat_percent -lt $POWERLEVEL9K_BATTERY_LOW_THRESHOLD ]] && local conn="%F{$POWERLEVEL9K_BATTERY_LOW_COLOR}" || local conn="%F{$POWERLEVEL9K_BATTERY_DISCONNECTED}"
     fi
+    if [[ -f /usr/bin/acpi ]]; then
+      [[ $(acpi | awk '{ print $5 }') =~ rate ]] && local tstring="..." || local tstring=${(f)$(date -u -d @$(acpi | awk '{ print $5 }' | sed s/://g) +%k:%M)}
+    fi
+    [[ ! -z $tstring ]] && local remain=" ($tstring)"
   fi
 
   # display prompt_segment

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1010,7 +1010,7 @@ powerlevel9k_init() {
   fi
 
   setopt prompt_subst
-
+  
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
   setopt PROMPT_CR PROMPT_PERCENT PROMPT_SUBST MULTIBYTE

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -652,7 +652,7 @@ prompt_battery() {
     fi
 
     # display prompt_segment
-    [[ ! -z $bat_percent ]] && "$1_prompt_segment" "$0" "black" "$DEFAULT_COLOR" "$conn$(print_icon 'BATTERY_ICON'){$fg_color} $bat_percent%% $remain"
+    [[ ! -z $bat_percent ]] && "$1_prompt_segment" "$0" "black" "$DEFAULT_COLOR" "$conn$(print_icon 'BATTERY_ICON')%F{$fg_color} $bat_percent%% $remain"
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -663,7 +663,7 @@ prompt_battery() {
     # return if no battery found
     [[ -z $bat ]] && return
 
-    local bat_percent=$(cat $bat/capacity)
+    [[ $(cat $bat/capacity) -gt 100 ]] && local bat_percent=100 || local bat_percent=$(cat $bat/capacity)
     [[ $(cat $bat/status) =~ Charging ]] && local connected=true
     [[ $(cat $bat/status) =~ Charging && $bat_percent =~ 100 ]] && local conn="%F{$POWERLEVEL9K_BATTERY_CHARGED}"
     [[ $(cat $bat/status) =~ Charging && $bat_percent -lt 100 ]] && local conn="%F{$POWERLEVEL9K_BATTERY_CHARGING}"
@@ -671,7 +671,12 @@ prompt_battery() {
       [[ $bat_percent -lt $POWERLEVEL9K_BATTERY_LOW_THRESHOLD ]] && local conn="%F{$POWERLEVEL9K_BATTERY_LOW_COLOR}" || local conn="%F{$POWERLEVEL9K_BATTERY_DISCONNECTED}"
     fi
     if [[ -f /usr/bin/acpi ]]; then
-      [[ $(acpi | awk '{ print $5 }') =~ rate ]] && local tstring="..." || local tstring=${(f)$(date -u -d @$(acpi | awk '{ print $5 }' | sed s/://g) +%k:%M)}
+      local time_remaining=$(acpi | awk '{ print $5 }')
+      if [[ $time_remaining =~ rate ]]; then
+        local tstring="..."
+      elif [[ $time_remaining =~ "[:digit:]+" ]]; then
+        local tstring=${(f)$(date -u -d @$(echo $time_remaining | sed s/://g) +%k:%M)}
+      fi
     fi
     [[ ! -z $tstring ]] && local remain=" ($tstring)"
   fi


### PR DESCRIPTION
Added a new prompt segment that can show you battery status on. Supports both OS X and Linux. On OS X it will display the time remaining until charged or discharged(not provided by the subsystem on Linux as far as I can tell). Will fail gracefully on any system without a battery.

<img width="863" alt="screen shot 2015-10-18 at 11 02 52 am" src="https://github-cloud.s3.amazonaws.com/assets/44096/10565549/e6a8f1e0-7587-11e5-92c3-988a136d2306.png">
