### PR TITLE
Add anaconda segment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The segments that are currently available are:
     * `symfony2_version` - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * **Python Segments:**
     * `virtualenv` - Your Python [VirtualEnv](https://virtualenv.pypa.io/en/latest/).
+    * `anaconda` - Your active [Anaconda](https://www.continuum.io/why-anaconda) environment.
 * **Ruby Segments:**
     * [`chruby`](#chruby) - Ruby environment information using `chruby` (if one is active).
     * [`rbenv`](#rbenv) - Ruby environment information using `rbenv` (if one is active).
@@ -135,6 +136,16 @@ The segments that are currently available are:
 
 ---------------------------------------------------------------------------------
 
+
+##### anaconda
+
+This segment shows your active anaconda environment.
+
+*Note: This segment relies on a perl-regex with lookbehind.
+If `ack` is not available the segment will try to use `grep`.
+Recent versions of grep offer a `-P` option to handle such things.
+On OSX, however, you want to install gnu-grep (e.g. via `brew install grep`)
+and alias the newly installed `ggrep` to `grep`. Alternatively, `brew install ack`.*
 
 ##### aws
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -288,6 +288,18 @@ right_prompt_segment() {
 # right-left but reads the opposite, this isn't necessary for the other side.
 CURRENT_BG='NONE'
 
+# Anaconda Environment
+prompt_anaconda() {
+  if $(hash ack 2>/dev/null); then
+    local active_conda_env=$(where conda | ack -o '(?<=envs/)[\w-]+(?=/bin)')
+  else
+    local active_conda_env=$(where conda | grep -o -P '(?<=envs/)[\w-]+(?=/bin)')
+  fi
+  if [[ -n $active_conda_env ]]; then
+    "$1_prompt_segment" "$0" "$2" "green" "black" "($active_conda_env)" ""
+  fi
+}
+
 # AWS Profile
 prompt_aws() {
   local aws_profile="$AWS_DEFAULT_PROFILE"


### PR DESCRIPTION
Shows the currently active anaconda environment different from root.
Requires `ack` or a recent version of `grep` supporting positive lookbehind.