### PR TITLE
Rename vcs default state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ script:
   - test/segments/dir.spec
   - test/segments/rust_version.spec
   - test/segments/go_version.spec
+  - test/segments/vcs.spec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## v0.4.0 (next)
 
+### `vcs` changes
+
+The default state was renamed to `clean`. If you overrode foreground
+or background color in the past, you need to rename your variables to:
+
+```zsh
+POWERLEVEL9K_VCS_CLEAN_FOREGROUND='cyan'
+POWERLEVEL9K_VCS_CLEAN_BACKGROUND='white'
+```
+
 ### `aws_eb_env` added
 
 This segment displays the current Elastic Beanstalk environment.

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -17,7 +17,7 @@ function +vi-git-untracked() {
     fi
 
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
-            -n $(git status ${FLAGS} | grep -E '^??' 2> /dev/null | tail -n1) ]]; then
+            -n $(git status ${FLAGS} | grep -E '^\?\?' 2> /dev/null | tail -n1) ]]; then
         hook_com[unstaged]+=" $(print_icon 'VCS_UNTRACKED_ICON')"
         VCS_WORKDIR_HALF_DIRTY=true
     else

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -755,11 +755,11 @@ prompt_vcs() {
   VCS_WORKDIR_DIRTY=false
   VCS_WORKDIR_HALF_DIRTY=false
 
-  # The vcs segment can have three different states - defaults to ''.
+  # The vcs segment can have three different states - defaults to 'clean'.
   local current_state=""
   typeset -AH vcs_states
   vcs_states=(
-    ''              'green'
+    'clean'         'green'
     'modified'      'red'
     'untracked'     'yellow'
   )
@@ -815,7 +815,7 @@ prompt_vcs() {
       if [[ "$VCS_WORKDIR_HALF_DIRTY" == true ]]; then
         current_state='untracked'
       else
-        current_state=''
+        current_state='clean'
       fi
     fi
     "$1_prompt_segment" "${0}_${(U)current_state}" "$2" "${vcs_states[$current_state]}" "$DEFAULT_COLOR" "$vcs_prompt" "$vcs_visual_identifier"

--- a/test/segments/vcs.spec
+++ b/test/segments/vcs.spec
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function testColorOverridingForCleanStateWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_CLEAN_FOREGROUND='cyan'
+  POWERLEVEL9K_VCS_CLEAN_BACKGROUND='white'
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+
+  assertEquals "%K{white} %F{cyan} master %k%F{white}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_CLEAN_FOREGROUND
+  unset POWERLEVEL9K_VCS_CLEAN_BACKGROUND
+}
+
+function testColorOverridingForModifiedStateWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_MODIFIED_FOREGROUND='red'
+  POWERLEVEL9K_VCS_MODIFIED_BACKGROUND='yellow'
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+  git add testfile
+
+  assertEquals "%K{yellow} %F{red} master ✚ %k%F{yellow}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_MODIFIED_FOREGROUND
+  unset POWERLEVEL9K_VCS_MODIFIED_BACKGROUND
+}
+
+function testColorOverridingForUntrackedStateWorks() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND='cyan'
+  POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND='yellow'
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{yellow} %F{cyan} master ? %k%F{yellow}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND
+  unset POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND
+}
+
+source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
The default state is now `clean`.

Bonus:
The regular expression for the untracked state did not work correctly on OSX. This is now fixed.