### PR TITLE
Improved symlink dereferencing on OSX by calling a perl script.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -51,7 +51,7 @@ fi
 # If this theme is sourced as a symlink, we need to locate the true URL
 if [[ -L $0 ]]; then
   # Script is a symlink
-  filename="$(realpath -P $0 2>/dev/null || readlink -f $0 2>/dev/null)"
+  filename="$(realpath -P $0 2>/dev/null || readlink -f $0 2>/dev/null || perl -MCwd=abs_path -le 'print abs_path readlink(shift);' $0 2>/dev/null)"
 elif [[ -f $0 ]]; then
   # Script is a file
   filename="$0"


### PR DESCRIPTION
This is a hotfix for the problem described in #182.
Instead of removing `readlink` and `realpath`, we try a third option (a perl script) to resolve the symlink.