### PR TITLE
Add Unit tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shunit2"]
+	path = shunit2
+	url = git@github.com:kward/shunit2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shunit2"]
 	path = shunit2
-	url = git@github.com:kward/shunit2.git
+	url = https://github.com/kward/shunit2.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ script:
   - test/powerlevel9k.spec
   - test/functions/utilities.spec
   - test/functions/colors.spec
+  - test/segments/dir.spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: true
+dist: trusty
 language: sh
 addons:
   apt:
@@ -12,7 +13,6 @@ before_script:
   - "zsh --version"
 
 install:
-  - "sudo apt-add-repository -y ppa:brainpower/testing"
   - "sudo apt-get update -qq"
   - "sudo apt-get install zsh"
   - "sudo chsh -s $(which zsh)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - test/functions/colors.spec
   - test/segments/dir.spec
   - test/segments/rust_version.spec
+  - test/segments/go_version.spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ install:
 
 script:
   - test/powerlevel9k.spec
+  - test/functions/utilities.spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+sudo: false
+
+php:
+    - '7.0'
+
+script:
+    - test/powerlevel9k.spec
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
-language: php
-sudo: false
+sudo: true
+language: sh
+addons:
+  apt:
+    packages:
+      - build-essential
 
-php:
-    - '7.0'
+before_script:
+  # Show the git version being used to test.
+  - "git --version"
+  # Show the zsh version being used to test.
+  - "zsh --version"
+
+install:
+  - "sudo apt-add-repository -y ppa:brainpower/testing"
+  - "sudo apt-get update -qq"
+  - "sudo apt-get install zsh"
+  - "sudo chsh -s $(which zsh)"
 
 script:
-    - test/powerlevel9k.spec
+  - test/powerlevel9k.spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ script:
   - test/functions/utilities.spec
   - test/functions/colors.spec
   - test/segments/dir.spec
+  - test/segments/rust_version.spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ install:
 script:
   - test/powerlevel9k.spec
   - test/functions/utilities.spec
+  - test/functions/colors.spec
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,14 @@
+# Structure
+
+The Unit-Tests do not follow exactly the file structure of Powerlevel9k itself.
+
+## Basic Tests
+
+Basic Tests belong in `test/powerlevel9k.spec` if they test basic functionality of
+Powerlevel9k itself. Basic functions from the `functions` directory have their
+Tests in separate files under `test/functions`.
+
+## Segment Tests
+
+These Tests tend to be more complex in setup than the basic tests. To avoid ending
+up in a huge single file, there is one file per segment in `test/segments`.

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -27,6 +27,9 @@ function set_default() {
 }
 
 # Converts large memory values into a human-readable unit (e.g., bytes --> GB)
+# Takes two arguments:
+#   * $size - The number which should be prettified
+#   * $base - The base of the number (default Bytes)
 printSizeHumanReadable() {
   typeset -F 2 size
   size="$1"+0.00001

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -471,7 +471,7 @@ prompt_dir() {
 # GO prompt
 prompt_go_version() {
   local go_version
-  go_version=$(go version 2>&1 | sed -E "s/.*(go[0-9.]*).*/\1/")
+  go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
 
   if [[ -n "$go_version" ]]; then
     "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version"

--- a/test/functions/colors.spec
+++ b/test/functions/colors.spec
@@ -1,0 +1,42 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function oneTimeSetUp() {
+  # Load Powerlevel9k
+  source functions/colors.zsh
+}
+
+function testGetColorCodeWithAnsiForegroundColor() {
+  assertEquals '002' "$(getColorCode 'green')"
+}
+
+function testGetColorCodeWithAnsiBackgroundColor() {
+  assertEquals '002' "$(getColorCode 'bg-green')"
+}
+
+function testGetColorCodeWithNumericalColor() {
+  assertEquals '002' "$(getColorCode '002')"
+}
+
+function testIsSameColorComparesAnsiForegroundAndNumericalColorCorrectly() {
+  assertTrue "isSameColor 'green' '002'"
+}
+
+function testIsSameColorComparesAnsiBackgroundAndNumericalColorCorrectly() {
+  assertTrue "isSameColor 'bg-green' '002'"
+}
+
+function testIsSameColorComparesNumericalBackgroundAndNumericalColorCorrectly() {
+  assertTrue "isSameColor '010' '2'"
+}
+
+function testIsSameColorDoesNotYieldNotEqualColorsTruthy() {
+  assertFalse "isSameColor 'green' '003'"
+}
+
+
+source shunit2/source/2.1/src/shunit2

--- a/test/functions/colors.spec
+++ b/test/functions/colors.spec
@@ -5,7 +5,7 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
-function oneTimeSetUp() {
+function setUp() {
   # Load Powerlevel9k
   source functions/colors.zsh
 }

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -1,0 +1,22 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function oneTimeSetUp() {
+  # Load Powerlevel9k
+  source functions/utilities.zsh
+}
+
+function testPrintSizeHumanReadableWithBigNumber() {
+  # Interesting: Currently we can't support numbers bigger than that.
+  assertEquals '0.87E' "$(printSizeHumanReadable 1000000000000000000)"
+}
+
+function testPrintSizeHumanReadableWithExabytesAsBase() {
+  assertEquals '9.77Z' "$(printSizeHumanReadable 10000 'E')"
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -5,8 +5,9 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
-function oneTimeSetUp() {
+function setUp() {
   # Load Powerlevel9k
+  source functions/icons.zsh
   source functions/utilities.zsh
 }
 

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -10,6 +10,24 @@ function oneTimeSetUp() {
   source functions/utilities.zsh
 }
 
+function testDefinedFindsDefinedVariable() {
+  my_var='X'
+
+  assertTrue "defined 'my_var'"
+  unset my_var
+}
+
+function testDefinedDoesNotFindUndefinedVariable() {
+  assertFalse "defined 'my_var'"
+}
+
+function testSetDefaultSetsVariable() {
+  set_default 'my_var' 'x'
+
+  assertEquals 'x' "$my_var"
+  unset my_var
+}
+
 function testPrintSizeHumanReadableWithBigNumber() {
   # Interesting: Currently we can't support numbers bigger than that.
   assertEquals '0.87E' "$(printSizeHumanReadable 1000000000000000000)"
@@ -17,6 +35,74 @@ function testPrintSizeHumanReadableWithBigNumber() {
 
 function testPrintSizeHumanReadableWithExabytesAsBase() {
   assertEquals '9.77Z' "$(printSizeHumanReadable 10000 'E')"
+}
+
+function testGetRelevantItem() {
+  typeset -a list
+  list=(a b c)
+  local callback='[[ "$item" == "b" ]] && echo "found"'
+
+  local result=$(getRelevantItem "$list" "$callback")
+  assertEquals 'found' "$result"
+
+  unset list
+}
+
+function testGetRelevantItemDoesNotReturnNotFoundItems() {
+  typeset -a list
+  list=(a b c)
+  local callback='[[ "$item" == "d" ]] && echo "found"'
+
+  local result=$(getRelevantItem "$list" "$callback")
+  assertEquals '' ''
+
+  unset list
+}
+
+function testSegmentShouldBeJoinedIfDirectPredecessingSegmentIsJoined() {
+  typeset -a segments
+  segments=(a b_joined c_joined)
+  # Look at the third segment
+  local current_index=3
+  local last_element_index=2
+
+  local joined
+  segmentShouldBeJoined $current_index $last_element_index "$segments" && joined=true || joined=false
+  assertTrue "$joined"
+
+  unset segments
+}
+
+function testSegmentShouldBeJoinedIfPredecessingSegmentIsJoinedTransitivley() {
+  typeset -a segments
+  segments=(a b_joined c_joined)
+  # Look at the third segment
+  local current_index=3
+  # The last printed segment was the first one,
+  # the second segmend was conditional.
+  local last_element_index=1
+
+  local joined
+  segmentShouldBeJoined $current_index $last_element_index "$segments" && joined=true || joined=false
+  assertTrue "$joined"
+
+  unset segments
+}
+
+function testSegmentShouldNotBeJoinedIfPredecessingSegmentIsNotJoinedButConditional() {
+  typeset -a segments
+  segments=(a b_joined c d_joined)
+  # Look at the fourth segment
+  local current_index=4
+  # The last printed segment was the first one,
+  # the second segmend was conditional.
+  local last_element_index=1
+
+  local joined
+  segmentShouldBeJoined $current_index $last_element_index "$segments" && joined=true || joined=false
+  assertFalse "$joined"
+
+  unset segments
 }
 
 source shunit2/source/2.1/src/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function oneTimeSetUp() {
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+  source functions/*
+}
+
+function testJoinedSegments() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
+
+  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black}%F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testTransitiveJoinedSegments() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
+
+  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black}%F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testJoiningWithConditionalSegment() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
+
+  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black} %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testDynamicColoringOfSegmentsWork() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND='red'
+
+  assertEquals "%K{red} %F{black}%~ %k%F{red}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -6,6 +6,7 @@ setopt shwordsplit
 SHUNIT_PARENT=$0
 
 function setUp() {
+  export TERM="xterm-256color"
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source functions/*

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -81,4 +81,14 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
   unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
 }
 
+function testOverwritingIconsWork() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_HOME_SUB_ICON='icon-here'
+
+  assertEquals "%K{blue} %F{black%}icon-here%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_DIR_HOME_SUB_ICON
+}
+
 source shunit2/source/2.1/src/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -5,7 +5,7 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
-function oneTimeSetUp() {
+function setUp() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source functions/*

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -45,4 +45,40 @@ function testDynamicColoringOfSegmentsWork() {
   unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
 }
 
+function testDynamicColoringOfVisualIdentifiersWork() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_MODE='awesome-patched'
+  POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR='green'
+
+  # Re-Source the icons, as the POWERLEVEL9K_MODE is directly
+  # evaluated there.
+  source functions/icons.zsh
+
+  assertEquals "%K{blue} %F{green%}%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_MODE
+  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR
+}
+
+function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_MODE='awesome-patched'
+  POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR='green'
+  POWERLEVEL9K_DIR_HOME_SUBFOLDER_FOREGROUND='red'
+  POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND='yellow'
+
+  # Re-Source the icons, as the POWERLEVEL9K_MODE is directly
+  # evaluated there.
+  source functions/icons.zsh
+
+  assertEquals "%K{yellow} %F{green%}%f %F{red}%~ %k%F{yellow}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_MODE
+  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR
+  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_FOREGROUND
+  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
+}
+
 source shunit2/source/2.1/src/shunit2

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -1,0 +1,118 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function testTruncateFoldersWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_folders'
+
+  FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{blue} %F{black}%3(c:…/:)%2c %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset FOLDER
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
+function testTruncateMiddleWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_middle'
+
+  FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{blue} %F{black}/tmp/po…st/1/12/123/1234/12…45/12…56/12…67/12…78/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset FOLDER
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
+function testTruncationFromRightWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_from_right'
+
+  FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{blue} %F{black}/tm…/po…/1/12/12…/12…/12…/12…/12…/12…/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset FOLDER
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
+function testHomeFolderDetectionWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_HOME_ICON='home-icon'
+
+  cd ~
+  assertEquals "%K{blue} %F{black%}home-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_HOME_ICON
+}
+
+function testHomeSubfolderDetectionWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_HOME_SUB_ICON='sub-icon'
+
+  FOLDER=~/powerlevel9k-test
+  mkdir $FOLDER
+  cd $FOLDER
+  assertEquals "%K{blue} %F{black%}sub-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr $FOLDER
+  unset FOLDER
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_HOME_SUB_ICON
+}
+
+function testOtherFolderDetectionWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  POWERLEVEL9K_FOLDER_ICON='folder-icon'
+
+  FOLDER=/tmp/powerlevel9k-test
+  mkdir $FOLDER
+  cd $FOLDER
+  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr $FOLDER
+  unset FOLDER
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_FOLDER_ICON
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function mockGo() {
+  echo 'go version go1.5.3 darwin/amd64'
+}
+
+function testGo() {
+  alias go=mockGo
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(go_version)
+
+  assertEquals "%K{green} %F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unalias go
+}
+
+function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
+  alias go=noGo
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias go
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function mockRust() {
+  echo 'rustc  0.4.1a-alpha'
+}
+
+function testRust() {
+  alias rustc=mockRust
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
+
+  assertEquals "%K{208} %F{black}Rust 0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unalias rustc
+}
+
+function testRustPrintsNothingIfRustIsNotAvailable() {
+  alias rustc=noRust
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias rustc
+}
+
+source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
This PR adds unit testing to this project. For now, it tests just "joining of segments" and "dynamic coloring of segments", as this is just a proof-of-concept. I we decide this PR is a good idea, then I'll add more tests..

### Why?
This theme is very flexible. As a result every change needs a lot of testing. At least I tend to forget certain tests, so the theme gets error prone.

### Hey! [The Build](https://travis-ci.org/dritter/powerlevel9k) fails!
Yep. Intentionally. :smile:
I branched off of 9e191d43058d66fd52d1c33a244523600848bd25 (right before e9da3d5146d5cf881249fa229e27b60428516aab), where joining of Segments is broken, so `testJoinedSegments` and `testTransitiveJoinedSegments` fail.

### How?
This PR adds [shunit2](https://github.com/kward/shunit2) as a git submodule and execute the unittests in `test/powerlevel9k.spec` with [Travis-CI](https://travis-ci.org). Btw. `shunit2` must not be a git submodule, we could install it directly on travis..
To execute the tests locally, just run `./test/powerlevel9k.spec`. The test have a hardcoded path to `shunit2´ and powerlevel9k, so they need to be executed from the root folder of the project.

### Benefits
Well, once enabled every PR gets tested, so every developer gets nice feedback. And we can add a nice badge to the README, so every user can easily see the build status of the project.

@bhilburn You have to enable this project for [Travis-ci](https://travis-ci.org/profile/bhilburn).