### PR TITLE
Make prompt_custom not print the segment if empty

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -444,8 +444,11 @@ prompt_context() {
 # the output in a segment.
 prompt_custom() {
   local command=POWERLEVEL9K_CUSTOM_$3:u
+  local segment_content="$(eval ${(P)command})"
 
-  "$1_prompt_segment" "${0}_${3:u}" "$2" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$(eval ${(P)command})"
+  if [[ -n $segment_content ]]; then
+    "$1_prompt_segment" "${0}_${3:u}" "$2" $DEFAULT_COLOR_INVERTED $DEFAULT_COLOR "$segment_content"
+  fi
 }
 
 # Dir: current working directory


### PR DESCRIPTION
Currently you can't make a conditional custom segment. This changes the
prompt_custom function responsible for printing custom segments so that
it won't print the segment in case the content is empty.

With this it becomes possible to make conditional custom prompts simply
by making it not print anything when it's not supposed to be shown.

This is in response to my own issue #267 about a way to make custom segments conditional without having to monkey patch anything. 

I first imagined adding a new var `POWERLEVEL9K_CUSTOM_NAME_CONDITION` with a condition that could be evaluated and used as a conditional, but @Tritlo insightfully suggested that it would be way simpler to just test if the custom command returned an empty string and only print the segment in case it didn't.