### PR TITLE
Non-verbose battery option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ requires `acpi` on Linux).
 |`POWERLEVEL9K_BATTERY_DISCONNECTED`|`$DEFAULT_COLOR`|Color to indicate absence of battery.|
 |`POWERLEVEL9K_BATTERY_LOW_THRESHOLD`|`10`|Threshold to consider battery level critical.|
 |`POWERLEVEL9K_BATTERY_LOW_COLOR`|`"red"`|Color to indicate critically low charge level.|
+|`POWERLEVEL9K_BATTERY_VERBOSE`|`true`|Display time remaining next to battery level.|
 
 Note that you can [modify the `_FOREGROUND`
 color](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -419,6 +419,8 @@ prompt_battery() {
   set_default POWERLEVEL9K_BATTERY_VERBOSE true
   if [[ "$POWERLEVEL9K_BATTERY_VERBOSE" == true ]]; then
     message="$bat_percent%%$remain"
+  else
+    message="$bat_percent%%"
   fi
 
   # Draw the prompt_segment


### PR DESCRIPTION
I noticed there was an undocumented `POWERLEVEL9K_BATTERY_VERBOSE` option, but setting it to true caused the battery option to display nothing but an icon. Having the % level only seemed like a sensible option for `false`. 

Let me know if there's something else to put here. I was not ambitious enough to make it fully customizable.