### PR TITLE
Async right prompt

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -982,9 +982,19 @@ build_right_prompt() {
   done
 }
 
+if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
+  ASYNC_PROC=0
+  socket=$(mktemp)
+  async() {
+    : > $socket #reset file
+    RPROMPT="$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX"
+    echo -n $RPROMPT >> $socket
+    kill -s USR1 $$
+  }
+fi
 powerlevel9k_prepare_prompts() {
   RETVAL=$?
-
+  RPROMPT=""
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
     PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
 $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
@@ -1006,10 +1016,27 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
     RPROMPT_PREFIX=''
     RPROMPT_SUFFIX=''
   fi
-
   if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
-    RPROMPT="$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX"
+    # kill previous async
+    if [[ "${ASYNC_PROC}" != 0 ]]; then
+      kill -TERM $ASYNC_PROC >/dev/null 2>&1
+    fi
+    async &!
+    ASYNC_PROC=$!
   fi
+}
+
+tidy() {
+  rm $socket
+  socket=""
+}
+trap tidy EXIT
+
+TRAPUSR1() {
+  RPROMPT="$(cat $socket)"
+  #: > $socket #reset file
+  # redisplay
+  zle && zle reset-prompt
 }
 
 function zle-line-init {
@@ -1017,7 +1044,7 @@ function zle-line-init {
   if (( ${+terminfo[smkx]} )); then
     printf '%s' ${terminfo[smkx]}
   fi
-  zle reset-prompt
+  #zle reset-prompt
   zle -R
 }
 
@@ -1026,13 +1053,13 @@ function zle-line-finish {
   if (( ${+terminfo[rmkx]} )); then
     printf '%s' ${terminfo[rmkx]}
   fi
-  zle reset-prompt
+  #zle reset-prompt
   zle -R
 }
 
 function zle-keymap-select {
   powerlevel9k_prepare_prompts
-  zle reset-prompt
+  #zle reset-prompt
   zle -R
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -979,8 +979,8 @@ build_right_prompt() {
     fi
 
     index=$((index + 1))
-    kill -s USR1 $$
   done
+  kill -s USR1 $$
 }
 
 if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -992,8 +992,7 @@ if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
   ASYNC_PROC=0
   socket=$(mktemp)
   async() {
-    rm -f $socket #reset file
-    touch $socket
+    : >! $socket #reset file
     build_right_prompt
   }
 fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -979,8 +979,13 @@ build_right_prompt() {
     fi
 
     index=$((index + 1))
+    if [[ "$POWERLEVEL9K_RPROMPT_RENDER_ASAP" == true ]]; then
+      kill -s USR1 $$
+    fi
   done
-  kill -s USR1 $$
+  if [[ "$POWERLEVEL9K_RPROMPT_RENDER_ASAP" != true ]]; then
+    kill -s USR1 $$
+  fi
 }
 
 if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -987,7 +987,8 @@ if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
   ASYNC_PROC=0
   socket=$(mktemp)
   async() {
-    : > $socket #reset file
+    rm -f $socket #reset file
+    touch $socket
     build_right_prompt
   }
 fi
@@ -1026,8 +1027,8 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
 }
 
 tidy() {
-  rm $socket
-  socket=""
+  rm -f $socket
+  unset $socket
 }
 trap tidy EXIT
 


### PR DESCRIPTION
This could be a solution to the lag experienced in #244.
An subprocess writes the prompt to a temporary file (unique to each zsh instance) as each element is loaded. A signal is send to the parent zsh process after each write so that the RPROMPT can be set to the new value. The temporary file is deleted when the zsh exits.

The three `zle reset-prompt` were removed from the other handlers as otherwise RPROMPT was reset to empty after hitting enter. However `powerlevel9k_prepare_prompts` handles `zle reset-prompt` so this shouldn't be a problem 