### PR TITLE
Configurable colors for the context prompt

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -439,7 +439,7 @@ prompt_context() {
       # Shell runs as root
       "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
     else
-      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+      "$1_prompt_segment" "$0" "$2" "$3" "$4" "$USER@%m"
     fi
   fi
 }


### PR DESCRIPTION
This probably needs some review.

It makes the colors for the context segment configurable with the standard `POWERLEVEL9K_CONTEXT_BACKGROUND` and `POWERLEVEL9K_CONTEXT_FOREGROUND` variables.

I'm not entirely sure what to do with the root variant of the segment.
