### PR TITLE
fixing segment call for new state implementation in prompt_load

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -519,7 +519,7 @@ prompt_load() {
     current_state="normal"
   fi
 
-  "$1_prompt_segment" "${0}${current_state}" "$2" "${load_states[$current_state]}" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
+  "$1_prompt_segment" "${0}_${current_state}" "$2" "${load_states[$current_state]}" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
 }
 
 # Node version


### PR DESCRIPTION
The changes to the new method of tracking state broke custom settings for the prompt_load segment. Without this fix it needs ```POWERLEVEL9K_LOAD_STATEBACKGROUND``` instead of ```POWERLEVEL9K_LOAD_STATE_BACKGROUND``` as with the previous version.