### PR TITLE
Try to fetch the utility function path automatically

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -32,9 +32,14 @@ if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
       print -P "%F{red}We could not locate the installation path of powerlevel9k.%f"
       print -P "Please specify by setting %F{blue}POWERLEVEL9K_INSTALLATION_PATH%f (full path incl. file name) at the very beginning of your ~/.zshrc"
       return 1
+    elif [[ -L "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      # Symlink
+      0="$POWERLEVEL9K_INSTALLATION_PATH"
     elif [[ -f "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      # File
       0="$POWERLEVEL9K_INSTALLATION_PATH"
     elif [[ -d "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      # Directory
       0="${POWERLEVEL9K_INSTALLATION_PATH}/powerlevel9k.zsh-theme"
     fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -41,7 +41,7 @@ elif [[ -f $0 ]]; then
   filename="$0"
 else
   print -P "%F{red}Script location could not be found!%f"
-  exit 1
+  return 1
 fi
 script_location="$(dirname $filename)"
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -26,7 +26,9 @@ if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
   else
     # Script is a function! We assume this to happen only in
     # prezto, as they use the zstyle-builtin to set the theme.
-    0="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+    [[ -z "$POWERLEVEL9K_INSTALLATION_PATH" ]] && POWERLEVEL9K_INSTALLATION_PATH="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+
+    0=$POWERLEVEL9K_INSTALLATION_PATH
   fi
 fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -32,6 +32,10 @@ if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
       print -P "%F{red}We could not locate the installation path of powerlevel9k.%f"
       print -P "Please specify by setting %F{blue}POWERLEVEL9K_INSTALLATION_PATH%f (full path incl. file name) at the very beginning of your ~/.zshrc"
       return 1
+    elif [[ -f "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      0="$POWERLEVEL9K_INSTALLATION_PATH"
+    elif [[ -d "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      0="${POWERLEVEL9K_INSTALLATION_PATH}/powerlevel9k.zsh-theme"
     fi
 
     0=$POWERLEVEL9K_INSTALLATION_PATH

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -23,10 +23,16 @@ if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
   if is-at-least 5.0.8; then
     # Try to find the correct path of the script.
     0=$(whence -v $0 | sed "s/$0 is a shell function from //")
+  elif [[ -f "${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/init.zsh" ]]; then
+    # If there is an prezto installation, we assume that powerlevel9k is linked there.
+    0="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
   else
-    # Script is a function! We assume this to happen only in
-    # prezto, as they use the zstyle-builtin to set the theme.
-    [[ -z "$POWERLEVEL9K_INSTALLATION_PATH" ]] && POWERLEVEL9K_INSTALLATION_PATH="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+    # Fallback: specify an installation path!
+    if [[ -z "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
+      print -P "%F{red}We could not locate the installation path of powerlevel9k.%f"
+      print -P "Please specify by setting %F{blue}POWERLEVEL9K_INSTALLATION_PATH%f (full path incl. file name) at the very beginning of your ~/.zshrc"
+      return 1
+    fi
 
     0=$POWERLEVEL9K_INSTALLATION_PATH
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -19,9 +19,15 @@
 
 # Check if the theme was called as a function.
 if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
-  # Script is a function! We assume this to happen only in
-  # prezto, as they use the zstyle-builtin to set the theme.
-  0="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+  autoload -U is-at-least
+  if is-at-least 5.0.8; then
+    # Try to find the correct path of the script.
+    0=$(whence -v $0 | sed "s/$0 is a shell function from //")
+  else
+    # Script is a function! We assume this to happen only in
+    # prezto, as they use the zstyle-builtin to set the theme.
+    0="${ZDOTDIR:-$HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+  fi
 fi
 
 # Check if filename is a symlink.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -42,8 +42,6 @@ if [[ $(whence -w prompt_powerlevel9k_setup) =~ "function" ]]; then
       # Directory
       0="${POWERLEVEL9K_INSTALLATION_PATH}/powerlevel9k.zsh-theme"
     fi
-
-    0=$POWERLEVEL9K_INSTALLATION_PATH
   fi
 fi
 


### PR DESCRIPTION
For ZSH 5.0.8 `whence -v` tells also the path to the command. In that case we can use that information to get a proper path to the utility functions.