### PR TITLE
Issue #131: This fixes history-substring-search, home and end keys.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -922,12 +922,26 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
 
 function zle-line-init {
   powerlevel9k_prepare_prompts
+  if (( ${+terminfo[smkx]} )); then
+    printf '%s' ${terminfo[smkx]}
+  fi
   zle reset-prompt
+  zle -R
+}
+
+function zle-line-finish {
+  powerlevel9k_prepare_prompts
+  if (( ${+terminfo[rmkx]} )); then
+    printf '%s' ${terminfo[rmkx]}
+  fi
+  zle reset-prompt
+  zle -R
 }
 
 function zle-keymap-select {
   powerlevel9k_prepare_prompts
   zle reset-prompt
+  zle -R
 }
 
 powerlevel9k_init() {
@@ -954,6 +968,7 @@ powerlevel9k_init() {
   add-zsh-hook precmd powerlevel9k_prepare_prompts
 
   zle -N zle-line-init
+  zle -N zle-line-finish
   zle -N zle-keymap-select
 }
 


### PR DESCRIPTION
This PR fixes the `history-substring`-issue as well as the `home` and `end` keys. This works for me with all frameworks _but_ OMZ with `vi-mode` activated. I used the following configuration (in the vagrant, as we need to source the `history-substring-search` widget):
```zsh
source /home/vagrant-omz/.oh-my-zsh/plugins/history-substring-search/history-substring-search.zsh
zmodload zsh/terminfo
bindkey "$terminfo[kcuu1]" history-substring-search-up
bindkey "$terminfo[kcud1]" history-substring-search-down
```

Huge thanks to @apjanke.