### PR TITLE
Add a toggle for the HOME_ICON

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,14 @@ To change the way how the current working directory is truncated, just set:
     # default behaviour is to truncate whole directories
 
 In each case you have to specify the length you want to shorten the directory
-to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in 
+to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
+
+When using the Awesome or flat fonts, there is an icon of a house at the left
+edge of this segment. To hide this icon, set:
+
+    # Hide the home icon
+    POWERLEVEL9K_SHOW_HOME_ICON=false
 
 ##### ip
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -961,7 +961,7 @@ powerlevel9k_init() {
   term_colors=$(tput colors)
   if (( term_colors < 256 )); then
     print -P "%F{red}WARNING!%f Your terminal supports less than 256 colors!"
-    print "You should set TERM=xterm-256colors in your ~/.zshrc"
+    print -P "You should put: %F{blue}export TERM=\"xterm-256color\"%f in your \~\/.zshrc"
   fi
 
   setopt prompt_subst

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -947,12 +947,26 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
 
 function zle-line-init {
   powerlevel9k_prepare_prompts
+  if (( ${+terminfo[smkx]} )); then
+    printf '%s' ${terminfo[smkx]}
+  fi
   zle reset-prompt
+  zle -R
+}
+
+function zle-line-finish {
+  powerlevel9k_prepare_prompts
+  if (( ${+terminfo[rmkx]} )); then
+    printf '%s' ${terminfo[rmkx]}
+  fi
+  zle reset-prompt
+  zle -R
 }
 
 function zle-keymap-select {
   powerlevel9k_prepare_prompts
   zle reset-prompt
+  zle -R
 }
 
 powerlevel9k_init() {
@@ -980,6 +994,7 @@ powerlevel9k_init() {
   add-zsh-hook precmd powerlevel9k_prepare_prompts
 
   zle -N zle-line-init
+  zle -N zle-line-finish
   zle -N zle-keymap-select
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -232,7 +232,7 @@ function print_icon() {
 printSizeHumanReadable() {
   local size=$1
   local extension
-  extension=(B K M G T P E Z Y)
+  extension=('B' 'K' 'M' 'G' 'T' 'P' 'E' 'Z' 'Y')
   local index=1
 
   # if the base is not Bytes

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -972,7 +972,7 @@ function zle-keymap-select {
 powerlevel9k_init() {
   # Display a warning if the terminal does not support 256 colors
   local term_colors
-  term_colors=$(tput colors)
+  term_colors=$(echotc Co)
   if (( term_colors < 256 )); then
     print -P "%F{red}WARNING!%f Your terminal supports less than 256 colors!"
     print -P "You should put: %F{blue}export TERM=\"xterm-256color\"%f in your \~\/.zshrc"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -643,7 +643,11 @@ prompt_dir() {
 
   fi
 
-  "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$(print_icon 'HOME_ICON')$current_path"
+  if [[ "$POWERLEVEL9K_SHOW_HOME_ICON" == false ]]; then
+    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$current_path"
+  else
+    "$1_prompt_segment" "$0" "blue" "$DEFAULT_COLOR" "$(print_icon 'HOME_ICON')$current_path"
+  fi
 }
 
 # Command number (in local history)


### PR DESCRIPTION
Prior to this, the HOME_ICON was always visible when using an Awesome or
flat font. Some users might want to hide that icon to save a bit of
horizontal space. Also, as the HOME_ICON is visible even when not in a
home directory, it can be a bit misleading if a user were to think that
it meant they were currently in their home directory (essentially
duplicating the meaning of '~').

This commit adds a toggle called `POWERLEVEL9K_SHOW_HOME_ICON` that, when
`true`, will hide the icon from the `dir` prompt.