### PR TITLE
Load warning improvements

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -511,7 +511,7 @@ prompt_ip() {
 prompt_load() {
   # The load segment can have three different states
   local current_state="unknown"
-  local cores=`nproc`
+  local cores=$(nproc)
 
   typeset -AH load_states
   load_states=(
@@ -528,9 +528,9 @@ prompt_load() {
   # Replace comma
   load_avg_1min=${load_avg_1min//,/.}
 
-  if [[ "$load_avg_1min" -gt `bc -l <<< "${cores} * 0.7"` ]]; then
+  if [[ "$load_avg_1min" -gt $(bc -l <<< "${cores} * 0.7") ]]; then
     current_state="critical"
-  elif [[ "$load_avg_1min" -gt `bc -l <<< "${cores} * 0.5"` ]]; then
+  elif [[ "$load_avg_1min" -gt $(bc -l <<< "${cores} * 0.5") ]]; then
     current_state="warning"
   else
     current_state="normal"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -511,6 +511,8 @@ prompt_ip() {
 prompt_load() {
   # The load segment can have three different states
   local current_state="unknown"
+  local cores=`nproc`
+
   typeset -AH load_states
   load_states=(
     'critical'      'red'
@@ -518,23 +520,23 @@ prompt_load() {
     'normal'        'green'
   )
   if [[ "$OS" == "OSX" ]]; then
-    load_avg_5min=$(sysctl vm.loadavg | grep -o -E '[0-9]+(\.|,)[0-9]+' | head -n 1)
+    load_avg_1min=$(sysctl vm.loadavg | grep -o -E '[0-9]+(\.|,)[0-9]+' | head -n 1)
   else
-    load_avg_5min=$(grep -o "[0-9.]*" /proc/loadavg | head -n 1)
+    load_avg_1min=$(grep -o "[0-9.]*" /proc/loadavg | head -n 1)
   fi
 
   # Replace comma
-  load_avg_5min=${load_avg_5min//,/.}
+  load_avg_1min=${load_avg_1min//,/.}
 
-  if [[ "$load_avg_5min" -gt 10 ]]; then
+  if [[ "$load_avg_1min" -gt `bc -l <<< "${cores} * 0.7"` ]]; then
     current_state="critical"
-  elif [[ "$load_avg_5min" -gt 3 ]]; then
+  elif [[ "$load_avg_1min" -gt `bc -l <<< "${cores} * 0.5"` ]]; then
     current_state="warning"
   else
     current_state="normal"
   fi
 
-  "$1_prompt_segment" "${0}_${current_state}" "$2" "${load_states[$current_state]}" "$DEFAULT_COLOR" "$load_avg_5min" 'LOAD_ICON'
+  "$1_prompt_segment" "${0}_${current_state}" "$2" "${load_states[$current_state]}" "$DEFAULT_COLOR" "$load_avg_1min" 'LOAD_ICON'
 }
 
 # Node version


### PR DESCRIPTION
Load warnings should be relative to the number of cores and not arbitrary. Also, the variable suggested the 5 minute load was being used, but it was 1 minute. Perhaps we could add this as a configuration option?