### PR TITLE
Fix NVM prompt to return if not used

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -560,6 +560,7 @@ prompt_node_version() {
 prompt_nvm() {
   [[ ! $(type nvm) =~ 'nvm is a shell function'* ]] && return
   local node_version=$(nvm current)
+  [[ ${node_version} = "none" ]] && return
   local nvm_default=$(cat $NVM_DIR/alias/default)
   [[ -z "${node_version}" ]] && return
   [[ "$node_version" =~ "$nvm_default" ]] && return

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -560,9 +560,8 @@ prompt_node_version() {
 prompt_nvm() {
   [[ ! $(type nvm) =~ 'nvm is a shell function'* ]] && return
   local node_version=$(nvm current)
-  [[ ${node_version} = "none" ]] && return
+  [[ -z "${node_version}" ]] || [[ ${node_version} = "none" ]] && return
   local nvm_default=$(cat $NVM_DIR/alias/default)
-  [[ -z "${node_version}" ]] && return
   [[ "$node_version" =~ "$nvm_default" ]] && return
 
   $1_prompt_segment "$0" "$2" "green" "011" "${node_version:1}" 'NODE_ICON'


### PR DESCRIPTION
This commit changes nvm prompt setup to return immediately if no node
version is installed/available.
Currently, prompt shows incorrect global node version _one_
Specifically, if you install nvm (from brew or manually) and do not have
global node installed (or set), then the prompt shows `${node_version:1}`
which evaluates to the string `one`. This is incorrect, and nvm should not
show anything. This commit ensures this by immediately returning if
`nvm current` returns "none".