### PR TITLE
added fish-like shortening strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,17 +207,16 @@ To change the way how the current working directory is truncated, just set:
 
 You can also change the delimiter (the dots in between) which is used to truncate the working directory. This setting is optional. The default are 2 dots.
 
-	# set the delimiter to an empty string to hide it
+    # set the delimiter to an empty string to hide it
     POWERLEVEL9K_SHORTEN_DELIMITER=""
     # or set it to anything else you want (e.g. 3 dots)
     POWERLEVEL9K_SHORTEN_DELIMITER="..."
 
 With this you could achive the truncate behaviour of the fish shell. Which turncates `/usr/share/plasma` to `/u/s/plasma`
 
-	POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
-	POWERLEVEL9K_SHORTEN_DELIMITER=""
-	POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
-
+    POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
+    POWERLEVEL9K_SHORTEN_DELIMITER=""
+    POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
 
 In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ To change the way how the current working directory is truncated, just set:
     POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
     # default behaviour is to truncate whole directories
 
+You can also change the delimiter (the dots in between) which is used to truncate the working directory. This setting is optional. The default are 2 dots.
+
+	# set the delimiter to an empty string to hide it
+    POWERLEVEL9K_SHORTEN_DELIMITER=""
+    # or set it to anything else you want (e.g. 3 dots)
+    POWERLEVEL9K_SHORTEN_DELIMITER="..."
+
+With this you could achive the truncate behaviour of the fish shell. Which turncates `/usr/share/plasma` to `/u/s/plasma`
+
+	POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
+	POWERLEVEL9K_SHORTEN_DELIMITER=""
+	POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
+
+
 In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -407,18 +407,23 @@ prompt_dir() {
   local current_path='%~'
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
 
+    if [ -z "$POWERLEVEL9K_SHORTEN_DELIMITER" ]
+    then
+      POWERLEVEL9K_SHORTEN_DELIMITER=".."
+    elif [ "$POWERLEVEL9K_SHORTEN_DELIMITER" = false ]
+    then
+      POWERLEVEL9K_SHORTEN_DELIMITER=""
+    fi
+
     case "$POWERLEVEL9K_SHORTEN_STRATEGY" in
       truncate_middle)
-        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})\//\1\.\.\2\//g")
+        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\2\//g")
       ;;
       truncate_from_right)
-        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1..\//g")
-      ;;
-      truncate_fish_like)
-        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1\//g")
+        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\//g")
       ;;
       *)
-        current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:.../:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
+        current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
       ;;
     esac
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -407,13 +407,7 @@ prompt_dir() {
   local current_path='%~'
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
 
-    if [ -z "$POWERLEVEL9K_SHORTEN_DELIMITER" ]
-    then
-      POWERLEVEL9K_SHORTEN_DELIMITER=".."
-    elif [ "$POWERLEVEL9K_SHORTEN_DELIMITER" = false ]
-    then
-      POWERLEVEL9K_SHORTEN_DELIMITER=""
-    fi
+    set_default POWERLEVEL9K_SHORTEN_DELIMITER ".."
 
     case "$POWERLEVEL9K_SHORTEN_STRATEGY" in
       truncate_middle)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -414,6 +414,9 @@ prompt_dir() {
       truncate_from_right)
         current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1..\//g")
       ;;
+      truncate_fish_like)
+        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1\//g")
+      ;;
       *)
         current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:.../:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
       ;;


### PR DESCRIPTION
In the FISH-Shell directories are shorten like this: `/u/s/plasma` for `/usr/share/plasma`

I added a new flag __truncate_fish_like__ to POWERLEVEL9K_SHORTEN_STRATEGY and basically removed the ".." from truncate_from_right.