### PR TITLE
Added segment deprecation helper

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -118,3 +118,18 @@ if [[ "$OS" == 'OSX' ]]; then
     SED_EXTENDED_REGEX_PARAMETER="-E"
   fi
 fi
+
+# Print a deprecation warning if an old segment is in use.
+# Takes the name of an associative array that contains the
+# deprecated segments as keys, the values contain the new
+# segment names.
+print_deprecation_warning() {
+  local -A raw_deprecated_segments=(${(kvP)1})
+
+  for key in ${(@k)raw_deprecated_segments}; do
+    if [[ -n "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[(r)$key]}" ]] || [[ -n "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[(r)$key]}" ]]; then
+      # segment is deprecated
+      print -P "%F{yellow}Warning!%f The '$key' segment is deprecated. Use '%F{blue}${raw_deprecated_segments[$key]}%f' instead. For more informations, have a look at the CHANGELOG.md."
+    fi
+  done
+}

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -754,6 +754,14 @@ powerlevel9k_init() {
     print -P "You should put: %F{blue}export TERM=\"xterm-256color\"%f in your \~\/.zshrc"
   fi
 
+  typeset -Ah deprecated_segments
+  # old => new
+  deprecated_segments=(
+    'longstatus'      'status'
+  )
+  print_deprecation_warning deprecated_segments
+
+
   setopt prompt_subst
   
   setopt LOCAL_OPTIONS


### PR DESCRIPTION
Now segments can be deprecated by adding them to the `deprecated_segments` array. This is kind of a backport from #119 