### PR TITLE
revise mac battery error when mac default date use linux's

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -359,7 +359,7 @@ prompt_battery() {
     local time_remaining=$(echo $raw_data | grep TimeRemaining | awk '{ print $5 }')
     if [[ -n $time_remaining ]]; then
       # this value is set to a very high number when the system is calculating
-      [[ $time_remaining -gt 10000 ]] && local tstring="..." || local tstring=${(f)$(date -u -r $(($time_remaining * 60)) +%k:%M)}
+      [[ $time_remaining -gt 10000 ]] && local tstring="..." || local tstring=${(f)$(/bin/date -u -r $(($time_remaining * 60)) +%k:%M)}
     fi
 
     # Get charge values
@@ -1079,3 +1079,4 @@ powerlevel9k_init() {
 }
 
 powerlevel9k_init "$@"
+


### PR DESCRIPTION
If mac install gnu command  by running `brew install coreutils ` and config gun command is default.It will get error when config `battery`.