### PR TITLE
Git tag not replacing branch

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -67,8 +67,12 @@ function +vi-git-tagname() {
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
-    # Append the tag segment to the branch one
-    [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+    head=$(git describe --all)
+    # Make sure that detached head and tag differ in name
+    if [[ "${head}" != "${tag}" ]]; then
+      # Append the tag segment to the branch one
+      [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+    fi
   fi
 }
 

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -62,16 +62,20 @@ function +vi-git-remotebranch() {
 
 function +vi-git-tagname() {
   # Only show the tag name if we are not in DETACHED_HEAD state,
-  # since in that case it would already be displayed in the branch segment
-  if [[ -z "$(git symbolic-ref HEAD 2>/dev/null)" ]] ; then
-    local tag
+  # or if the current branch's HEAD is the same commit as a tag but
+  # doesn't have the same name
+  local tag
+  tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
 
-    tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
+  if [[ -z "$(git symbolic-ref HEAD 2>/dev/null)" || ! -z "${tag}" ]] ; then
     head=$(git describe --all)
-    # Make sure that detached head and tag differ in name
-    if [[ "${head}" != "${tag}" ]]; then
-      # Append the tag segment to the branch one
-      [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+    # Make sure that detached head or checked out name differs from tag name
+    if [[ "${head}" != "${tag}" ||
+      "$(git rev-parse --abbrev-ref HEAD)" != "${tag}" &&
+      "$(git rev-parse --abbrev-ref HEAD)" != "HEAD" &&
+      "$(git rev-list -n 1 HEAD)" == "$(git rev-list -n 1 ${tag})" ]]; then
+        # Append the tag segment to the branch one
+        [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
     fi
   fi
 }

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -61,10 +61,13 @@ function +vi-git-remotebranch() {
 }
 
 function +vi-git-tagname() {
+  # Only show the tag name if we are not in DETACHED_HEAD state,
+  # since in that case it would already be displayed in the branch segment
   if [[ -n "$(git status | grep 'HEAD detached')" ]] ; then
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
+    # Append the tag segment to the branch one
     [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
   fi
 }

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -61,10 +61,12 @@ function +vi-git-remotebranch() {
 }
 
 function +vi-git-tagname() {
+  if [[ -n "$(git status | grep 'HEAD detached')" ]] ; then
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
     [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+  fi
 }
 
 # Show count of stashed changes

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -64,7 +64,7 @@ function +vi-git-tagname() {
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
-    [[ -n "${tag}" ]] && hook_com[branch]="$(print_icon 'VCS_TAG_ICON')${tag}"
+    [[ -n "${tag}" ]] && hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
 }
 
 # Show count of stashed changes

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -63,7 +63,7 @@ function +vi-git-remotebranch() {
 function +vi-git-tagname() {
   # Only show the tag name if we are not in DETACHED_HEAD state,
   # since in that case it would already be displayed in the branch segment
-  if [[ -n "$(git status | grep 'HEAD detached')" ]] ; then
+  if [[ -z "$(git symbolic-ref HEAD 2>/dev/null)" ]] ; then
     local tag
 
     tag=$(git describe --tags --exact-match HEAD 2>/dev/null)


### PR DESCRIPTION
Copy of #234 on right branch.

- [x] Move request on `next` branch.
- [x] Hide tag in DETACHED_HEAD states.
- [x] ~~Show hash in DETACHED_HEAD states.~~ (Already handled by default implementation)
- [x] ~~Handle non-Awesome icons.~~ (Already handled by [an internal function][1])
- [x] Better DETACHED_HEAD state detection.
- [x] Special cases handling

[1]: https://github.com/nmaggioni/powerlevel9k/blob/next/functions/icons.zsh#L201