### PR TITLE
Consider delimiter length while right truncating directories

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -204,5 +204,7 @@ function segmentShouldBeJoined() {
 # Given a directory path, truncate it according to the settings for
 # `truncate_from_right`
 function truncatePathFromRight() {
-  echo $1 | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\//g"
+  local delim_len=${#POWERLEVEL9K_SHORTEN_DELIMITER}
+  echo $1 | sed $SED_EXTENDED_REGEX_PARAMETER \
+ "s@(([^/]{$((POWERLEVEL9K_SHORTEN_DIR_LENGTH))})([^/]{$delim_len}))[^/]+/@\2$POWERLEVEL9K_SHORTEN_DELIMITER/@g"
 }

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -60,7 +60,7 @@ function testTruncationFromRightWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}/tm…/po…/1/12/12…/12…/12…/12…/12…/12…/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test


### PR DESCRIPTION
Truncate the path from the right by taking in account the delimiter length, so that directories with names shorter than truncated name + delimiter aren't incorrectly truncated.

For example, if `SHORTEN_DIR_LENGTH` is 4 and the delimiter is `..``, `../tests/..` and `../custom/..` are not incorrectly "truncated" to `../test../..` and `../cust../..`, both of which are longer or the same length as the original untruncated directory names.