### PR TITLE
Add pyenv segment showing active python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The segments that are currently available are:
 * **Python Segments:**
     * `virtualenv` - Your Python [VirtualEnv](https://virtualenv.pypa.io/en/latest/).
     * [`anaconda`](#anaconda) - Your active [Anaconda](https://www.continuum.io/why-anaconda) environment.
-    * [`pyenv`](#pyenv) - Your active python version as indicated by the first word of `[pyenv](https://github.com/yyuu/pyenv) version` unless it is _system_.
+    * [`pyenv`](#pyenv) - Your active python version as indicated by [pyenv](https://github.com/yyuu/pyenv). Note that it simply displays the first word of `pyenv version` but skips the prompt if it is _system_.
 * **Ruby Segments:**
     * [`chruby`](#chruby) - Ruby environment information using `chruby` (if one is active).
     * [`rbenv`](#rbenv) - Ruby environment information using `rbenv` (if one is active).

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The segments that are currently available are:
 * **Python Segments:**
     * `virtualenv` - Your Python [VirtualEnv](https://virtualenv.pypa.io/en/latest/).
     * [`anaconda`](#anaconda) - Your active [Anaconda](https://www.continuum.io/why-anaconda) environment.
+    * [`pyenv`](#pyenv) - Your active python version as indicated by the first word of `[pyenv](https://github.com/yyuu/pyenv) version` unless it is _system_.
 * **Ruby Segments:**
     * [`chruby`](#chruby) - Ruby environment information using `chruby` (if one is active).
     * [`rbenv`](#rbenv) - Ruby environment information using `rbenv` (if one is active).

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -934,6 +934,18 @@ prompt_virtualenv() {
   fi
 }
 
+# pyenv: current active python version (with restrictions)
+# More information on pyenv (Python version manager like rbenv and rvm):
+# https://github.com/yyuu/pyenv
+# the prompt parses output of pyenv version and only displays the first word
+prompt_pyenv() {
+  local pyenv_version="$(pyenv version 2>/dev/null)"
+  local python_name="${pyenv_version[(w)1]}"
+  if [[ -n "$pyenv_version" && "${python_name}" != "system" ]]; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${python_name}"
+  fi
+}
+
 ################################################################
 # Prompt processing and drawing
 ################################################################

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -939,10 +939,12 @@ prompt_virtualenv() {
 # https://github.com/yyuu/pyenv
 # the prompt parses output of pyenv version and only displays the first word
 prompt_pyenv() {
-  local pyenv_version="$(pyenv version 2>/dev/null)"
-  local python_name="${pyenv_version[(w)1]}"
-  if [[ -n "$pyenv_version" && "${python_name}" != "system" ]]; then
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${python_name}"
+  # get first word using `cut` to be consistent with other prompts
+  # this reads better for devs familiar with sed/awk/grep/cut utilities
+  # using shell expansion/substitution may hamper future maintainability
+  local pyenv_version="$(pyenv version 2>/dev/null | cut -d ' ' -f1)"
+  if [[ -n "$pyenv_version" && "${pyenv_version}" != "system" ]]; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${pyenv_version}"
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -942,7 +942,7 @@ prompt_pyenv() {
   # get first word using `cut` to be consistent with other prompts
   # this reads better for devs familiar with sed/awk/grep/cut utilities
   # using shell expansion/substitution may hamper future maintainability
-  local pyenv_version="$(pyenv version 2>/dev/null | cut -d ' ' -f1)"
+  local pyenv_version="$(pyenv version 2>/dev/null | head -n1 | cut -d' ' -f1)"
   if [[ -n "$pyenv_version" && "${pyenv_version}" != "system" ]]; then
     "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${pyenv_version}"
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -943,6 +943,9 @@ prompt_pyenv() {
   # this reads better for devs familiar with sed/awk/grep/cut utilities
   # using shell expansion/substitution may hamper future maintainability
   local pyenv_version="$(pyenv version 2>/dev/null | head -n1 | cut -d' ' -f1)"
+  # for the sake of posterity, alternative is:
+  # local pyenv_version="$(pyenv version 2>/dev/null)"
+  # pyenv_version="${pyenv_version%% *}"
   if [[ -n "$pyenv_version" && "${pyenv_version}" != "system" ]]; then
     "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${pyenv_version}"
   fi


### PR DESCRIPTION
I created a new segment for use with [pyenv](https://github.com/yyuu/pyenv) to
manage python versions. This prompt can be used in place of `virtualenv`
segment, however, it is targeted at users of pyenv and not meant to
replace the `virtualenv` segment.

The prompt works by parsing output of `pyenv version` and displaying the
first word of the output as segment text. The design (color etc.) is
same as the `virtualenv` segment to respect consistency.

Tested on my personal machines (Mac OSX 10.11.4 and Ubuntu 15.04). The
segment would need to be revisited if `pyenv version` changes its output
format.