### PR TITLE
Add pyenv segment to show active non-system python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The segments that are currently available are:
 * **Python Segments:**
     * `virtualenv` - Your Python [VirtualEnv](https://virtualenv.pypa.io/en/latest/).
     * [`anaconda`](#anaconda) - Your active [Anaconda](https://www.continuum.io/why-anaconda) environment.
+    * `pyenv` - Your active python version as reported by the first word of [`pyenv version`](https://github.com/yyuu/pyenv). Note that the segment is not displayed if that word is _system_ i.e. the segment is inactive if you are using system python.
 * **Ruby Segments:**
     * [`chruby`](#chruby) - Ruby environment information using `chruby` (if one is active).
     * [`rbenv`](#rbenv) - Ruby environment information using `rbenv` (if one is active).

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -935,6 +935,22 @@ prompt_virtualenv() {
   fi
 }
 
+# pyenv: current active python version (with restrictions)
+# More information on pyenv (Python version manager like rbenv and rvm):
+# https://github.com/yyuu/pyenv
+# the prompt parses output of pyenv version and only displays the first word
+prompt_pyenv() {
+  local pyenv_version="$(pyenv version 2>/dev/null)"
+  pyenv_version="${pyenv_version%% *}"
+  # XXX: The following should return the same as above.
+  # This reads better for devs familiar with sed/awk/grep/cut utilities
+  # Using shell expansion/substitution may hamper future maintainability
+  #local pyenv_version="$(pyenv version 2>/dev/null | head -n1 | cut -d' ' -f1)"
+  if [[ -n "$pyenv_version" && "$pyenv_version" != "system" ]]; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$pyenv_version" 'PYTHON_ICON'
+  fi
+}
+
 ################################################################
 # Prompt processing and drawing
 ################################################################


### PR DESCRIPTION
I created a new segment for use with pyenv to manage python versions. This prompt can be used in place of `virtualenv` segment, however, it is targeted at users of [pyenv](https://github.com/yyuu/pyenv) and not meant to replace the `virtualenv` segment.

The prompt works by parsing output of `pyenv version` and displaying the first word of the output as segment text. The design (color etc.) is same as the `virtualenv` segment to respect consistency. The segment would need to be revisited if `pyenv version` changes its output format. ~~Furthermore, a small change would be required if and when PR #260 is accepted to include python icon for the segment.~~ The python icon is now added to the prompt.

Tested on my personal machines (Mac OSX 10.11.4 and Ubuntu 15.04). Feel free to reword the README.md changes to make it more, err, _readable_.