### PR TITLE
Custom command segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.3.0 (next)
 
+### New segment `custom_command` added
+
+A new segment that allows users to define a custom command was added.
+
 ### `virtualenv` changes
 
 This segment now respects `VIRTUAL_ENV_DISABLE_PROMPT`. If this variable is set 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The segments that are currently available are:
 * [aws](#aws) - The current AWS profile, if active.
 * [battery](#battery) - Current battery status.
 * [context](#context) - Your username and host.
+* [custom_command](#custom_command) - A custom command to display the output of.
 * [dir](#dir) - Your current working directory.
 * **go_version** - Show the current GO version.
 * **history** - The command number for the current line.
@@ -121,6 +122,59 @@ In addition to the above it supports standard _FOREGROUND value without affectin
 
 Supports both OS X and Linux(time remaining requires the acpi program on Linux)
 
+##### custom_command
+
+The `custom_...` segment lets you add a custom command to your prompt, to e.g. display the wifi signal. You choose a name for the segment yourself, (here signal), and then set the appropriate variables, as so (based on the name you chose)
+
+    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_signal)
+    POWERLEVEL9K_CUSTOM_SIGNAL="echo signal: \$(nmcli device wifi | grep yes | awk '{print \$8}')"
+    POWERLEVEL9K_CUSTOM_SIGNAL_BACKGROUND="blue"
+    POWERLEVEL9K_CUSTOM_SIGNAL_FOREGROUND="yellow"
+    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(aws status load ram)
+
+gives
+
+![simplesignal](http://i.imgur.com/SQmYVFL.png)
+
+Instead of defining the command inline (if it is kinda long or unreadable), one can also add a function to the .zshrc like:
+
+    zsh_signal(){
+            local signal=$(nmcli device wifi | grep yes | awk '{print $8}')
+            local color='%F{yellow}'
+            [[ $signal -gt 75 ]] && color='%F{green}'
+            [[ $signal -lt 50 ]] && color='%F{red}'
+            echo -n "%{$color%}\uf230  $signal%{%f%}" # \uf230 is 
+    }
+
+And then by changing the custom commands array (and rearranging a bit the prompt elements) to read:
+
+    POWERLEVEL9K_CUSTOM_SIGNAL="zsh_signal"
+
+Then this updated command looks like:
+
+![signal](http://i.imgur.com/hviMATC.png)
+
+You can also have multiple custom commands. Say you have
+
+    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery custom_signal dir vcs virtualenv custom_time )
+    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(aws status load ram custom_docker)
+
+    POWERLEVEL9K_CUSTOM_SIGNAL="zsh_signal"
+    POWERLEVEL9K_CUSTOM_SIGNAL_FOREGROUND="white"
+    POWERLEVEL9K_CUSTOM_SIGNAL_BACKGROUND="black"
+
+    POWERLEVEL9K_CUSTOM_DOCKER='echo "\uf299 $(docker ps -a | grep Up | wc -l)"' # \uf299 is 
+    POWERLEVEL9K_CUSTOM_DOCKER_FOREGROUND="white"
+    POWERLEVEL9K_CUSTOM_DOCKER_BACKGROUND="blue"
+
+    POWERLEVEL9K_CUSTOM_TIME='echo "$(date +%s)"'
+    POWERLEVEL9K_CUSTOM_TIME_FOREGROUND="black"
+    POWERLEVEL9K_CUSTOM_TIME_BACKGROUND="yellow"
+
+
+Then you get:
+
+![](http://i.imgur.com/QGGBTqY.png)
 
 ##### context
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -208,6 +208,15 @@ prompt_aws() {
   fi
 }
 
+# Custom: a way for the user to specify custom commands to run,
+# and display the output of.
+#
+prompt_custom() {
+  local command=POWERLEVEL9K_CUSTOM_$2:u
+
+  "$1_prompt_segment" "${0}_${2:u}" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$(eval ${(P)command})"
+}
+
 prompt_battery() {
   icons[BATTERY_ICON]=$'\UE894'
   # set default values of not specified in shell
@@ -681,7 +690,13 @@ build_left_prompt() {
   defined POWERLEVEL9K_LEFT_PROMPT_ELEMENTS || POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
 
   for element in "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[@]}"; do
-    "prompt_$element" "left"
+    # Check if it is a custom command, otherwise interpet it as
+    # a prompt.
+    if [[ $element[0,7] =~ "custom_" ]]; then
+      "prompt_custom" "left" $element[8,-1]
+    else
+      "prompt_$element" "left"
+    fi
   done
 
   left_prompt_end
@@ -692,7 +707,13 @@ build_right_prompt() {
   defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
 
   for element in "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
-    "prompt_$element" "right"
+    # Check if it is a custom command, otherwise interpet it as
+    # a prompt.
+    if [[ $element[0,7] =~ "custom_" ]]; then
+      "prompt_custom" "right" $element[8,-1]
+    else
+      "prompt_$element" "right"
+    fi
   done
 }
 


### PR DESCRIPTION
This segment allows the user to run an arbitrary command and display the result as a segment. Useful to enable users to monitor whatever they want, without having to muck around in powerlevel9k itself.

    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_command)

    POWERLEVEL9K_CUSTOM_COMMANDS=("echo signal: \$(nmcli device wifi | grep yes | awk '{print \$8}')" )
    POWERLEVEL9K_CUSTOM_COMMAND_BACKGROUNDS=("blue")
    POWERLEVEL9K_CUSTOM_COMMAND_FOREGROUNDS=("yellow")
    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(aws status load ram)


gives


![custom_command](https://cloud.githubusercontent.com/assets/1667287/11259502/5d340d20-8e62-11e5-9a95-047970616cec.png)

Instead of defining the command inline (if it is kinda long or unreadable), one can also add a function to the .zshrc like:
 
    zsh_signal(){
         local signal=$(nmcli device wifi | grep yes | awk '{print $8}')
         local color='%F{yellow}'
         [[ $signal -gt 75 ]] && color='%F{green}'
         [[ $signal -lt 50 ]] && color='%F{red}'
         echo -n "%{$color%}  $signal%{%f%}"
  
  }

And then just change custom commands array to read

    POWERLEVEL9K_CUSTOM_COMMANDS=("zsh_signal")

With this updated command, this looks like:

![signal](https://cloud.githubusercontent.com/assets/1667287/11299082/f8e46a5e-8f83-11e5-8801-33b2a4618bc7.png)

