### PR TITLE
Add a new segment for current active docker machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The segments that are currently available are:
 * **AWS Segments:**
     * [`aws`](#aws) - The current AWS profile, if active.
     * `aws_eb_env` - The current Elastic Beanstalk Environment.
-* `docker_machine` - The current Docker Machine
+* `docker_machine` - The current Docker Machine.
 
 **Other:**
 * [`custom_command`](#custom_command) - Create a custom segment to display the

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The segments that are currently available are:
 * **AWS Segments:**
     * [`aws`](#aws) - The current AWS profile, if active.
     * `aws_eb_env` - The current Elastic Beanstalk Environment.
+* `docker_machine` - The current Docker Machine
 
 **Other:**
 * [`custom_command`](#custom_command) - Create a custom segment to display the

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -51,6 +51,7 @@ case $POWERLEVEL9K_MODE in
       LOAD_ICON                      $'\UE190 '             # 
       SWAP_ICON                      $'\UE87D'              # 
       RAM_ICON                       $'\UE1E2 '             # 
+      SERVER_ICON                    $'\UE895'              # 
       VCS_UNTRACKED_ICON             $'\UE16C'              # 
       VCS_UNSTAGED_ICON              $'\UE17C'              # 
       VCS_STAGED_ICON                $'\UE168'              # 
@@ -105,6 +106,7 @@ case $POWERLEVEL9K_MODE in
       LOAD_ICON                      $'\UF080 '             # 
       SWAP_ICON                      $'\UF0E4'              # 
       RAM_ICON                       $'\UF0E4'              # 
+      SERVER_ICON                    $'\UF296'              # 
       VCS_UNTRACKED_ICON             $'\UF059'              # 
       VCS_UNSTAGED_ICON              $'\UF06A'              # 
       VCS_STAGED_ICON                $'\UF055'              # 
@@ -155,6 +157,7 @@ case $POWERLEVEL9K_MODE in
       LOAD_ICON                      'L'
       SWAP_ICON                      'SWP'
       RAM_ICON                       'RAM'
+      SERVER_ICON                    ''
       VCS_UNTRACKED_ICON             '?'
       VCS_UNSTAGED_ICON              $'\u25CF'              # ●
       VCS_STAGED_ICON                $'\u271A'              # ✚

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -463,6 +463,15 @@ prompt_dir() {
   fi
 }
 
+# Docker machine
+prompt_docker_machine() {
+  local docker_machine="$DOCKER_MACHINE_NAME"
+
+  if [[ -n "$docker_machine" ]]; then
+    "$1_prompt_segment" "$0" "$2" "magenta" "$DEFAULT_COLOR" "$docker_machine" 'SERVER_ICON'
+  fi
+}
+
 # GO prompt
 prompt_go_version() {
   local go_version
@@ -572,7 +581,7 @@ prompt_nodeenv() {
   local nodeenv_path="$NODE_VIRTUAL_ENV"
   if [[ -n "$nodeenv_path" && "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
     local info="$(node -v)[$(basename "$nodeenv_path")]"
-    "$1_prompt_segment" "$0" "$2" "black" "green" "$info" 'NODE_ICON' 
+    "$1_prompt_segment" "$0" "$2" "black" "green" "$info" 'NODE_ICON'
   fi
 }
 


### PR DESCRIPTION
I don't know if you are interested in adding new simple segments? (especially since we can add new custom segments easily).
But in case, this PR add a new segment for display the current active Docker Machine.