### PR TITLE
Show OK in non verbose status prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ This segment shows the return code of the last command.
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|`POWERLEVEL9K_STATUS_VERBOSE`|`true`|Set to false if you wish to hide this segment when the last command completed successfully.|
+|`POWERLEVEL9K_STATUS_VERBOSE`|`true`|Set to false if you wish to not show the error code when the last command returned an error and optionally hide this segment when the last command completed successfully by setting `POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE` to false.|
+|`POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE`|`false`|Set to true if you wish to show this segment when the last command completed successfully in non-verbose mode.|
 
 ##### ram
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -739,6 +739,7 @@ prompt_rvm() {
 
 # Status: return code if verbose, otherwise just an icon if an error occurred
 set_default POWERLEVEL9K_STATUS_VERBOSE true
+set_default POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE false
 prompt_status() {
   if [[ "$RETVAL" -ne 0 ]]; then
     if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
@@ -746,7 +747,7 @@ prompt_status() {
     else
       "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "" 'FAIL_ICON'
     fi
-  else
+  elif [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true || "$POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
     "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "046" "" 'OK_ICON'
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -740,16 +740,14 @@ prompt_rvm() {
 # Status: return code if verbose, otherwise just an icon if an error occurred
 set_default POWERLEVEL9K_STATUS_VERBOSE true
 prompt_status() {
-  if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
-    if [[ "$RETVAL" -ne 0 ]]; then
+  if [[ "$RETVAL" -ne 0 ]]; then
+    if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
       "$1_prompt_segment" "$0_ERROR" "$2" "red" "226" "$RETVAL" 'CARRIAGE_RETURN_ICON'
     else
-      "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "046" "" 'OK_ICON'
-    fi
-  else
-    if [[ "$RETVAL" -ne 0 ]]; then
       "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "" 'FAIL_ICON'
     fi
+  else
+    "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "046" "" 'OK_ICON'
   fi
 }
 
@@ -1082,4 +1080,3 @@ powerlevel9k_init() {
 }
 
 powerlevel9k_init "$@"
-


### PR DESCRIPTION
Adds functionality with a toggle to show the OK identifier displayed in verbose mode in non-verbose mode too.