### PR TITLE
Configurable path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## next
+
+### `dir` changes
+
+Added an option to configure the path separator. If you want something
+else than an ordinary slash, you could set
+`POWERLEVEL9K_DIR_PATH_SEPARATOR` to whatever you want.
+
 ## v0.4.0
 
 ### Development changes

--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ The `truncate_with_package_name` strategy gives your directory path relative to 
 
 the path shown would be `my-cool-project`.  If you navigate to `$HOME/projects/my-project/src`, then the path shown would be `my-cool-project/src`.  Please note that this currently looks for `.git` directory to determine the root of the project.
 
+If you want to customize the directory separator, you could set:
+```zsh
+# You'll need patched awesome-terminal fonts for that example
+POWERLEVEL9K_DIR_PATH_SEPARATOR="%f "$'\uE0B1'" %F"
+```
+
 ##### ip
 
 This segment tries to examine all currently used network interfaces and prints

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ variables to your `~/.zshrc`.
 
 So if you wanted to set these variables manually, you would put the following in
 your `~/.zshrc`:
-
-    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
-    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
-
+```zsh
+POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir rbenv vcs)
+POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status history time)
+```
 #### Available Prompt Segments
 The segments that are currently available are:
 
@@ -198,28 +198,28 @@ The `custom_...` segment allows you to turn the output of a custom command into
 a prompt segment. As an example, if you wanted to create a custom segment to
 display your WiFi signal strength, you might define a custom segment called
 `custom_wifi_signal` like this:
-
-    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_wifi_signal)
-    POWERLEVEL9K_CUSTOM_WIFI_SIGNAL="echo signal: \$(nmcli device wifi | grep yes | awk '{print \$8}')"
-    POWERLEVEL9K_CUSTOM_WIFI_SIGNAL_BACKGROUND="blue"
-    POWERLEVEL9K_CUSTOM_WIFI_SIGNAL_FOREGROUND="yellow"
-
+```zsh
+POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_wifi_signal)
+POWERLEVEL9K_CUSTOM_WIFI_SIGNAL="echo signal: \$(nmcli device wifi | grep yes | awk '{print \$8}')"
+POWERLEVEL9K_CUSTOM_WIFI_SIGNAL_BACKGROUND="blue"
+POWERLEVEL9K_CUSTOM_WIFI_SIGNAL_FOREGROUND="yellow"
+```
 If you prefer, you can also define the function in your `.zshrc` rather than
 putting it in-line with the variable export, as shown above. Just don't forget
 to invoke your function from your segment! Example code that achieves the same
 result as the above:
+```zsh
+zsh_wifi_signal(){
+    local signal=$(nmcli device wifi | grep yes | awk '{print $8}')
+    local color='%F{yellow}'
+    [[ $signal -gt 75 ]] && color='%F{green}'
+    [[ $signal -lt 50 ]] && color='%F{red}'
+    echo -n "%{$color%}\uf230  $signal%{%f%}" # \uf230 is 
+}
 
-    zsh_wifi_signal(){
-            local signal=$(nmcli device wifi | grep yes | awk '{print $8}')
-            local color='%F{yellow}'
-            [[ $signal -gt 75 ]] && color='%F{green}'
-            [[ $signal -lt 50 ]] && color='%F{red}'
-            echo -n "%{$color%}\uf230  $signal%{%f%}" # \uf230 is 
-    }
-
-    POWERLEVEL9K_CUSTOM_WIFI_SIGNAL="zsh_wifi_signal"
-    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_wifi_signal)
-
+POWERLEVEL9K_CUSTOM_WIFI_SIGNAL="zsh_wifi_signal"
+POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context time battery dir vcs virtualenv custom_wifi_signal)
+```
 The command, above, gives you the wireless signal segment shown below:
 
 ![signal](http://i.imgur.com/hviMATC.png)
@@ -253,11 +253,11 @@ Powerline" fonts, there are additional glyphs, as well:
 | None       | None      | ![](https://cloud.githubusercontent.com/assets/1544760/12183452/40f79286-b58f-11e5-9b8c-ed1343a07b08.png) | Outside of your home folder |
 
 To turn off these icons you could set these variables to an empty string.
-
-    POWERLEVEL9K_HOME_ICON=''
-    POWERLEVEL9K_HOME_SUB_ICON=''
-    POWERLEVEL9K_FOLDER_ICON=''
-
+```zsh
+POWERLEVEL9K_HOME_ICON=''
+POWERLEVEL9K_HOME_SUB_ICON=''
+POWERLEVEL9K_FOLDER_ICON=''
+```
 You can limit the output to a certain length by truncating long paths.
 Customizations available are:
 
@@ -269,11 +269,11 @@ Customizations available are:
 
 For example, if you wanted the truncation behavior of the `fish` shell, which
 truncates `/usr/share/plasma` to `/u/s/plasma`, you would use the following:
-
-    POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
-    POWERLEVEL9K_SHORTEN_DELIMITER=""
-    POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
-
+```zsh
+POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
+POWERLEVEL9K_SHORTEN_DELIMITER=""
+POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
+```
 In each case you have to specify the length you want to shorten the directory
 to. So in some cases `POWERLEVEL9K_SHORTEN_DIR_LENGTH` means characters, in
 others whole directories.
@@ -343,16 +343,16 @@ See [Unit Test Ratios](#unit-test-ratios), below.
 |`POWERLEVEL9K_TIME_FORMAT`|`'H:M:S'`|ZSH time format to use in this segment.|
 
 As an example, if you wanted a reversed time format, you would use this:
-
-    # Reversed time format
-    POWERLEVEL9K_TIME_FORMAT='%D{%S:%M:%H}'
-
+```zsh
+# Reversed time format
+POWERLEVEL9K_TIME_FORMAT='%D{%S:%M:%H}'
+```
 If you are using an "Awesome Powerline Font", you can add a time symbol to this
 segment, as well:
-
-    # Output time, date, and a symbol from the "Awesome Powerline Font" set
-    POWERLEVEL9K_TIME_FORMAT="%D{%H:%M:%S \uE868  %d.%m.%y}"
-
+```zsh
+# Output time, date, and a symbol from the "Awesome Powerline Font" set
+POWERLEVEL9K_TIME_FORMAT="%D{%H:%M:%S \uE868  %d.%m.%y}"
+```
 ##### vcs
 
 By default, the `vcs` segment will provide quite a bit of information. Further

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -501,17 +501,21 @@ prompt_dir() {
         current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
       ;;
     esac
-
   fi
 
-  local current_icon=''
+  typeset -AH dir_states
+  dir_states=(
+    "DEFAULT"         "FOLDER_ICON"
+    "HOME"            "HOME_ICON"
+    "HOME_SUBFOLDER"  "HOME_SUB_ICON"
+  )
+  local current_state="DEFAULT"
   if [[ $(print -P "%~") == '~' ]]; then
-    "$1_prompt_segment" "$0_HOME" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_ICON'
+    current_state="HOME"
   elif [[ $(print -P "%~") == '~'* ]]; then
-    "$1_prompt_segment" "$0_HOME_SUBFOLDER" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'HOME_SUB_ICON'
-  else
-    "$1_prompt_segment" "$0_DEFAULT" "$2" "blue" "$DEFAULT_COLOR" "$current_path" 'FOLDER_ICON'
+    current_state="HOME_SUBFOLDER"
   fi
+  "$1_prompt_segment" "$0_${current_state}" "$2" "blue" "$DEFAULT_COLOR" "$current_path" "${dir_states[$current_state]}"
 }
 
 # Docker machine

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -505,7 +505,7 @@ prompt_dir() {
   fi
 
   if [[ "${POWERLEVEL9K_DIR_PATH_SEPARATOR}" != "/" ]]; then
-    current_path=$(echo "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")
+    current_path=$(print -P "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")
   fi
 
   typeset -AH dir_states
@@ -520,7 +520,7 @@ prompt_dir() {
   elif [[ $(print -P "%~") == '~'* ]]; then
     current_state="HOME_SUBFOLDER"
   fi
-  "$1_prompt_segment" "$0_${current_state}" "$2" "blue" "$DEFAULT_COLOR" "$current_path" "${dir_states[$current_state]}"
+  "$1_prompt_segment" "$0_${current_state}" "$2" "blue" "$DEFAULT_COLOR" "${current_path}" "${dir_states[$current_state]}"
 }
 
 # Docker machine

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -456,6 +456,7 @@ prompt_custom() {
 }
 
 # Dir: current working directory
+set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
 prompt_dir() {
   local current_path='%~'
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
@@ -501,6 +502,10 @@ prompt_dir() {
         current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
       ;;
     esac
+  fi
+
+  if [[ "${POWERLEVEL9K_DIR_PATH_SEPARATOR}" != "/" ]]; then
+    current_path=$(echo "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")
   fi
 
   typeset -AH dir_states


### PR DESCRIPTION
Now the path separator is configurable. You just need to set `POWERLEVEL9K_DIR_PATH_SEPARATOR` to whatever you want.

![bildschirmfoto 2016-11-29 um 23 00 37](https://cloud.githubusercontent.com/assets/1544760/20730975/8825d88e-b688-11e6-996a-00449ea663dc.png)

As you can see, the change is independent from the shorten strategy. So these can be combined in every way. 

Further, you could even change the color for that separator. In my case is used the following setting:
```zsh
POWERLEVEL9K_DIR_PATH_SEPARATOR="%f "$'\uE0B1'" %F"
```