### PR TITLE
Fix incorrect background jobs number

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -322,6 +322,10 @@ prompt_aws_eb_env() {
 set_default POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE true
 prompt_background_jobs() {
   local background_jobs_number=${$(jobs -l | wc -l)// /}
+  local wrong_lines=`jobs -l | awk '/pwd now/{ count++ } END {print count}'`
+  if [[ wrong_lines -gt 0 ]]; then
+     background_jobs_number=$(( $background_jobs_number - $wrong_lines ))
+  fi
   if [[ background_jobs_number -gt 0 ]]; then
     local background_jobs_number_print=""
     if [[ "$POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE" == "true" ]] && [[ "$background_jobs_number" -gt 1 ]]; then


### PR DESCRIPTION
The jobs -l command displays a "pwd now :..." line when a job was launched from a different directory than the current one that cause powerlevel9k to display an incorrect number of background jobs. This change fixes it.