### PR TITLE
Make prompt_status show return code in non verbose mode

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -752,7 +752,7 @@ prompt_status() {
     fi
   else
     if [[ "$RETVAL" -ne 0 ]]; then
-      "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "" 'FAIL_ICON'
+      "$1_prompt_segment" "$0_ERROR" "$2" "red" "226" "$RETVAL" 'CARRIAGE_RETURN_ICON'
     fi
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -510,7 +510,7 @@ prompt_dir() {
   set_default POWERLEVEL9K_DIR_SPLIT_MODE false
   if [[ $POWERLEVEL9K_DIR_SPLIT_MODE == true ]]; then
     current_path=$(print -P $current_path)
-    current_path=$(echo $current_path | cut -c1 | sed "s,/,$(print_icon 'ICON_SLASH') ,g")$(echo $current_path | cut -c2- | sed "s,/, $(print_icon 'LEFT_SUBSEGMENT_SEPARATOR') ,g")
+    current_path=$(echo $current_path | cut -c1 | sed "s,/,$(print_icon 'ICON_SLASH'),g")$(echo $current_path | cut -c2- | sed "s,/, $(print_icon 'LEFT_SUBSEGMENT_SEPARATOR') ,g" | sed "s,^\(.\), \1,")
   fi
 
   local current_icon=''

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -455,7 +455,6 @@ prompt_custom() {
 prompt_dir() {
   local current_path='%~'
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
-
     set_default POWERLEVEL9K_SHORTEN_DELIMITER $'\U2026'
 
     case "$POWERLEVEL9K_SHORTEN_STRATEGY" in
@@ -506,6 +505,12 @@ prompt_dir() {
       ;;
     esac
 
+  fi
+
+  set_default POWERLEVEL9K_DIR_SPLIT_MODE false
+  if [[ $POWERLEVEL9K_DIR_SPLIT_MODE == true ]]; then
+    current_path=$(print -P $current_path)
+    current_path=$(echo $current_path | cut -c1 | sed "s,/,$(print_icon 'ICON_SLASH') ,g")$(echo $current_path | cut -c2- | sed "s,/, $(print_icon 'LEFT_SUBSEGMENT_SEPARATOR') ,g")
   fi
 
   local current_icon=''


### PR DESCRIPTION
Hello,

I was surprised to discover that the VERBOSE=FALSE for the status prompt doesn't do only what is written in the documentation. Not only does it hide the segment when the last command is OK, it also changes the background color when there is an error and hides the return code.

This PR fixes this in the most basic way by making the segment behave exactly as in the docs.

Another option would be to add a second option:
 * POWERLEVEL9K_STATUS_VERBOSE would control wether the return code is shown, or only the symbol
 * POWERLEVEL9K_STATUS_HIDE_SUCCESS, false by default, would control wether the segment is present when the last command exited with success.