### PR TITLE
add "yellow" state to prompt for git repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.3.2
+
+### `vcs` changes
+
+A new state `UNTRACKED` was added to the `vcs` segment. So we now
+have 3 states for repositories: `UNTRACKED`, `MODIFIED`, and the
+default state. The `UNTRACKED` state is active when there are files
+in the repository directory which have not been added to the repo
+(the same as when the `+` icon appears). The default color for the
+`UNTRACKED` state is now yellow, and the default color for the
+`MODIFIED` state is now read, but those colors can be changed by
+setting these variables, for example:
+```zsh
+POWERLEVEL9K_VCS_MODIFIED_FOREGROUND='black'
+POWERLEVEL9K_VCS_MODIFIED_BACKGROUND='white'
+POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND='green'
+POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND='blue'
+```
+
 ## v0.3.1
 
 ### `dir` changes

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -10,6 +10,9 @@ function +vi-git-untracked() {
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
             -n $(git ls-files --others --exclude-standard | sed q) ]]; then
         hook_com[unstaged]+=" %F{$POWERLEVEL9K_VCS_FOREGROUND}$(print_icon 'VCS_UNTRACKED_ICON')%f"
+        VCS_WORKDIR_HALF_DIRTY=true
+    else
+        VCS_WORKDIR_HALF_DIRTY=false
     fi
 }
 
@@ -90,4 +93,3 @@ function +vi-vcs-detect-changes() {
     VCS_WORKDIR_DIRTY=false
   fi
 }
-

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -730,6 +730,8 @@ prompt_vcs() {
   autoload -Uz vcs_info
 
   VCS_WORKDIR_DIRTY=false
+  VCS_WORKDIR_HALF_DIRTY=false
+
   VCS_CHANGESET_PREFIX=''
   if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
     # Default: Just display the first 12 characters of our changeset-ID.
@@ -774,9 +776,13 @@ prompt_vcs() {
     if [[ "$VCS_WORKDIR_DIRTY" == true ]]; then
       # $vcs_visual_identifier gets set in +vi-vcs-detect-changes in functions/vcs.zsh,
       # as we have there access to vcs_info internal hooks.
-      "$1_prompt_segment" "$0_MODIFIED" "$2" "yellow" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
+      "$1_prompt_segment" "$0_MODIFIED" "$2" "red" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
     else
-      "$1_prompt_segment" "$0" "$2" "green" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
+      if [[ "$VCS_WORKDIR_HALF_DIRTY" == true ]]; then
+        "$1_prompt_segment" "$0_UNTRACKED" "$2" "yellow" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
+      else
+        "$1_prompt_segment" "$0" "$2" "green" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
It is nice to be able to colorize the VCS section of my prompt to be yellow when there are untracked files in the repository directory that haven't been added yet. So the section of the prompt is green when everything is up to date, yellow if there are untracked files, and red when it is truely "dirty" - when there are changes that haven't been committed. Feel free to modify and/or integrate! Thanks