### PR TITLE
Add anaconda segment.

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -280,6 +280,14 @@ right_prompt_segment() {
 # right-left but reads the opposite, this isn't necessary for the other side.
 CURRENT_BG='NONE'
 
+# Anaconda Environment
+prompt_anaconda() {
+  local active_conda_env=$(where conda | ggrep -o -P '(?<=envs/)[\w-]+(?=/bin)')
+  if [[ -n $active_conda_env ]]; then
+    "$1_prompt_segment" "$0" "$2" "green" "black" "($active_conda_env)" ""
+  fi
+}
+
 # AWS Profile
 prompt_aws() {
   local aws_profile="$AWS_DEFAULT_PROFILE"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -282,7 +282,7 @@ CURRENT_BG='NONE'
 
 # Anaconda Environment
 prompt_anaconda() {
-  local active_conda_env=$(where conda | ggrep -o -P '(?<=envs/)[\w-]+(?=/bin)')
+  local active_conda_env=$(where conda | grep -o -P '(?<=envs/)[\w-]+(?=/bin)')
   if [[ -n $active_conda_env ]]; then
     "$1_prompt_segment" "$0" "$2" "green" "black" "($active_conda_env)" ""
   fi


### PR DESCRIPTION
Find active anaconda environment (different from root).
If `conda` links to a point within a custom environment, the containing
env will be shown.