### PR TITLE
Added POWERLEVEL9K_VCS_HIDE_TAGS variable to hide tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,10 @@ customization is provided via:
 |`POWERLEVEL9K_SHOW_CHANGESET`|`false`|Set to `true` to display the hash / changeset in the segment.|
 |`POWERLEVEL9K_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
 |`POWERLEVEL9K_VCS_SHOW_SUBMODULE_DIRTY`|`true`|Set to `false` to not reflect submodule status in the top-level repository prompt.|
+|`POWERLEVEL9K_VCS_HIDE_TAGS`|unset|Set to `true` to stop tags being displayed in the segment.|
 
-**vcs Symbols**
+
+##### vcs symbols
 
 The `vcs` segment uses various symbols to tell you the state of your repository.
 These symbols depend on your installed font and selected `POWERLEVEL9K_MODE`

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -61,24 +61,26 @@ function +vi-git-remotebranch() {
 }
 
 function +vi-git-tagname() {
-  # If we are on a tag, append the tagname to the current branch string.
-  local tag
-  tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
+  if [[ -z "${POWERLEVE9K_VCS_HIDE_TAGS}" ]]; then
+    # If we are on a tag, append the tagname to the current branch string.
+    local tag
+    tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
 
-  if [[ -n "${tag}" ]] ; then
-    # There is a tag that points to our current commit. Need to determine if we
-    # are also on a branch, or are in a DETACHED_HEAD state.
-    if [[ -z $(git symbolic-ref HEAD 2>/dev/null) ]]; then
-      # DETACHED_HEAD state. We want to append the tag name to the commit hash
-      # and print it. Unfortunately, `vcs_info` blows away the hash when a tag
-      # exists, so we have to manually retrieve it and clobber the branch
-      # string.
-      local revision
-      revision=$(git rev-list -n 1 --abbrev-commit --abbrev=${POWERLEVEL9K_VCS_INTERNAL_HASH_LENGTH} HEAD)
-      hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${revision} $(print_icon 'VCS_TAG_ICON')${tag}"
-    else
-      # We are on both a tag and a branch; print both by appending the tag name.
-      hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+    if [[ -n "${tag}" ]] ; then
+      # There is a tag that points to our current commit. Need to determine if we
+      # are also on a branch, or are in a DETACHED_HEAD state.
+      if [[ -z $(git symbolic-ref HEAD 2>/dev/null) ]]; then
+        # DETACHED_HEAD state. We want to append the tag name to the commit hash
+        # and print it. Unfortunately, `vcs_info` blows away the hash when a tag
+        # exists, so we have to manually retrieve it and clobber the branch
+        # string.
+        local revision
+        revision=$(git rev-list -n 1 --abbrev-commit --abbrev=${POWERLEVEL9K_VCS_INTERNAL_HASH_LENGTH} HEAD)
+        hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${revision} $(print_icon 'VCS_TAG_ICON')${tag}"
+      else
+        # We are on both a tag and a branch; print both by appending the tag name.
+        hook_com[branch]+=" $(print_icon 'VCS_TAG_ICON')${tag}"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
Added variable to control the hiding of tags as too many tags can lead to a whole line taken up with just the git information.