### PR TITLE
Missed changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.3.0 (next)
+## v0.3.0
 
 ### Introduced "visual identifiers" to the segments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,31 @@ You can now merge segments together by suffixing the segment name with "_joined"
 For Developers: Be aware that the order of parameters in left/right_prompt_segment
 has changed. Now a boolean parameter must be set as second parameter (true if joined).
 
+### `dir` changes
+
+This segment now has "state", which means you now can change the colors seperatly
+depending if you are in your homefolder or not.
+Your variables for that should now look like:
+```zsh
+POWERLEVEL9K_DIR_HOME_BACKGROUND='green'
+POWERLEVEL9K_DIR_HOME_FOREGROUND='cyan'
+POWERLEVEL9K_DIR_DEFAULT_BACKGROUND='red'
+POWERLEVEL9K_DIR_DEFAULT_FOREGROUND='yellow'
+```
+
 ### `status` changes
 
 The `status` segment was split up into three segments. `background_jobs` prints
 an icon if there are background jobs. `root_indicator` prints an icon if the user
 is root. The `status` segment focuses now on the status only.
+The `status` segment also now has "state". If you want to overwrite the colors,
+you have to add the state to your variables:
+```zsh
+POWERLEVEL9K_STATUS_ERROR_BACKGROUND='green'
+POWERLEVEL9K_STATUS_ERROR_FOREGROUND='cyan'
+POWERLEVEL9K_STATUS_OK_BACKGROUND='red'
+POWERLEVEL9K_STATUS_OK_FOREGROUND='yellow'
+```
 
 ### New segment `custom_command` added
 


### PR DESCRIPTION
D'oh! I missed some changelog entries on some minor BC breaks.. With introducing state to segments, the variables for them changed.

@bhilburn This commit should also be on master.

Code changes from cd5b4d0debac05a74131f06efa918172586865ec and 5a4de1d2742e6e19a1ffb7ea8c418a923599391e

Additionally, I reworked the [Special Segment Colors](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#special-segment-colors) part in the wiki.