### PR TITLE
Adding command prompt for AWS Elastic Beanstalk environment name

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -29,6 +29,7 @@ case $POWERLEVEL9K_MODE in
       ROOT_ICON                      $'\UE801'              # 
       RUBY_ICON                      $'\UE847'              # 
       AWS_ICON                       $'\UE895'              # 
+      AWS_EB_ICON                    $'\U1F331'             # 🌱
       BACKGROUND_JOBS_ICON           $'\UE82F '             # 
       TEST_ICON                      $'\UE891'              # 
       TODO_ICON                      $'\U2611'              # ☑
@@ -81,6 +82,7 @@ case $POWERLEVEL9K_MODE in
       ROOT_ICON                      $'\uF201'              # 
       RUBY_ICON                      $'\UF247'              # 
       AWS_ICON                       $'\UF296'              # 
+      AWS_EB_ICON                    $'\U1F331'             # 🌱
       BACKGROUND_JOBS_ICON           $'\UF013 '             # 
       TEST_ICON                      $'\UF291'              # 
       TODO_ICON                      $'\U2611'              # ☑
@@ -128,6 +130,7 @@ case $POWERLEVEL9K_MODE in
       ROOT_ICON                      $'\u26A1'              # ⚡
       RUBY_ICON                      ''
       AWS_ICON                       'AWS:'
+      AWS_EB_ICON                    $'\U1F331'             # 🌱
       BACKGROUND_JOBS_ICON           $'\u2699'              # ⚙
       TEST_ICON                      ''
       TODO_ICON                      $'\U2611'              # ☑

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -208,6 +208,14 @@ prompt_aws() {
   fi
 }
 
+# Current Elastic Beanstalk environment
+prompt_aws_eb_env() {
+  if [ -e .elasticbeanstalk/config.yml ]; then
+    local eb_env=$(cat .elasticbeanstalk/config.yml | grep environment 2> /dev/null | awk '{print $2}')
+    "$1_prompt_segment" "$0" black green "$(print_icon 'AWS_EB_ICON')  $eb_env"
+  fi
+}
+
 # Custom: a way for the user to specify custom commands to run,
 # and display the output of.
 #


### PR DESCRIPTION
Print out the current AWS Elastic Beanstalk environment name when the ./.elasticbeanstalk folder exists. Great complement to the EB CLI.

I'm not sure about the icons (couldn't find anything equivalent in the other icon sets), so I just used the emoji icon for all sets. Let me know if that's not OK and I can do some searching.

Cheers!