### PR TITLE
Adding svn support

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -110,11 +110,25 @@ function +vi-vcs-detect-changes() {
     vcs_visual_identifier='VCS_GIT_ICON'
   elif [[ "${hook_com[vcs]}" == "hg" ]]; then
     vcs_visual_identifier='VCS_HG_ICON'
+#  elif [[ "${hook_com[vcs]}" == "svn" ]]; then
+#    vcs_visual_identifier='VCS_SVN_ICON'
   fi
 
   if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
     VCS_WORKDIR_DIRTY=true
   else
     VCS_WORKDIR_DIRTY=false
+  fi
+}
+
+function +vi-svn-detect-changes() {
+  local svn_status=$(svn status)
+  if [[ -n "$(echo "$svn_status" | grep \^\?)" ]]; then
+    VCS_WORKDIR_DIRTY=true
+  elif [[ -n "$(echo "$svn_status" | grep \^\A)" ]]; then
+    VCS_WORKDIR_HALF_DIRTY=true
+  else
+    VCS_WORKDIR_DIRTY=false
+    VCS_WORKDIR_HALF_DIRTY=false
   fi
 }

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -124,11 +124,11 @@ function +vi-vcs-detect-changes() {
 function +vi-svn-detect-changes() {
   local svn_status=$(svn status)
   if [[ -n "$(echo "$svn_status" | grep \^\?)" ]]; then
+    hook_com[unstaged]+=" $(print_icon 'VCS_STASH_ICON')"
     VCS_WORKDIR_HALF_DIRTY=true
-  elif [[ -n "$(echo "$svn_status" | grep \^\A)" ]]; then
+  fi
+  if [[ -n "$(echo "$svn_status" | grep \^\A)" ]]; then
     VCS_WORKDIR_DIRTY=true
-  else
-    VCS_WORKDIR_DIRTY=false
-    VCS_WORKDIR_HALF_DIRTY=false
+    hook_com[unstaged]+=" $(print_icon 'VCS_STAGED_ICON')"
   fi
 }

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -124,9 +124,9 @@ function +vi-vcs-detect-changes() {
 function +vi-svn-detect-changes() {
   local svn_status=$(svn status)
   if [[ -n "$(echo "$svn_status" | grep \^\?)" ]]; then
-    VCS_WORKDIR_DIRTY=true
-  elif [[ -n "$(echo "$svn_status" | grep \^\A)" ]]; then
     VCS_WORKDIR_HALF_DIRTY=true
+  elif [[ -n "$(echo "$svn_status" | grep \^\A)" ]]; then
+    VCS_WORKDIR_DIRTY=true
   else
     VCS_WORKDIR_DIRTY=false
     VCS_WORKDIR_HALF_DIRTY=false

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -880,6 +880,8 @@ powerlevel9k_vcs_init() {
   zstyle ':vcs_info:git*+set-message:*' hooks $POWERLEVEL9K_VCS_GIT_HOOKS
   defined POWERLEVEL9K_VCS_HG_HOOKS || POWERLEVEL9K_VCS_HG_HOOKS=(vcs-detect-changes)
   zstyle ':vcs_info:hg*+set-message:*' hooks $POWERLEVEL9K_VCS_HG_HOOKS
+  defined POWERLEVEL9K_VCS_SVN_HOOKS || POWERLEVEL9K_VCS_SVN_HOOKS=(svn-detect-changes)
+  zstyle ':vcs_info:svn*+set-message:*' hooks $POWERLEVEL9K_VCS_SVN_HOOKS
 
   # For Hg, only show the branch name
   zstyle ':vcs_info:hg*:*' branchformat "$(print_icon 'VCS_BRANCH_ICON')%b"


### PR DESCRIPTION
What is working now?

* the prompt changes the color when something is unstaged.
* the prompt displays the UNSTAGED_ICON and UNTRACKED_ICON
* the behaviour is pretty similiar to the behaviour of the vcs git prompt..

Note: There is a bug. The unstaged and untracked icons are not displayed when the prompt has changed the color because of the font in the last section of the prompt has the same colour as the changed prompt. We need to modify the standard svn prompt