### PR TITLE
Fix '+vi-svn-detect-changes:local:1: not valid in this context'

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -125,7 +125,7 @@ function +vi-vcs-detect-changes() {
 }
 
 function +vi-svn-detect-changes() {
-  local svn_status=$(svn status)
+  local svn_status="$(svn status)"
   if [[ -n "$(echo "$svn_status" | grep \^\?)" ]]; then
     hook_com[unstaged]+=" $(print_icon 'VCS_UNTRACKED_ICON')"
     VCS_WORKDIR_HALF_DIRTY=true


### PR DESCRIPTION
This is on Linux Mint 17.3, with zsh 5.0.2 (x86_64-pc-linux-gnu).

If you navigate to a SVN directory, it shows something like the following:
```sh
+vi-svn-detect-changes:local:1: not valid in this context: Gemfile.lock         
  ~/D/D/C/w/qa X=''
X=''
'?'=0
Performing=''
status=0
on=''
external=''
item=''
at=''
Performing=''
status=0
on=''
external=''
item=''
at=''   
```

Per a similar workaround described in this issue https://github.com/zsh-users/zsh-autosuggestions/issues/127#issuecomment-188513043, you can just wrap the call in quotes.