### PR TITLE
Create a toggle for the icon in the dir prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
 
+When using the Awesome or flat fonts, there is an icon of a house at the left
+edge of this segment. To hide this icon, set:
+
+    # Hide the home icon
+    POWERLEVEL9K_SHOW_HOME_ICON=false
+
 ##### ip
 
 This segment shows you your current internal IP address. It tries to examine

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -421,7 +421,6 @@ prompt_dir() {
 
   fi
 
-  local current_icon=''
   if [[ $POWERLEVEL9K_SHOW_HOME_ICON == false ]]; then
     "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path"
   elif [[ $(print -P "%~") == '~'* ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -422,7 +422,9 @@ prompt_dir() {
   fi
 
   local current_icon=''
-  if [[ $(print -P "%~") == '~'* ]]; then
+  if [[ $POWERLEVEL9K_SHOW_HOME_ICON == false ]]; then
+    "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path"
+  elif [[ $(print -P "%~") == '~'* ]]; then
     "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
   else
     "$1_prompt_segment" "$0_DEFAULT" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'


### PR DESCRIPTION
Prior to this, the HOME_ICON and FOLDER_ICON was always visible when using an Awesome or flat font. Some users might want to hide that icon to save a bit of horizontal space.

This commit adds a toggle called `POWERLEVEL9K_SHOW_HOME_ICON` that, when `true`, will hide the icon from the `dir` prompt.