### PR TITLE
Add chruby prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ The segments that are currently available are:
 * **os_icon** - Display a nice little icon, depending on your operating system.
 * **php_version** - Show the current PHP version.
 * **ram** - Show free RAM
-* [rbenv](#rbenv) - Ruby environment information (if one is active).
+* [rbenv](#rbenv) - Ruby environment information using `rbenv` (if one is active).
+* [chruby](#chruby) - Ruby environment information using `chruby` (if one is active; also, see postmodern/chruby#245 for issue with auto switching of ruby).
 * **root_indicator** - An indicator if the user is root.
 * [rspec_stats](#rspec_stats) - Show a ratio of test classes vs code classes for RSpec.
 * **rust_version** - Display the current rust version.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -622,6 +622,17 @@ prompt_rbenv() {
   fi
 }
 
+# chruby information
+# see https://github.com/postmodern/chruby/issues/245 for chruby_auto issue with ZSH
+prompt_chruby() {
+  local chruby_env
+  chrb_env="$(chruby 2> /dev/null | grep \* | tr -d '* ')"
+  # Don't show anything if the chruby did not change the default ruby
+  if [[ "${chrb_env:-system}" != "system" ]]; then
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "${chrb_env}" 'RUBY_ICON'
+  fi
+}
+
 # Print an icon if user is root.
 prompt_root_indicator() {
   if [[ "$UID" -eq 0 ]]; then


### PR DESCRIPTION
New PR based off `origin:next` instead of `origin:master` see #227 

Add new `chruby` prompt to show ruby version using `chruby`.
Update the README accordingly.

See postmodern/chruby#245 for issue with auto switching ruby version using `.ruby_version` file.
Partially closes #119 , replacement for #227.