### PR TITLE
Add prompt for current installed swift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ The segments that are currently available are:
     * [`rspec_stats`](#rspec_stats) - Show a ratio of test classes vs code classes for RSpec.
 * **Rust Segments:**
     * `rust_version` - Display the current rust version and [logo](https://www.rust-lang.org/logos/rust-logo-blk.svg).
+* **Swift Segments:**
+    * `swift_version` - Show the version number of the installed Swift.
 
 **Cloud Segments:**
 * **AWS Segments:**

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -72,6 +72,7 @@ case $POWERLEVEL9K_MODE in
       VCS_SVN_ICON                   '(svn) '
       RUST_ICON                      ''
       PYTHON_ICON                    $'\U1F40D'             # 🐍
+      SWIFT_ICON                     ''
     )
   ;;
   'awesome-fontconfig')
@@ -126,6 +127,7 @@ case $POWERLEVEL9K_MODE in
       VCS_SVN_ICON                   '(svn) '
       RUST_ICON                      $'\uE6A8'              #  
       PYTHON_ICON                    $'\U1F40D'             # 🐍
+      SWIFT_ICON                     ''
     )
   ;;
   *)
@@ -180,6 +182,7 @@ case $POWERLEVEL9K_MODE in
       VCS_SVN_ICON                   ''
 	    RUST_ICON                      ''
       PYTHON_ICON                    ''
+      SWIFT_ICON                     'Swift'
     )
   ;;
 esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -965,6 +965,17 @@ prompt_pyenv() {
   fi
 }
 
+# Swift version
+prompt_swift_version() {
+  local swift_version=($(swift --version 2>/dev/null))
+  [[ -z "${swift_version}" ]] && return
+
+  # Extract semantic version
+  swift_version=$(echo ${swift_version} | sed -e 's/[^0-9.]*\([0-9.]*\).*/\1/')
+
+  "$1_prompt_segment" "$0" "$2" "magenta" "white" "${swift_version}" 'SWIFT_ICON'
+}
+
 ################################################################
 # Prompt processing and drawing
 ################################################################
@@ -1091,4 +1102,3 @@ powerlevel9k_init() {
 }
 
 powerlevel9k_init "$@"
-


### PR DESCRIPTION
This commit will add a prompt for the current installed swift version. As soon as the PR is merged, I will add a configuration example to the [Wiki](https://github.com/bhilburn/powerlevel9k/wiki/Show-Off-Your-Config).

<img width="780" alt="screen shot 2016-12-02 at 09 21 54" src="https://cloud.githubusercontent.com/assets/12066405/20858072/3f4a8ce8-b93c-11e6-9b72-00731a6d9010.png">
