### PR TITLE
Removed whitespace before git tag

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -52,7 +52,7 @@ function +vi-git-tagname() {
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
-    [[ -n "${tag}" ]] && hook_com[branch]=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_TAG_ICON')${tag}%f"
+    [[ -n "${tag}" ]] && hook_com[branch]="%F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_TAG_ICON')${tag}%f"
 }
 
 # Show count of stashed changes


### PR DESCRIPTION
I had it in `awesome-patched` mode as well, so I just removed the redundant whitespace.