### PR TITLE
Split up `ram` segment into `ram` and `swap`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.4.0 (next)
+
+### `ram` changes
+
+The `ram` segment was split up into `ram` and `swap`. The `POWERLEVEL9K_RAM_ELEMENTS`
+variable is void.
+
 ## v0.3.1
 
 ### `dir` changes

--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ The segments that are currently available are:
 * **nvm** - Show the version of Node that is currently active, if it differs from the version used by NVM
 * **os_icon** - Display a nice little icon, depending on your operating system.
 * **php_version** - Show the current PHP version.
-* [ram](#ram) - Show free RAM and used Swap.
+* **ram** - Show free RAM
 * [rbenv](#rbenv) - Ruby environment information (if one is active).
 * **root_indicator** - An indicator if the user is root.
 * [rspec_stats](#rspec_stats) - Show a ratio of test classes vs code classes for RSpec.
 * **rust_version** - Display the current rust version.
 * [status](#status) - The return code of the previous command.
+* **swap** - Prints the current swap size.
 * [symphony2_tests](#symphony2_tests) - Show a ratio of test classes vs code classes for Symfony2.
 * **symphony2_version** - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * [time](#time) - System time.
@@ -252,12 +253,6 @@ This segment shows the return code of the last command.
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`POWERLEVEL9K_STATUS_VERBOSE`|`true`|Set to false if you wish to hide this segment when the last command completed successfully.|
-
-##### ram
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
-|`POWERLEVEL9K_RAM_ELEMENTS`|Both|Specify `ram_free` or `swap_used` to only show one or the other rather than both.|
 
 ##### symphony2_tests
 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -48,7 +48,7 @@ case $POWERLEVEL9K_MODE in
       FOLDER_ICON                    $'\UE818'              # 
       NETWORK_ICON                   $'\UE1AD'              # 
       LOAD_ICON                      $'\UE190 '             # 
-      #RAM_ICON                       $'\UE87D'             # 
+      SWAP_ICON                      $'\UE87D'              # 
       RAM_ICON                       $'\UE1E2 '             # 
       VCS_UNTRACKED_ICON             $'\UE16C'              # 
       VCS_UNSTAGED_ICON              $'\UE17C'              # 
@@ -101,6 +101,7 @@ case $POWERLEVEL9K_MODE in
       FOLDER_ICON                    $'\UF115'              # 
       NETWORK_ICON                   $'\UF09E'              # 
       LOAD_ICON                      $'\UF080 '             # 
+      SWAP_ICON                      $'\UF0E4'              # 
       RAM_ICON                       $'\UF0E4'              # 
       VCS_UNTRACKED_ICON             $'\UF059'              # 
       VCS_UNSTAGED_ICON              $'\UF06A'              # 
@@ -149,6 +150,7 @@ case $POWERLEVEL9K_MODE in
       FOLDER_ICON                    ''
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
+      SWAP_ICON                      'SWP'
       RAM_ICON                       'RAM'
       VCS_UNTRACKED_ICON             '?'
       VCS_UNSTAGED_ICON              $'\u25CF'              # ●


### PR DESCRIPTION
This is more flexible, and we save a variable.

If users wish to have this as one segment, the can join them together..