### PR TITLE
added variable to be able to set the end of the prompt explicitly

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -451,6 +451,11 @@ left_prompt_end() {
     echo -n "%{%k%}"
   fi
   echo -n "%{%f%} "
+  if [[ -n $POWERLEVEL9K_PROMPT_END ]]; then
+    echo -n "%{%f%}$POWERLEVEL9K_PROMPT_END"
+  else
+    echo -n "%{%f%} "
+  fi
   CURRENT_BG=''
 }
 


### PR DESCRIPTION
This is to allow users to have their prompt end in the way they want, e.g. if you want your prompt to end with "$", you can set POWERLEVEL9K_PROMPT_END="$".