### PR TITLE
Add shortening strategy based on package.json name

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Customizations available are:
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`POWERLEVEL9K_SHORTEN_DIR_LENGTH`|`2`|If your shorten strategy, below, is entire directories, this field determines how many directories to leave at the end. If your shorten strategy is by character count, this field determines how many characters to allow per directory string.|
-|`POWERLEVEL9K_SHORTEN_STRATEGY`|None|How the directory strings should be truncated. By default, it will truncate whole directories. Other options are `truncate_middle`, which leaves the start and end of the directory strings, and `truncate_from_right`, which cuts starting from the end of the string.|
+|`POWERLEVEL9K_SHORTEN_STRATEGY`|None|How the directory strings should be truncated. By default, it will truncate whole directories. Other options are `truncate_middle`, which leaves the start and end of the directory strings, and `truncate_from_right`, which cuts starting from the end of the string.  You can also use `truncate_with_package_name` to use the `package.json` `name` field to abbreviate the directory path.|
 |`POWERLEVEL9K_SHORTEN_DELIMITER`|`..`|Delimiter to use in truncated strings. This can be any string you choose, including an empty string if you wish to have no delimiter.|
 
 For example, if you wanted the truncation behavior of the `fish` shell, which
@@ -256,6 +256,15 @@ In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
 
+The `truncate_with_package_name` strategy gives your directory path relative to the root of your project.  For example, if you have a project inside `$HOME/projects/my-project` with a `package.json` that looks like:
+
+```json
+{
+  "name": "my-cool-project"
+}
+```
+
+the path shown would be `my-cool-project`.  If you navigate to `$HOME/projects/my-project/src`, then the path shown would be `my-cool-project/src`.  Please note that this currently looks for `.git` directory to determine the root of the project.
 
 ##### ip
 

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -186,3 +186,9 @@ function segmentShouldBeJoined() {
     return 1
   fi
 }
+
+# Given a directory path, truncate it according to the settings for
+# `truncate_from_right`
+function truncatePathFromRight() {
+  echo $1 | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\//g"
+}

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -446,6 +446,42 @@ prompt_dir() {
       truncate_from_right)
         current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\//g")
       ;;
+      truncate_with_package_name)
+        local name repo_path package_path current_dir zero
+
+        # Get the path of the Git repo, which should have the package.json file
+        if repo_path=$(git rev-parse --git-dir 2>/dev/null); then
+          if [[ "$repo_path" == ".git" ]]; then
+            # If the current path is the root of the project, then the package path is
+            # the current directory and we don't want to append anything to represent
+            # the path to a subdirectory
+            package_path="."
+            subdirectory_path=""
+          else
+            # If the current path is something else, get the path to the package.json
+            # file by finding the repo path and removing the '.git` from the path
+            package_path=${repo_path:0:-4}
+            zero='%([BSUbfksu]|([FB]|){*})'
+            current_dir=$(pwd)
+            # Then, find the length of the package_path string, and save the
+            # subdirectory path as a substring of the current directory's path from 0
+            # to the length of the package path's string
+            subdirectory_path="/${current_dir:${#${(S%%)package_path//$~zero/}}}"
+          fi
+        fi
+
+        # Parse the 'name' from the package.json; if there are any problems, just
+        # print the file path
+        if name=$( cat "$package_path/package.json" 2> /dev/null | grep "\"name\""); then
+          name=$(echo $name | awk -F ':' '{print $2}' | awk -F '"' '{print $2}')
+
+          # Instead of printing out the full path, print out the name of the package
+          # from the package.json and append the current subdirectory
+          current_path="`echo $name | tr -d '"'`$subdirectory_path"
+        else
+          current_path='%~'
+        fi
+      ;;
       *)
         current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
       ;;
@@ -572,7 +608,7 @@ prompt_nodeenv() {
   local nodeenv_path="$NODE_VIRTUAL_ENV"
   if [[ -n "$nodeenv_path" && "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
     local info="$(node -v)[$(basename "$nodeenv_path")]"
-    "$1_prompt_segment" "$0" "$2" "black" "green" "$info" 'NODE_ICON' 
+    "$1_prompt_segment" "$0" "$2" "black" "green" "$info" 'NODE_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -444,7 +444,7 @@ prompt_dir() {
         current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\2\//g")
       ;;
       truncate_from_right)
-        current_path=$(pwd | sed -e "s,^$HOME,~," | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\//g")
+        current_path=$(truncatePathFromRight $(pwd | sed -e "s,^$HOME,~,") )
       ;;
       truncate_with_package_name)
         local name repo_path package_path current_dir zero
@@ -466,7 +466,7 @@ prompt_dir() {
             # Then, find the length of the package_path string, and save the
             # subdirectory path as a substring of the current directory's path from 0
             # to the length of the package path's string
-            subdirectory_path="/${current_dir:${#${(S%%)package_path//$~zero/}}}"
+            subdirectory_path=$(truncatePathFromRight "/${current_dir:${#${(S%%)package_path//$~zero/}}}")
           fi
         fi
 
@@ -479,7 +479,7 @@ prompt_dir() {
           # from the package.json and append the current subdirectory
           current_path="`echo $name | tr -d '"'`$subdirectory_path"
         else
-          current_path='%~'
+          current_path=$(truncatePathFromRight $(pwd | sed -e "s,^$HOME,~,") )
         fi
       ;;
       *)


### PR DESCRIPTION
Finally got around to re-implementing #140 without using the `jq` tool, and against the current `next` branch so it can be pulled in easily.

I'm happy to pull the comments out if you'd prefer; I just left them in now because they were in my original implementation.