### PR TITLE
background_jobs segment : add number of jobs if >1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND='black'
 POWERLEVEL9K_DIR_HOME_SUBFOLDER_FOREGROUND='white'
 ```
 
+### `background_jobs` changes
+Now displays the number of background jobs if there's more than 1.
+You can disable it by setting :
+```zsh
+POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE=false
+```
+
 ## v0.3.0
 
 ### Introduced "visual identifiers" to the segments

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -290,9 +290,15 @@ prompt_aws() {
 }
 
 # Segment to indicate background jobs with an icon.
+set_default POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE true
 prompt_background_jobs() {
-  if [[ $(jobs -l | wc -l) -gt 0 ]]; then
-    "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR" "cyan" "" 'BACKGROUND_JOBS_ICON'
+  local background_jobs_number=$(jobs -l | wc -l)
+  if [[ background_jobs_number -gt 0 ]]; then
+    local background_jobs_number_print=""
+    if [[ POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE ]] && [[ background_jobs_number -gt 1 ]]; then
+      background_jobs_number_print="$background_jobs_number"
+    fi
+    "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR" "cyan" "$background_jobs_number_print" 'BACKGROUND_JOBS_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -292,7 +292,7 @@ prompt_aws() {
 # Segment to indicate background jobs with an icon.
 set_default POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE true
 prompt_background_jobs() {
-  local background_jobs_number=$(jobs -l | wc -l)
+  local background_jobs_number=${$(jobs -l | wc -l)// /}
   if [[ background_jobs_number -gt 0 ]]; then
     local background_jobs_number_print=""
     if [[ POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE ]] && [[ background_jobs_number -gt 1 ]]; then


### PR DESCRIPTION
I think it should be the default behavior, but I've added `POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE` var to disable it :)