### PR TITLE
Rephrasing of error message when TERM not 256 color

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -936,7 +936,7 @@ powerlevel9k_init() {
   term_colors=$(tput colors)
   if (( term_colors < 256 )); then
     print -P "%F{red}WARNING!%f Your terminal supports less than 256 colors!"
-    print "You should set TERM=xterm-256colors in your ~/.zshrc"
+    print -P "You should put: %F{blue}export TERM=\"xterm-256color\"%f in your \~\/.zshrc"
   fi
 
   setopt LOCAL_OPTIONS


### PR DESCRIPTION
    - Literal command to be added is highlighted in blue
    - Now beginners won't try to add an incorrect command to ~/.zshrc
