### PR TITLE
Add sub folder icon when in home subdirectories

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -44,6 +44,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     $'\UE271'              # 
       SUNOS_ICON                     $'\U1F31E '            # 🌞
       HOME_ICON                      $'\UE12C'              # 
+      HOME_SUB_ICON                  $'\UE18D'              # 
       FOLDER_ICON                    $'\UE818'              # 
       NETWORK_ICON                   $'\UE1AD'              # 
       LOAD_ICON                      $'\UE190 '             # 
@@ -96,6 +97,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     $'\UF17C'              # 
       SUNOS_ICON                     $'\UF185 '             # 
       HOME_ICON                      $'\UF015'              # 
+      HOME_SUB_ICON                  $'\UF07C'              # 
       FOLDER_ICON                    $'\UF115'              # 
       NETWORK_ICON                   $'\UF09E'              # 
       LOAD_ICON                      $'\UF080 '             # 
@@ -143,6 +145,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
       HOME_ICON                      ''
+      HOME_SUB_ICON                  ''
       FOLDER_ICON                    ''
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
@@ -202,4 +205,3 @@ get_icon_names() {
     echo "POWERLEVEL9K_$key: ${icons[$key]}"
   done
 }
-

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -429,8 +429,10 @@ prompt_dir() {
   fi
 
   local current_icon=''
-  if [[ $(print -P "%~") == '~'* ]]; then
+  if [[ $(print -P "%~") == '~' ]]; then
     "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
+  elif [[ $(print -P "%~") == '~'* ]]; then
+    "$1_prompt_segment" "$0_HOME_SUBFOLDER" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_SUB_ICON'
   else
     "$1_prompt_segment" "$0_DEFAULT" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
   fi


### PR DESCRIPTION
Just wanted to help out but not 100% sure if this is the current way to fix this but I noticed when I was in a directory the home icon was still displayed instead of the folder icon but once this was removed it works correctly.

Thanks again for creating such a wonderful theme with lots of customisation. 