### PR TITLE
Improve the rbenv prompt by using `version-name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ specify the correct network interface by setting:
 |----------|---------------|-------------|
 |`POWERLEVEL9K_IP_INTERFACE`|None|The NIC for which you wish to display the IP address. Example: `eth0`.|
 
+##### rbenv
+
+This segment shows the version of Ruby being used when using `rbenv` to change your current Ruby stack.
+
+It figures out the version being used by taking the output of the `rbenv version-name` command.
+
+* If `rbenv` is not in $PATH, nothing will be shown.
+* If the current Ruby version is the same as the global Ruby version, nothing will be shown.
+
 ##### rspec_stats
 
 See [Unit Test Ratios](#unit-test-ratios), below.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -605,8 +605,16 @@ prompt_ram() {
 
 # rbenv information
 prompt_rbenv() {
-  if [[ -n "$RBENV_VERSION" ]]; then
-    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$RBENV_VERSION" 'RUBY_ICON'
+  if which rbenv 2>/dev/null >&2; then
+    local rbenv_version_name="$(rbenv version-name)"
+    local rbenv_global="$(rbenv global)"
+
+    # Don't show anything if the current Ruby is the same as the global Ruby.
+    if [[ $rbenv_version_name == $rbenv_global ]]; then
+      return
+    fi
+
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
   fi
 }
 


### PR DESCRIPTION
Prior to this, the rbenv prompt only showed something if the
`$RBENV_VERSION` environment variable was set. This was not a complete
solution because rbenv can be configured locally, per directory, with
dotfiles. When using dotfiles, the `$RBENV_VERSION` variable is not set.

This fixes the issue by taking the output of the `rbenv version-name`
command which shows the real rbenv version being used based on any of
the 4 ways to change rbenv as shown here:

https://github.com/rbenv/rbenv#choosing-the-ruby-version

This commit also adds documentation to the README that describes the prompt.

Fixes issue #215 

Thanks to @MatthewMDavis for the original version of the patch: https://github.com/MatthewMDavis/powerlevel9k/commit/96a8408a0c27ed6dc10dfa8829a549419ab5d4ec