### PR TITLE
PYTHON ICON for virtualenv prompt

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -69,7 +69,8 @@ case $POWERLEVEL9K_MODE in
       VCS_REMOTE_BRANCH_ICON         ' '$'\UE804 '          # 
       VCS_GIT_ICON                   $'\UE20E '             # 
       VCS_HG_ICON                    $'\UE1C3 '             # 
-	  RUST_ICON                      ''                     
+      RUST_ICON                      ''
+      PYTHON_ICON                    ''
     )
   ;;
   'awesome-fontconfig')
@@ -121,7 +122,8 @@ case $POWERLEVEL9K_MODE in
       VCS_REMOTE_BRANCH_ICON         ' '$'\UF204 '          # 
       VCS_GIT_ICON                   $'\UF113 '             # 
       VCS_HG_ICON                    $'\UF0C3 '             # 
-      RUST_ICON                      $'\UE6A8'              #  
+      RUST_ICON                      $'\UE6A8'              # 
+      PYTHON_ICON                    $'\UE63C'              # 
     )
   ;;
   *)
@@ -173,7 +175,8 @@ case $POWERLEVEL9K_MODE in
       VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
       VCS_GIT_ICON                   ''
       VCS_HG_ICON                    ''
-	  RUST_ICON                      ''
+      RUST_ICON                      ''
+      PYTHON_ICON                    ''
     )
   ;;
 esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -930,7 +930,7 @@ prompt_vi_mode() {
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n "$virtualenv_path" && "$VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "($(basename "$virtualenv_path"))"
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$(basename "$virtualenv_path")" 'PYTHON_ICON'
   fi
 }
 


### PR DESCRIPTION
Rust, Ruby icon already support, I'm so susprise why virtualenv still don't have icon.
I get Python icon Unicode from here: https://vorillaz.github.io/devicons/#/cheat

![Preview](http://storage9.static.itmages.com/i/16/0504/h_1462373439_7452058_fd802bf7f1.png)

