### PR TITLE
Add shorten strategy for package.json name

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,26 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
+
+Another option is to truncate the path such that it is shown relative to
+the current `name` property in a `package.json` file at the root of the current
+`git` project.  You can enable that with the following:
+
+    POWERLEVEL9K_SHORTEN_DIR_LENGTH=true
+    POWERLEVEL9K_SHORTEN_STRATEGY="truncate_with_package_name"
+
+For example, if you have a project in `~/projects/my-project` with a `package.json`
+that looks like this:
+
+    {
+      'name': 'My Cool Project'
+    }
+
+the prompt will display `My Cool Project`.  When you `cd` into a subdirectory,
+it will appear as `My Cool Project/subdirectory`.  Note: this requires
+[jq](https://stedolan.github.io/jq/) to be installed.
 
 ##### ip
 


### PR DESCRIPTION
I was using this shortening technique before I found `powerlevel9k`, and since I found it so useful I decided to integrate it "properly" as a shortening technique.  Basically, the idea is that if your project has a `package.json` at the root of the `git` project, it will abbreviate the entire path up to the project with just the name of the package, and then show a relative path from there.

For example, if you have a project in `~/projects/my-cool-project` with a `package.json` that looks like this:

```json
{
  "name": "My Cool Project"
}
```

and then navigate to `~/projects/my-cool-project/tests`, the directory will be shown as `My Cool Project/tests`.

It does have a dependency on [`jq`](https://stedolan.github.io/jq/), so if that's a problem I can try to find a different way to extract the name field using more commonly-installed tools.  `jq` just makes working with `JSON` files really easy.

Another thing that I've thought about doing as an improvement is simply traversing upward in the path to the current directory, searching for a `package.json` file.  This would mean that you no longer need the `.git` folder to be present to work, and you can also use multiple `package.json` files inside you project to create shortened names for particular sub-directories.  If you're interested in those changes, I'll take a look at adding them.