### PR TITLE
Battery segment: rework part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ A new segment that allows users to define a custom command was added.
 
 ### `virtualenv` changes
 
-This segment now respects `VIRTUAL_ENV_DISABLE_PROMPT`. If this variable is set 
+This segment now respects `VIRTUAL_ENV_DISABLE_PROMPT`. If this variable is set
 to `true`, the segments does not get rendered.
 
 ### `load` changes
@@ -22,7 +22,7 @@ segment is able to show the free ram and used swap.
 ### `vcs` changes
 
 This prompt uses the `VCS_INFO` subsystem by ZSH. From now on this subsystem
-is only invoked if a `vcs` segment was configured. 
+is only invoked if a `vcs` segment was configured.
 
 ### `rvm` changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## v0.3.0 (next)
 
+### Introduced "visual identifiers" to the segments
+
+Now almost every segment can have a visual identifier, which is an
+icon whose color could be adjusted by users.
+
 ### New segment `custom_command` added
 
 A new segment that allows users to define a custom command was added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 Now almost every segment can have a visual identifier, which is an
 icon whose color could be adjusted by users.
 
+### Added ability for "joined" segments
+
+You can now merge segments together by suffixing the segment name with "_joined".
+For Developers: Be aware that the order of parameters in left/right_prompt_segment
+has changed. Now a boolean parameter must be set as second parameter (true if joined).
+
+### `status` changes
+
+The `status` segment was split up into three segments. `background_jobs` prints
+an icon if there are background jobs. `root_indicator` prints an icon if the user
+is root. The `status` segment focuses now on the status only.
+
 ### New segment `custom_command` added
 
 A new segment that allows users to define a custom command was added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.3.0 (next)
 
+### New segment `custom_command` added
+
+A new segment that allows users to define a custom command was added.
+
 ### `virtualenv` changes
 
 This segment now respects `VIRTUAL_ENV_DISABLE_PROMPT`. If this variable is set 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
 
 ##### ip

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ configuration is the default:
 The segments that are currently available are:
 
 * [aws](#aws) - The current AWS profile, if active.
+* **background_jobs** - Indicator for background jobs.
 * [battery](#battery) - Current battery status.
 * [context](#context) - Your username and host.
 * [custom_command](#custom_command) - A custom command to display the output of.
@@ -85,9 +86,10 @@ The segments that are currently available are:
 * **php_version** - Show the current PHP version.
 * [ram](#ram) - Show free RAM and used Swap.
 * [rbenv](#rbenv) - Ruby environment information (if one is active).
+* **root_indicator** - An indicator if the user is root.
 * [rspec_stats](#rspec_stats) - Show a ratio of test classes vs code classes for RSpec.
 * **rust_version** - Display the current rust version.
-* [status](#status) - The return code of the previous command, and status of background jobs.
+* [status](#status) - The return code of the previous command.
 * [symphony2_tests](#symphony2_tests) - Show a ratio of test classes vs code classes for Symfony2.
 * **symphony2_version** - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * [time](#time) - System time.
@@ -222,10 +224,9 @@ See [Unit Test Ratios](#unit-test-ratios), below.
 
 ##### status
 
-This segment shows the return code of the last command, and the presence of any
-background jobs. By default, this segment will always print, but you can
-customize it to only print if there is an error or a forked job by setting the
-following variable in your `~/.zshrc`.
+This segment shows the return code of the last command. By default, this
+segment will always print, but you can customize it to only print if there
+is an error by setting the following variable in your `~/.zshrc`.
 
     POWERLEVEL9K_STATUS_VERBOSE=false
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The segments that are currently available are:
 * [aws](#aws) - The current AWS profile, if active.
 * [battery](#battery) - Current battery status.
 * [context](#context) - Your username and host.
+* [custom_command](#custom_command) - A custom command to display the output of.
 * [dir](#dir) - Your current working directory.
 * **go_version** - Show the current GO version.
 * **history** - The command number for the current line.
@@ -121,6 +122,59 @@ In addition to the above it supports standard _FOREGROUND value without affectin
 
 Supports both OS X and Linux(time remaining requires the acpi program on Linux)
 
+##### custom_command
+
+The `custom_...` segment lets you add a custom command to your prompt, to e.g. display the wifi signal. You choose a name for the segment yourself, (here signal), and then set the appropriate variables, as so (based on the name you chose)
+
+    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_signal)
+    POWERLEVEL9K_CUSTOM_SIGNAL="echo signal: \$(nmcli device wifi | grep yes | awk '{print \$8}')"
+    POWERLEVEL9K_CUSTOM_SIGNAL_BACKGROUND="blue"
+    POWERLEVEL9K_CUSTOM_SIGNAL_FOREGROUND="yellow"
+    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(aws status load ram)
+
+gives
+
+![simplesignal](http://i.imgur.com/SQmYVFL.png)
+
+Instead of defining the command inline (if it is kinda long or unreadable), one can also add a function to the .zshrc like:
+
+    zsh_signal(){
+            local signal=$(nmcli device wifi | grep yes | awk '{print $8}')
+            local color='%F{yellow}'
+            [[ $signal -gt 75 ]] && color='%F{green}'
+            [[ $signal -lt 50 ]] && color='%F{red}'
+            echo -n "%{$color%}\uf230  $signal%{%f%}" # \uf230 is 
+    }
+
+And then by changing the custom commands array (and rearranging a bit the prompt elements) to read:
+
+    POWERLEVEL9K_CUSTOM_SIGNAL="zsh_signal"
+
+Then this updated command looks like:
+
+![signal](http://i.imgur.com/hviMATC.png)
+
+You can also have multiple custom commands. Say you have
+
+    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery custom_signal dir vcs virtualenv custom_time )
+    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(aws status load ram custom_docker)
+
+    POWERLEVEL9K_CUSTOM_SIGNAL="zsh_signal"
+    POWERLEVEL9K_CUSTOM_SIGNAL_FOREGROUND="white"
+    POWERLEVEL9K_CUSTOM_SIGNAL_BACKGROUND="black"
+
+    POWERLEVEL9K_CUSTOM_DOCKER='echo "\uf299 $(docker ps -a | grep Up | wc -l)"' # \uf299 is 
+    POWERLEVEL9K_CUSTOM_DOCKER_FOREGROUND="white"
+    POWERLEVEL9K_CUSTOM_DOCKER_BACKGROUND="blue"
+
+    POWERLEVEL9K_CUSTOM_TIME='echo "$(date +%s)"'
+    POWERLEVEL9K_CUSTOM_TIME_FOREGROUND="black"
+    POWERLEVEL9K_CUSTOM_TIME_BACKGROUND="yellow"
+
+
+Then you get:
+
+![](http://i.imgur.com/QGGBTqY.png)
 
 ##### context
 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -44,6 +44,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     $'\UE271'              # 
       SUNOS_ICON                     $'\U1F31E '            # 🌞
       HOME_ICON                      $'\UE12C '             # 
+      FOLDER_ICON                    $'\UE818 '             # 
       NETWORK_ICON                   $'\UE1AD '             # 
       LOAD_ICON                      $'\UE190 '             # 
       #RAM_ICON                       $'\UE87D'             # 
@@ -95,6 +96,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     $'\UF17C'              # 
       SUNOS_ICON                     $'\UF185 '             # 
       HOME_ICON                      $'\UF015 '             # 
+      FOLDER_ICON                    $'\UF115 '             # 
       NETWORK_ICON                   $'\UF09E '             # 
       LOAD_ICON                      $'\UF080 '             # 
       RAM_ICON                       $'\UF0E4'              # 
@@ -141,6 +143,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
       HOME_ICON                      ''
+      FOLDER_ICON                    ''
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
       RAM_ICON                       'RAM'

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -43,9 +43,9 @@ case $POWERLEVEL9K_MODE in
       FREEBSD_ICON                   $'\U1F608 '            # 😈
       LINUX_ICON                     $'\UE271'              # 
       SUNOS_ICON                     $'\U1F31E '            # 🌞
-      HOME_ICON                      $'\UE12C '             # 
-      FOLDER_ICON                    $'\UE818 '             # 
-      NETWORK_ICON                   $'\UE1AD '             # 
+      HOME_ICON                      $'\UE12C'              # 
+      FOLDER_ICON                    $'\UE818'              # 
+      NETWORK_ICON                   $'\UE1AD'              # 
       LOAD_ICON                      $'\UE190 '             # 
       #RAM_ICON                       $'\UE87D'             # 
       RAM_ICON                       $'\UE1E2 '             # 
@@ -95,9 +95,9 @@ case $POWERLEVEL9K_MODE in
       FREEBSD_ICON                   $'\U1F608 '            # 😈
       LINUX_ICON                     $'\UF17C'              # 
       SUNOS_ICON                     $'\UF185 '             # 
-      HOME_ICON                      $'\UF015 '             # 
-      FOLDER_ICON                    $'\UF115 '             # 
-      NETWORK_ICON                   $'\UF09E '             # 
+      HOME_ICON                      $'\UF015'              # 
+      FOLDER_ICON                    $'\UF115'              # 
+      NETWORK_ICON                   $'\UF09E'              # 
       LOAD_ICON                      $'\UF080 '             # 
       RAM_ICON                       $'\UF0E4'              # 
       VCS_UNTRACKED_ICON             $'\UF059'              # 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -190,9 +190,8 @@ fi
 function print_icon() {
   local icon_name=$1
   local ICON_USER_VARIABLE=POWERLEVEL9K_${icon_name}
-  local USER_ICON=${(P)ICON_USER_VARIABLE}
   if defined "$ICON_USER_VARIABLE"; then
-    echo -n "$USER_ICON"
+    echo -n "${(P)ICON_USER_VARIABLE}"
   else
     echo -n "${icons[$icon_name]}"
   fi

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -64,8 +64,8 @@ case $POWERLEVEL9K_MODE in
       VCS_COMMIT_ICON                $'\UE821 '             # 
       VCS_BRANCH_ICON                $'\UE220'              # 
       VCS_REMOTE_BRANCH_ICON         ' '$'\UE804 '          # 
-      VCS_GIT_ICON                   $'\UE20E  '            # 
-      VCS_HG_ICON                    $'\UE1C3  '            # 
+      VCS_GIT_ICON                   $'\UE20E '             # 
+      VCS_HG_ICON                    $'\UE1C3 '             # 
     )
   ;;
   'awesome-fontconfig')
@@ -111,8 +111,8 @@ case $POWERLEVEL9K_MODE in
       VCS_COMMIT_ICON                $'\UF221 '             # 
       VCS_BRANCH_ICON                $'\UF126'              # 
       VCS_REMOTE_BRANCH_ICON         ' '$'\UF204 '          # 
-      VCS_GIT_ICON                   $'\UF113  '            # 
-      VCS_HG_ICON                    $'\UF0C3  '            # 
+      VCS_GIT_ICON                   $'\UF113 '             # 
+      VCS_HG_ICON                    $'\UF0C3 '             # 
     )
   ;;
   *)

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -78,6 +78,12 @@ function +vi-hg-bookmarks() {
 }
 
 function +vi-vcs-detect-changes() {
+  if [[ "${hook_com[vcs]}" == "git" ]]; then
+    vcs_visual_identifier='VCS_GIT_ICON'
+  elif [[ "${hook_com[vcs]}" == "hg" ]]; then
+    vcs_visual_identifier='VCS_HG_ICON'
+  fi
+
   if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
     VCS_WORKDIR_DIRTY=true
   else

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -782,7 +782,7 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
       RPROMPT_PREFIX='%{'$'\e[1A''%}' # one line up
       RPROMPT_SUFFIX='%{'$'\e[1B''%}' # one line down
     else
-      RPROMPT_PREFIX='' 
+      RPROMPT_PREFIX=''
       RPROMPT_SUFFIX=''
     fi
   else
@@ -838,7 +838,7 @@ powerlevel9k_init() {
   print_deprecation_warning deprecated_segments
 
   setopt prompt_subst
-  
+
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
   setopt PROMPT_CR PROMPT_PERCENT PROMPT_SUBST MULTIBYTE

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -449,7 +449,7 @@ prompt_ip() {
     fi
   fi
 
-  "$1_prompt_segment" "$0" "cyan" "$DEFAULT_COLOR" "$(print_icon 'NETWORK_ICON') $ip"
+  "$1_prompt_segment" "$0" "cyan" "$DEFAULT_COLOR" "$ip" 'NETWORK_ICON'
 }
 
 prompt_load() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -223,8 +223,7 @@ right_prompt_segment() {
 
   local visual_identifier
   if [[ -n $5 ]]; then
-    # Swap the spaces around an icon if the icon is displayed on the right side.
-    visual_identifier=$(print_icon $5 | sed -E "s/( *)([^ ]*)( *)/\3\2\1/")
+    visual_identifier="$(print_icon $5)"
     # Allow users to overwrite the color for the visual identifier only.
     local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
     set_default $visual_identifier_color_variable $fg

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -391,12 +391,10 @@ prompt_dir() {
 
   local current_icon=''
   if [[ $(print -P "%~") == '~'* ]]; then
-    current_icon=$(print_icon 'HOME_ICON')
+    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
   else
-    current_icon=$(print_icon 'FOLDER_ICON')
+    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
   fi
-
-  "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_icon$current_path"
 }
 
 # GO-prompt

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -550,7 +550,7 @@ prompt_nvm() {
   [[ -z "${node_version}" ]] && return
   [[ "$node_version" =~ "$nvm_default" ]] && return
 
-  $1_prompt_segment "$0" "green" "011" "${node_version:1} $(print_icon 'NODE_ICON')"
+  $1_prompt_segment "$0" "green" "011" "${node_version:1}" 'NODE_ICON'
 }
 
 # rbenv information

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -589,7 +589,7 @@ prompt_rvm() {
   local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
 
   if [[ -n "$version$gemset" ]]; then
-    "$1_prompt_segment" "$0" "240" "$DEFAULT_COLOR" "$version$gemset $(print_icon 'RUBY_ICON') "
+    "$1_prompt_segment" "$0" "240" "$DEFAULT_COLOR" "$version$gemset" 'RUBY_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -473,7 +473,7 @@ prompt_load() {
     FUNCTION_SUFFIX="_NORMAL"
   fi
 
-  "$1_prompt_segment" "$0$FUNCTION_SUFFIX" "$BACKGROUND_COLOR" "$DEFAULT_COLOR" "$(print_icon 'LOAD_ICON') $load_avg_5min"
+  "$1_prompt_segment" "$0$FUNCTION_SUFFIX" "$BACKGROUND_COLOR" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
 }
 
 # Node version

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -159,6 +159,10 @@ left_prompt_segment() {
   local visual_identifier
   if [[ -n $5 ]]; then
     visual_identifier="$(print_icon $5)"
+    # Allow users to overwrite the color for the visual identifier only.
+    local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
+    set_default $visual_identifier_color_variable $fg
+    visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     # Add an whitespace if we print more than just the visual identifier
     [[ -n $4 ]] && visual_identifier="$visual_identifier "
   fi
@@ -221,6 +225,10 @@ right_prompt_segment() {
   if [[ -n $5 ]]; then
     # Swap the spaces around an icon if the icon is displayed on the right side.
     visual_identifier=$(print_icon $5 | sed -E "s/( *)([^ ]*)( *)/\3\2\1/")
+    # Allow users to overwrite the color for the visual identifier only.
+    local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
+    set_default $visual_identifier_color_variable $fg
+    visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     # Add an whitespace if we print more than just the visual identifier
     [[ -n $4 ]] && visual_identifier=" $visual_identifier"
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -556,7 +556,7 @@ prompt_nvm() {
 # rbenv information
 prompt_rbenv() {
   if [[ -n "$RBENV_VERSION" ]]; then
-    "$1_prompt_segment" "$0" "red" "$DEFAULT_COLOR" "$RBENV_VERSION"
+    "$1_prompt_segment" "$0" "red" "$DEFAULT_COLOR" "$RBENV_VERSION" 'RUBY_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -159,12 +159,14 @@ left_prompt_segment() {
   local visual_identifier
   if [[ -n $5 ]]; then
     visual_identifier="$(print_icon $5)"
-    # Allow users to overwrite the color for the visual identifier only.
-    local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-    set_default $visual_identifier_color_variable $3
-    visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-    # Add an whitespace if we print more than just the visual identifier
-    [[ -n $4 ]] && visual_identifier="$visual_identifier "
+    if [[ -n "$visual_identifier" ]]; then
+      # Allow users to overwrite the color for the visual identifier only.
+      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
+      set_default $visual_identifier_color_variable $3
+      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
+      # Add an whitespace if we print more than just the visual identifier
+      [[ -n $4 ]] && visual_identifier="$visual_identifier "
+    fi
   fi
 
   echo -n "$visual_identifier%{$fg%}$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
@@ -224,12 +226,14 @@ right_prompt_segment() {
   local visual_identifier
   if [[ -n $5 ]]; then
     visual_identifier="$(print_icon $5)"
-    # Allow users to overwrite the color for the visual identifier only.
-    local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-    set_default $visual_identifier_color_variable $3
-    visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-    # Add an whitespace if we print more than just the visual identifier
-    [[ -n $4 ]] && visual_identifier=" $visual_identifier"
+    if [[ -n "$visual_identifier" ]]; then
+      # Allow users to overwrite the color for the visual identifier only.
+      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
+      set_default $visual_identifier_color_variable $3
+      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
+      # Add an whitespace if we print more than just the visual identifier
+      [[ -n $4 ]] && visual_identifier=" $visual_identifier"
+    fi
   fi
 
   echo -n "$4$visual_identifier$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS%f"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -161,7 +161,7 @@ left_prompt_segment() {
     visual_identifier="$(print_icon $5)"
     # Allow users to overwrite the color for the visual identifier only.
     local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-    set_default $visual_identifier_color_variable $fg
+    set_default $visual_identifier_color_variable $3
     visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     # Add an whitespace if we print more than just the visual identifier
     [[ -n $4 ]] && visual_identifier="$visual_identifier "
@@ -226,7 +226,7 @@ right_prompt_segment() {
     visual_identifier="$(print_icon $5)"
     # Allow users to overwrite the color for the visual identifier only.
     local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-    set_default $visual_identifier_color_variable $fg
+    set_default $visual_identifier_color_variable $3
     visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     # Add an whitespace if we print more than just the visual identifier
     [[ -n $4 ]] && visual_identifier=" $visual_identifier"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -549,7 +549,7 @@ prompt_ram() {
           base=K
         fi
 
-        rendition+="$(print_icon 'RAM_ICON') $(printSizeHumanReadable "$ramfree" $base) "
+        rendition+="$(printSizeHumanReadable "$ramfree" $base) "
       ;;
       swap_used)
         if [[ "$OS" == "OSX" ]]; then
@@ -572,7 +572,7 @@ prompt_ram() {
     esac
   done
 
-  "$1_prompt_segment" "$0" "$2" "yellow" "$DEFAULT_COLOR" "${rendition% }"
+  "$1_prompt_segment" "$0" "$2" "yellow" "$DEFAULT_COLOR" "${rendition% }" 'RAM_ICON'
 }
 
 # Node version from NVM
@@ -616,7 +616,7 @@ prompt_rspec_stats() {
     code_amount=$(ls -1 app/**/*.rb | wc -l)
     tests_amount=$(ls -1 spec/**/*.rb | wc -l)
 
-    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "RSpec $(print_icon 'TEST_ICON')"
+    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "RSpec" 'TEST_ICON'
   fi
 }
 
@@ -655,7 +655,7 @@ prompt_symfony2_tests() {
     code_amount=$(ls -1 src/**/*.php | grep -vc Tests)
     tests_amount=$(ls -1 src/**/*.php | grep -c Tests)
 
-    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "SF2 $(print_icon 'TEST_ICON')"
+    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "SF2" 'TEST_ICON'
   fi
 }
 
@@ -664,7 +664,7 @@ prompt_symfony2_version() {
   if [[ -f app/bootstrap.php.cache ]]; then
     local symfony2_version
     symfony2_version=$(grep " VERSION " app/bootstrap.php.cache | sed -e 's/[^.0-9]*//g')
-    "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$(print_icon 'SYMFONY_ICON') $symfony2_version"
+    "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$symfony2_version" 'SYMFONY_ICON'
   fi
 }
 
@@ -678,9 +678,9 @@ build_test_stats() {
   typeset -F 2 ratio
   local ratio=$(( (tests_amount/code_amount) * 100 ))
 
-  (( ratio >= 75 )) && "$1_prompt_segment" "${2}_GOOD" "$3" "cyan" "$DEFAULT_COLOR" "$headline: $ratio%%"
-  (( ratio >= 50 && ratio < 75 )) && "$1_prompt_segment" "${2}_AVG" "$3" "yellow" "$DEFAULT_COLOR" "$headline: $ratio%%"
-  (( ratio < 50 )) && "$1_prompt_segment" "${2}_BAD" "red" "$3" "$DEFAULT_COLOR" "$headline: $ratio%%"
+  (( ratio >= 75 )) && "$1_prompt_segment" "${2}_GOOD" "$3" "cyan" "$DEFAULT_COLOR" "$headline: $ratio%%" "$6"
+  (( ratio >= 50 && ratio < 75 )) && "$1_prompt_segment" "$2_AVG" "$3" "yellow" "$DEFAULT_COLOR" "$headline: $ratio%%" "$6"
+  (( ratio < 50 )) && "$1_prompt_segment" "$2_BAD" "$3" "red" "$DEFAULT_COLOR" "$headline: $ratio%%" "$6"
 }
 
 # System time
@@ -723,8 +723,7 @@ prompt_vcs() {
   zstyle ':vcs_info:*' check-for-changes true
 
   VCS_DEFAULT_FORMAT="$VCS_CHANGESET_PREFIX%F{$POWERLEVEL9K_VCS_FOREGROUND}%b%c%u%m%f"
-  zstyle ':vcs_info:git*:*' formats "%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_GIT_ICON')%f$VCS_DEFAULT_FORMAT"
-  zstyle ':vcs_info:hg*:*' formats "%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_HG_ICON')%f$VCS_DEFAULT_FORMAT"
+  zstyle ':vcs_info:*' formats "$VCS_DEFAULT_FORMAT"
 
   zstyle ':vcs_info:*' actionformats "%b %F{red}| %a%f"
 
@@ -751,9 +750,11 @@ prompt_vcs() {
 
   if [[ -n "$vcs_prompt" ]]; then
     if [[ "$VCS_WORKDIR_DIRTY" == true ]]; then
-      "$1_prompt_segment" "$0_MODIFIED" "$2" "yellow" "$DEFAULT_COLOR" "$vcs_prompt"
+      # $vcs_visual_identifier gets set in +vi-vcs-detect-changes in functions/vcs.zsh,
+      # as we have there access to vcs_info internal hooks.
+      "$1_prompt_segment" "$0_MODIFIED" "$2" "yellow" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
     else
-      "$1_prompt_segment" "$0" "$2" "green" "$DEFAULT_COLOR" "$vcs_prompt"
+      "$1_prompt_segment" "$0" "$2" "green" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
     fi
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -668,7 +668,7 @@ prompt_todo() {
   if $(hash todo.sh 2>&-); then
     count=$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }')
     if [[ "$count" = <-> ]]; then
-      "$1_prompt_segment" "$0" "244" "$DEFAULT_COLOR" "$(print_icon 'TODO_ICON') $count"
+      "$1_prompt_segment" "$0" "244" "$DEFAULT_COLOR" "$count" 'TODO_ICON'
     fi
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -251,7 +251,7 @@ prompt_aws() {
   local aws_profile="$AWS_DEFAULT_PROFILE"
   if [[ -n "$aws_profile" ]];
   then
-    "$1_prompt_segment" "$0" red white "$(print_icon 'AWS_ICON') $aws_profile"
+    "$1_prompt_segment" "$0" red white "$aws_profile" 'AWS_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -320,7 +320,14 @@ prompt_dir() {
 
   fi
 
-  "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$(print_icon 'HOME_ICON')$current_path"
+  local current_icon=''
+  if [[ $(print -P "%~") == '~'* ]]; then
+    current_icon=$(print_icon 'HOME_ICON')
+  else
+    current_icon=$(print_icon 'FOLDER_ICON')
+  fi
+
+  "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_icon$current_path"
 }
 
 # GO-prompt

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -208,6 +208,15 @@ prompt_aws() {
   fi
 }
 
+# Custom: a way for the user to specify custom commands to run,
+# and display the output of.
+#
+prompt_custom() {
+  local command=POWERLEVEL9K_CUSTOM_$2:u
+
+  "$1_prompt_segment" "${0}_${2:u}" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$(eval ${(P)command})"
+}
+
 prompt_battery() {
   icons[BATTERY_ICON]=$'\UE894'
   # set default values of not specified in shell
@@ -680,7 +689,13 @@ build_left_prompt() {
   defined POWERLEVEL9K_LEFT_PROMPT_ELEMENTS || POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
 
   for element in "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[@]}"; do
-    "prompt_$element" "left"
+    # Check if it is a custom command, otherwise interpet it as
+    # a prompt.
+    if [[ $element[0,7] =~ "custom_" ]]; then
+      "prompt_custom" "left" $element[8,-1]
+    else
+      "prompt_$element" "left"
+    fi
   done
 
   left_prompt_end
@@ -691,7 +706,13 @@ build_right_prompt() {
   defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
 
   for element in "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
-    "prompt_$element" "right"
+    # Check if it is a custom command, otherwise interpet it as
+    # a prompt.
+    if [[ $element[0,7] =~ "custom_" ]]; then
+      "prompt_custom" "right" $element[8,-1]
+    else
+      "prompt_$element" "right"
+    fi
   done
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -120,57 +120,67 @@ CURRENT_BG='NONE'
 # Takes four arguments:
 #   * $1: Name of the function that was orginally invoked (mandatory).
 #         Necessary, to make the dynamic color-overwrite mechanism work.
-#   * $2: Background color
-#   * $3: Foreground color
-#   * $4: The segment content
-#   * $5: An identifying icon (must be a key of the icons array)
-# The latter four can be omitted,
+#   * $2: A flag if the segment should be joined with the previous one.
+#   * $3: Background color
+#   * $4: Foreground color
+#   * $5: The segment content
+#   * $6: An identifying icon (must be a key of the icons array)
+# The latter three can be omitted,
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS " "
 left_prompt_segment() {
   # Overwrite given background-color by user defined variable for this segment.
   local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_BACKGROUND
   local BG_COLOR_MODIFIER=${(P)BACKGROUND_USER_VARIABLE}
-  [[ -n $BG_COLOR_MODIFIER ]] && 2="$BG_COLOR_MODIFIER"
+  [[ -n $BG_COLOR_MODIFIER ]] && 3="$BG_COLOR_MODIFIER"
 
   # Overwrite given foreground-color by user defined variable for this segment.
   local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_FOREGROUND
   local FG_COLOR_MODIFIER=${(P)FOREGROUND_USER_VARIABLE}
-  [[ -n $FG_COLOR_MODIFIER ]] && 3="$FG_COLOR_MODIFIER"
+  [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n $2 ]] && bg="%K{$2}" || bg="%k"
-  [[ -n $3 ]] && fg="%F{$3}" || fg="%f"
-  if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$2" "$CURRENT_BG"; then
-    # Middle segment
-    echo -n "%{$bg%F{$CURRENT_BG}%}$(print_icon 'LEFT_SEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
-  elif isSameColor "$CURRENT_BG" "$2"; then
+  [[ -n "$3" ]] && bg="%K{$3}" || bg="%k"
+  [[ -n "$4" ]] && fg="%F{$4}" || fg="%f"
+
+  local joined=$2
+  if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$3" "$CURRENT_BG"; then
+    echo -n "%{$bg%F{$CURRENT_BG}%}"
+    if [[ $joined == false ]]; then
+      # Middle segment
+      echo -n "$(print_icon 'LEFT_SEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    fi
+  elif isSameColor "$CURRENT_BG" "$3"; then
     # Middle segment with same color as previous segment
     # We take the current foreground color as color for our
     # subsegment (or the default color). This should have
     # enough contrast.
     local complement
-    [[ -n $3 ]] && complement=$3 || complement=$DEFAULT_COLOR
-    echo -n "%{$bg%F{$complement}%}$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    [[ -n "$4" ]] && complement="$4" || complement=$DEFAULT_COLOR
+    echo -n "%{$bg%F{$complement}%}"
+    if [[ $joined == false ]]; then
+      echo -n "$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    fi
   else
     # First segment
     echo -n "%{$bg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   fi
 
   local visual_identifier
-  if [[ -n $5 ]]; then
-    visual_identifier="$(print_icon $5)"
+  if [[ -n $6 ]]; then
+    visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-      set_default $visual_identifier_color_variable $3
+      set_default $visual_identifier_color_variable $4
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
       # Add an whitespace if we print more than just the visual identifier
-      [[ -n $4 ]] && visual_identifier="$visual_identifier "
+      [[ -n "$5" ]] && visual_identifier="$visual_identifier "
     fi
   fi
 
-  echo -n "$visual_identifier%{$fg%}$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
-  CURRENT_BG=$2
+  [[ -n "$5" ]] && echo -n "${visual_identifier}%{$fg%}${5}${POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS}"
+
+  CURRENT_BG=$3
 }
 
 # End the left prompt, closes the final segment.
@@ -190,54 +200,66 @@ CURRENT_RIGHT_BG='NONE'
 # Takes four arguments:
 #   * $1: Name of the function that was orginally invoked (mandatory).
 #         Necessary, to make the dynamic color-overwrite mechanism work.
-#   * $2: Background color
-#   * $3: Foreground color
-#   * $4: The segment content
-#   * $5: An identifying icon (must be a key of the icons array)
+#   * $2: A flag if the segment should be joined with the previous one.
+#   * $3: Background color
+#   * $4: Foreground color
+#   * $5: The segment content
+#   * $6: An identifying icon (must be a key of the icons array)
 # No ending for the right prompt segment is needed (unlike the left prompt, above).
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS " "
 right_prompt_segment() {
   # Overwrite given background-color by user defined variable for this segment.
   local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_BACKGROUND
   local BG_COLOR_MODIFIER=${(P)BACKGROUND_USER_VARIABLE}
-  [[ -n $BG_COLOR_MODIFIER ]] && 2="$BG_COLOR_MODIFIER"
+  [[ -n $BG_COLOR_MODIFIER ]] && 3="$BG_COLOR_MODIFIER"
 
   # Overwrite given foreground-color by user defined variable for this segment.
   local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_FOREGROUND
   local FG_COLOR_MODIFIER=${(P)FOREGROUND_USER_VARIABLE}
-  [[ -n $FG_COLOR_MODIFIER ]] && 3="$FG_COLOR_MODIFIER"
+  [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n $2 ]] && bg="%K{$2}" || bg="%k"
-  [[ -n $3 ]] && fg="%F{$3}" || fg="%f"
+  [[ -n "$3" ]] && bg="%K{$3}" || bg="%k"
+  [[ -n "$4" ]] && fg="%F{$4}" || fg="%f"
 
-  if isSameColor "$CURRENT_RIGHT_BG" "$2"; then
-    # Middle segment with same color as previous segment
-    # We take the current foreground color as color for our
-    # subsegment (or the default color). This should have
-    # enough contrast.
-    local complement
-    [[ -n $3 ]] && complement=$3 || complement=$DEFAULT_COLOR
-    echo -n "%F{$complement}$(print_icon 'RIGHT_SUBSEGMENT_SEPARATOR')%f%{$bg%}%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS"
-  else
-    echo -n "%F{$2}$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f%{$bg%}%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS"
-  fi
-
-  local visual_identifier
-  if [[ -n $5 ]]; then
-    visual_identifier="$(print_icon $5)"
-    if [[ -n "$visual_identifier" ]]; then
-      # Allow users to overwrite the color for the visual identifier only.
-      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-      set_default $visual_identifier_color_variable $3
-      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-      # Add an whitespace if we print more than just the visual identifier
-      [[ -n $4 ]] && visual_identifier=" $visual_identifier"
+  local joined=$2
+  # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
+  if [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]]; then
+    if isSameColor "$CURRENT_RIGHT_BG" "$3"; then
+      # Middle segment with same color as previous segment
+      # We take the current foreground color as color for our
+      # subsegment (or the default color). This should have
+      # enough contrast.
+      local complement
+      [[ -n "$4" ]] && complement="$4" || complement=$DEFAULT_COLOR
+      echo -n "%F{$complement}$(print_icon 'RIGHT_SUBSEGMENT_SEPARATOR')%f"
+    else
+      echo -n "%F{$3}$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f"
     fi
   fi
 
-  echo -n "$4$visual_identifier$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS%f"
-  CURRENT_RIGHT_BG=$2
+  local visual_identifier
+  if [[ -n "$6" ]]; then
+    visual_identifier="$(print_icon $6)"
+    if [[ -n "$visual_identifier" ]]; then
+      # Allow users to overwrite the color for the visual identifier only.
+      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
+      set_default $visual_identifier_color_variable $4
+      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
+      # Add an whitespace if we print more than just the visual identifier
+      [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
+    fi
+  fi
+
+  echo -n "%{$bg%}%{$fg%}"
+
+  # Print whitespace only if segment is not joined or first right segment
+  [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
+
+  # Print segment content
+  [[ -n "$5" ]] && echo -n "${5}${visual_identifier}${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}%f"
+
+  CURRENT_RIGHT_BG=$3
 }
 
 ################################################################
@@ -254,7 +276,7 @@ prompt_aws() {
   local aws_profile="$AWS_DEFAULT_PROFILE"
   if [[ -n "$aws_profile" ]];
   then
-    "$1_prompt_segment" "$0" red white "$aws_profile" 'AWS_ICON'
+    "$1_prompt_segment" "$0" "$2" red white "$aws_profile" 'AWS_ICON'
   fi
 }
 
@@ -262,9 +284,16 @@ prompt_aws() {
 # and display the output of.
 #
 prompt_custom() {
-  local command=POWERLEVEL9K_CUSTOM_$2:u
+  local command=POWERLEVEL9K_CUSTOM_$3:u
 
-  "$1_prompt_segment" "${0}_${2:u}" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$(eval ${(P)command})"
+  "$1_prompt_segment" "${0}_${3:u}" "$2" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$(eval ${(P)command})"
+}
+
+# print an icon, if there are background jobs
+prompt_background_jobs() {
+  if [[ $(jobs -l | wc -l) -gt 0 ]]; then
+    "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR" "cyan" "$(print_icon 'BACKGROUND_JOBS_ICON')"
+  fi
 }
 
 prompt_battery() {
@@ -357,7 +386,7 @@ prompt_battery() {
   fi
 
   # display prompt_segment
-  [[ -n $bat_percent ]] && "$1_prompt_segment" "${0}_${current_state}" "$DEFAULT_COLOR" "${battery_states[$current_state]}" "$message" 'BATTERY_ICON'
+  [[ -n $bat_percent ]] && "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${battery_states[$current_state]}" "$message" 'BATTERY_ICON'
 }
 
 # Context: user@hostname (who am I and where am I)
@@ -366,9 +395,9 @@ prompt_context() {
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
     if [[ $(print -P "%#") == '#' ]]; then
       # Shell runs as root
-      "$1_prompt_segment" "$0_ROOT" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
     else
-      "$1_prompt_segment" "$0_DEFAULT" "$DEFAULT_COLOR" "011" "$USER@%m"
+      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
     fi
   fi
 }
@@ -394,9 +423,9 @@ prompt_dir() {
 
   local current_icon=''
   if [[ $(print -P "%~") == '~'* ]]; then
-    "$1_prompt_segment" "$0_HOME" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
+    "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
   else
-    "$1_prompt_segment" "$0_DEFAULT" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
+    "$1_prompt_segment" "$0_DEFAULT" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
   fi
 }
 
@@ -406,13 +435,13 @@ prompt_go_version() {
   go_version=$(go version 2>&1 | sed -E "s/.*(go[0-9.]*).*/\1/")
 
   if [[ -n "$go_version" ]]; then
-    "$1_prompt_segment" "$0" "green" "255" "$go_version"
+    "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version"
   fi
 }
 
 # Command number (in local history)
 prompt_history() {
-  "$1_prompt_segment" "$0" "244" "$DEFAULT_COLOR" '%h'
+  "$1_prompt_segment" "$0" "$2" "244" "$DEFAULT_COLOR" '%h'
 }
 
 prompt_icons_test() {
@@ -421,7 +450,7 @@ prompt_icons_test() {
     # the next color has enough contrast to read.
     local random_color=$((RANDOM % 8))
     local next_color=$((random_color+1))
-    "$1_prompt_segment" "$0" "$random_color" "$next_color" "$key: ${icons[$key]}"
+    "$1_prompt_segment" "$0" "$2" "$random_color" "$next_color" "$key: ${icons[$key]}"
   done
 }
 
@@ -452,7 +481,7 @@ prompt_ip() {
     fi
   fi
 
-  "$1_prompt_segment" "$0" "cyan" "$DEFAULT_COLOR" "$ip" 'NETWORK_ICON'
+  "$1_prompt_segment" "$0" "$2" "cyan" "$DEFAULT_COLOR" "$ip" 'NETWORK_ICON'
 }
 
 prompt_load() {
@@ -476,7 +505,7 @@ prompt_load() {
     FUNCTION_SUFFIX="_NORMAL"
   fi
 
-  "$1_prompt_segment" "$0$FUNCTION_SUFFIX" "$BACKGROUND_COLOR" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
+  "$1_prompt_segment" "$0$FUNCTION_SUFFIX" "$2" "$BACKGROUND_COLOR" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
 }
 
 # Node version
@@ -484,12 +513,12 @@ prompt_node_version() {
   local node_version=$(node -v 2>/dev/null)
   [[ -z "${node_version}" ]] && return
 
-  "$1_prompt_segment" "$0" "green" "white" "${node_version:1}" 'NODE_ICON'
+  "$1_prompt_segment" "$0" "$2" "green" "white" "${node_version:1}" 'NODE_ICON'
 }
 
 # print a little OS icon
 prompt_os_icon() {
-  "$1_prompt_segment" "$0" "black" "255" "$OS_ICON"
+  "$1_prompt_segment" "$0" "$2" "black" "255" "$OS_ICON"
 }
 
 # print PHP version number
@@ -498,7 +527,7 @@ prompt_php_version() {
   php_version=$(php -v 2>&1 | grep -oe "^PHP\s*[0-9.]*")
 
   if [[ -n "$php_version" ]]; then
-    "$1_prompt_segment" "$0" "013" "255" "$php_version"
+    "$1_prompt_segment" "$0" "$2" "013" "255" "$php_version"
   fi
 }
 
@@ -543,7 +572,7 @@ prompt_ram() {
     esac
   done
 
-  "$1_prompt_segment" "$0" "yellow" "$DEFAULT_COLOR" "${rendition% }"
+  "$1_prompt_segment" "$0" "$2" "yellow" "$DEFAULT_COLOR" "${rendition% }"
 }
 
 # Node version from NVM
@@ -554,13 +583,20 @@ prompt_nvm() {
   [[ -z "${node_version}" ]] && return
   [[ "$node_version" =~ "$nvm_default" ]] && return
 
-  $1_prompt_segment "$0" "green" "011" "${node_version:1}" 'NODE_ICON'
+  $1_prompt_segment "$0" "$2" "green" "011" "${node_version:1}" 'NODE_ICON'
 }
 
 # rbenv information
 prompt_rbenv() {
   if [[ -n "$RBENV_VERSION" ]]; then
-    "$1_prompt_segment" "$0" "red" "$DEFAULT_COLOR" "$RBENV_VERSION" 'RUBY_ICON'
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$RBENV_VERSION" 'RUBY_ICON'
+  fi
+}
+
+# print an icon if user is root.
+prompt_root_indicator() {
+  if [[ "$UID" -eq 0 ]]; then
+    "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR" "yellow" "$(print_icon 'ROOT_ICON')"
   fi
 }
 
@@ -570,7 +606,7 @@ prompt_rust_version() {
   rust_version=$(rustc --version 2>&1 | grep -oe "^rustc\s*[^ ]*" | grep -o '[0-9.a-z\\\-]*$')
 
   if [[ -n "$rust_version" ]]; then
-    "$1_prompt_segment" "$0" "208" "$DEFAULT_COLOR" "Rust $rust_version"
+    "$1_prompt_segment" "$0" "$2" "208" "$DEFAULT_COLOR" "Rust $rust_version"
   fi
 }
 # RSpec test ratio
@@ -580,7 +616,7 @@ prompt_rspec_stats() {
     code_amount=$(ls -1 app/**/*.rb | wc -l)
     tests_amount=$(ls -1 spec/**/*.rb | wc -l)
 
-    build_test_stats "$1" "$0" "$code_amount" "$tests_amount" "RSpec $(print_icon 'TEST_ICON')"
+    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "RSpec $(print_icon 'TEST_ICON')"
   fi
 }
 
@@ -592,33 +628,24 @@ prompt_rvm() {
   local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
 
   if [[ -n "$version$gemset" ]]; then
-    "$1_prompt_segment" "$0" "240" "$DEFAULT_COLOR" "$version$gemset" 'RUBY_ICON'
+    "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$version$gemset" 'RUBY_ICON'
   fi
 }
 
 # Status: (return code, root status, background jobs)
 set_default POWERLEVEL9K_STATUS_VERBOSE true
 prompt_status() {
-  local symbols bg
-  symbols=()
-
   if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
     if [[ "$RETVAL" -ne 0 ]]; then
-      symbols+="%F{226}$RETVAL $(print_icon 'CARRIAGE_RETURN_ICON')%f"
-      bg="red"
+      "$1_prompt_segment" "$0_ERROR" "$2" "red" "226" "$RETVAL $(print_icon 'CARRIAGE_RETURN_ICON')"
     else
-      symbols+="%F{046}$(print_icon 'OK_ICON')%f"
-      bg="black"
+      "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "046" "$(print_icon 'OK_ICON')"
     fi
   else
-    [[ "$RETVAL" -ne 0 ]] && symbols+="%{%F{red}%}$(print_icon 'FAIL_ICON')%f"
-    bg="$DEFAULT_COLOR"
+    if [[ "$RETVAL" -ne 0 ]]; then
+      "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "$(print_icon 'FAIL_ICON')"
+    fi
   fi
-
-  [[ "$UID" -eq 0 ]] && symbols+="%{%F{yellow}%} $(print_icon 'ROOT_ICON')%f"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}$(print_icon 'BACKGROUND_JOBS_ICON')%f"
-
-  [[ -n "$symbols" ]] && "$1_prompt_segment" "$0" "$bg" "white" "$symbols"
 }
 
 # Symfony2-PHPUnit test ratio
@@ -628,7 +655,7 @@ prompt_symfony2_tests() {
     code_amount=$(ls -1 src/**/*.php | grep -vc Tests)
     tests_amount=$(ls -1 src/**/*.php | grep -c Tests)
 
-    build_test_stats "$1" "$0" "$code_amount" "$tests_amount" "SF2 $(print_icon 'TEST_ICON')"
+    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "SF2 $(print_icon 'TEST_ICON')"
   fi
 }
 
@@ -637,23 +664,23 @@ prompt_symfony2_version() {
   if [[ -f app/bootstrap.php.cache ]]; then
     local symfony2_version
     symfony2_version=$(grep " VERSION " app/bootstrap.php.cache | sed -e 's/[^.0-9]*//g')
-    "$1_prompt_segment" "$0" "240" "$DEFAULT_COLOR" "$(print_icon 'SYMFONY_ICON') $symfony2_version"
+    "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$(print_icon 'SYMFONY_ICON') $symfony2_version"
   fi
 }
 
 # Show a ratio of tests vs code
 build_test_stats() {
-  local code_amount="$3"
-  local tests_amount="$4"+0.00001
-  local headline="$5"
+  local code_amount="$4"
+  local tests_amount="$5"+0.00001
+  local headline="$6"
 
   # Set float precision to 2 digits:
   typeset -F 2 ratio
   local ratio=$(( (tests_amount/code_amount) * 100 ))
 
-  (( ratio >= 75 )) && "$1_prompt_segment" "${2}_GOOD" "cyan" "$DEFAULT_COLOR" "$headline: $ratio%%"
-  (( ratio >= 50 && ratio < 75 )) && "$1_prompt_segment" "$2_AVG" "yellow" "$DEFAULT_COLOR" "$headline: $ratio%%"
-  (( ratio < 50 )) && "$1_prompt_segment" "$2_BAD" "red" "$DEFAULT_COLOR" "$headline: $ratio%%"
+  (( ratio >= 75 )) && "$1_prompt_segment" "${2}_GOOD" "$3" "cyan" "$DEFAULT_COLOR" "$headline: $ratio%%"
+  (( ratio >= 50 && ratio < 75 )) && "$1_prompt_segment" "${2}_AVG" "$3" "yellow" "$DEFAULT_COLOR" "$headline: $ratio%%"
+  (( ratio < 50 )) && "$1_prompt_segment" "${2}_BAD" "red" "$3" "$DEFAULT_COLOR" "$headline: $ratio%%"
 }
 
 # System time
@@ -663,7 +690,7 @@ prompt_time() {
     time_format="$POWERLEVEL9K_TIME_FORMAT"
   fi
 
-  "$1_prompt_segment" "$0" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "$time_format"
+  "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "$time_format"
 }
 
 # todo.sh: shows the number of tasks in your todo.sh file
@@ -671,7 +698,7 @@ prompt_todo() {
   if $(hash todo.sh 2>&-); then
     count=$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }')
     if [[ "$count" = <-> ]]; then
-      "$1_prompt_segment" "$0" "244" "$DEFAULT_COLOR" "$count" 'TODO_ICON'
+      "$1_prompt_segment" "$0" "$2" "244" "$DEFAULT_COLOR" "$count" 'TODO_ICON'
     fi
   fi
 }
@@ -724,12 +751,10 @@ prompt_vcs() {
 
   if [[ -n "$vcs_prompt" ]]; then
     if [[ "$VCS_WORKDIR_DIRTY" == true ]]; then
-      "$1_prompt_segment" "$0_MODIFIED" "yellow" "$DEFAULT_COLOR"
+      "$1_prompt_segment" "$0_MODIFIED" "$2" "yellow" "$DEFAULT_COLOR" "$vcs_prompt"
     else
-      "$1_prompt_segment" "$0" "green" "$DEFAULT_COLOR"
+      "$1_prompt_segment" "$0" "$2" "green" "$DEFAULT_COLOR" "$vcs_prompt"
     fi
-
-    echo -n "$vcs_prompt "
   fi
 }
 
@@ -739,10 +764,10 @@ set_default POWERLEVEL9K_VI_COMMAND_MODE_STRING "NORMAL"
 prompt_vi_mode() {
   case ${KEYMAP} in
     main|viins)
-      "$1_prompt_segment" "$0_INSERT" "$DEFAULT_COLOR" "blue" "$POWERLEVEL9K_VI_INSERT_MODE_STRING"
+      "$1_prompt_segment" "$0_INSERT" "$2" "$DEFAULT_COLOR" "blue" "$POWERLEVEL9K_VI_INSERT_MODE_STRING"
     ;;
     vicmd)
-      "$1_prompt_segment" "$0_NORMAL" "$DEFAULT_COLOR" "default" "$POWERLEVEL9K_VI_COMMAND_MODE_STRING"
+      "$1_prompt_segment" "$0_NORMAL" "$2" "$DEFAULT_COLOR" "default" "$POWERLEVEL9K_VI_COMMAND_MODE_STRING"
     ;;
   esac
 }
@@ -753,7 +778,7 @@ prompt_vi_mode() {
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n "$virtualenv_path" && "$VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
-    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "($(basename "$virtualenv_path"))"
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "($(basename "$virtualenv_path"))"
   fi
 }
 
@@ -766,12 +791,18 @@ build_left_prompt() {
   defined POWERLEVEL9K_LEFT_PROMPT_ELEMENTS || POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
 
   for element in "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+    # Check if the segment should be joined with the previous one
+    local joined=false
+    if [[ ${element[-7,-1]} == '_joined' ]]; then
+      element="${element[0,-8]}"
+      joined=true
+    fi
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
     if [[ $element[0,7] =~ "custom_" ]]; then
-      "prompt_custom" "left" $element[8,-1]
+      "prompt_custom" "left" "$joined" $element[8,-1]
     else
-      "prompt_$element" "left"
+      "prompt_$element" "left" "$joined"
     fi
   done
 
@@ -780,15 +811,21 @@ build_left_prompt() {
 
 # Right prompt
 build_right_prompt() {
-  defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
+  defined POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS || POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status root_indicator background_jobs history time)
 
   for element in "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
+    # Check if the segment should be joined with the previous one
+    local joined=false
+    if [[ ${element[-7,-1]} == '_joined' ]]; then
+      element="${element[0,-8]}"
+      joined=true
+    fi
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
     if [[ $element[0,7] =~ "custom_" ]]; then
-      "prompt_custom" "right" $element[8,-1]
+      "prompt_custom" "right" "$joined" $element[8,-1]
     else
-      "prompt_$element" "right"
+      "prompt_$element" "right" "$joined"
     fi
   done
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -346,15 +346,15 @@ prompt_battery() {
   fi
 
   # prepare string
-  local message="$(print_icon 'BATTERY_ICON')"
+  local message
   # Default behavior: Be verbose!
   set_default POWERLEVEL9K_BATTERY_VERBOSE true
   if [[ "$POWERLEVEL9K_BATTERY_VERBOSE" == true ]]; then
-    message="$message $bat_percent%%$remain"
+    message="$bat_percent%%$remain"
   fi
 
   # display prompt_segment
-  [[ -n $bat_percent ]] && "$1_prompt_segment" "${0}_${current_state}" "$DEFAULT_COLOR" "${battery_states[$current_state]}" "$message"
+  [[ -n $bat_percent ]] && "$1_prompt_segment" "${0}_${current_state}" "$DEFAULT_COLOR" "${battery_states[$current_state]}" "$message" 'BATTERY_ICON'
 }
 
 # Context: user@hostname (who am I and where am I)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -123,7 +123,8 @@ CURRENT_BG='NONE'
 #   * $2: Background color
 #   * $3: Foreground color
 #   * $4: The segment content
-# The latter three can be omitted,
+#   * $5: An identifying icon (must be a key of the icons array)
+# The latter four can be omitted,
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS " "
 left_prompt_segment() {
   # Overwrite given background-color by user defined variable for this segment.
@@ -154,8 +155,16 @@ left_prompt_segment() {
     # First segment
     echo -n "%{$bg%}%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   fi
+
+  local visual_identifier
+  if [[ -n $5 ]]; then
+    visual_identifier="$(print_icon $5)"
+    # Add an whitespace if we print more than just the visual identifier
+    [[ -n $4 ]] && visual_identifier="$visual_identifier "
+  fi
+
+  echo -n "$visual_identifier$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   CURRENT_BG=$2
-  [[ -n $4 ]] && echo -n "$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
 }
 
 # End the left prompt, closes the final segment.
@@ -178,6 +187,7 @@ CURRENT_RIGHT_BG='NONE'
 #   * $2: Background color
 #   * $3: Foreground color
 #   * $4: The segment content
+#   * $5: An identifying icon (must be a key of the icons array)
 # No ending for the right prompt segment is needed (unlike the left prompt, above).
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS " "
 right_prompt_segment() {
@@ -206,8 +216,16 @@ right_prompt_segment() {
   else
     echo -n "%F{$2}$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f%{$bg%}%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS"
   fi
-  [[ -n $4 ]] && echo -n "$4$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS%f"
 
+  local visual_identifier
+  if [[ -n $5 ]]; then
+    # Swap the spaces around an icon if the icon is displayed on the right side.
+    visual_identifier=$(print_icon $5 | sed -E "s/( *)([^ ]*)( *)/\3\2\1/")
+    # Add an whitespace if we print more than just the visual identifier
+    [[ -n $4 ]] && visual_identifier=" $visual_identifier"
+  fi
+
+  echo -n "$4$visual_identifier$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS%f"
   CURRENT_RIGHT_BG=$2
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -394,9 +394,9 @@ prompt_dir() {
 
   local current_icon=''
   if [[ $(print -P "%~") == '~'* ]]; then
-    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
+    "$1_prompt_segment" "$0_HOME" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
   else
-    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
+    "$1_prompt_segment" "$0_DEFAULT" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -481,7 +481,7 @@ prompt_node_version() {
   local node_version=$(node -v 2>/dev/null)
   [[ -z "${node_version}" ]] && return
 
-  "$1_prompt_segment" "$0" "green" "white" "${node_version:1} $(print_icon 'NODE_ICON')"
+  "$1_prompt_segment" "$0" "green" "white" "${node_version:1}" 'NODE_ICON'
 }
 
 # print a little OS icon

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -142,7 +142,7 @@ left_prompt_segment() {
   [[ -n $3 ]] && fg="%F{$3}" || fg="%f"
   if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$2" "$CURRENT_BG"; then
     # Middle segment
-    echo -n "%{$bg%F{$CURRENT_BG}%}$(print_icon 'LEFT_SEGMENT_SEPARATOR')%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    echo -n "%{$bg%F{$CURRENT_BG}%}$(print_icon 'LEFT_SEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   elif isSameColor "$CURRENT_BG" "$2"; then
     # Middle segment with same color as previous segment
     # We take the current foreground color as color for our
@@ -150,10 +150,10 @@ left_prompt_segment() {
     # enough contrast.
     local complement
     [[ -n $3 ]] && complement=$3 || complement=$DEFAULT_COLOR
-    echo -n "%{$bg%F{$complement}%}$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    echo -n "%{$bg%F{$complement}%}$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   else
     # First segment
-    echo -n "%{$bg%}%{$fg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    echo -n "%{$bg%}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   fi
 
   local visual_identifier
@@ -167,7 +167,7 @@ left_prompt_segment() {
     [[ -n $4 ]] && visual_identifier="$visual_identifier "
   fi
 
-  echo -n "$visual_identifier$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+  echo -n "$visual_identifier%{$fg%}$4$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   CURRENT_BG=$2
 }
 


### PR DESCRIPTION
I didn't forget about @rjorgenson's wish to easily change the color of an icon from #157 . Now I think I have a good piece of code. 
Now there is a concept of a "visual identifier" of a segment. This is much like a logo of a segment. Before this change we printed the icons into the message that is passed to `left_prompt_segment` and a big part of segments just have one icon..

What this code does is quite simple, `left_prompt_segment` take a new parameter that can have its own color (by setting a variable like `POWERLEVEL9K_<segment>_<state>_VISUAL_IDENTIFIER_COLOR` (e.g. `POWERLEVEL9K_BATTERY_DISCONNECTED_VISUAL_IDENTIFIER='red'`).

A quite extensive example:
```zsh
POWERLEVEL9K_DIR_HOME_VISUAL_IDENTIFIER_COLOR='green'
POWERLEVEL9K_DIR_HOME_FOREGROUND='cyan'
POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR='red'
POWERLEVEL9K_DIR_DEFAULT_FOREGROUND='yellow'
POWERLEVEL9K_FOLDER_ICON='Dir'
```

The benefits in short:
- General code: Every segment can have a visual identifier (and thus change its color)
- Cleaner code: The segments don't have to know anything about this
- Very flexible

I even did a branch for the "print_icon"-variant, but it didn't work out: The `print_icon` function is called first, and we don't know which color the user set for that segment. I think this is what @rjorgenson meant with "keeping track". Sorry for not getting your point.