### PR TITLE
Add nerdfont icons

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -157,7 +157,7 @@ case $POWERLEVEL9K_MODE in
       BACKGROUND_JOBS_ICON           $'\uF013 '             # 
       TEST_ICON                      $'\uF188'              # 
       TODO_ICON                      $'\u2611'              # ☑
-      BATTERY_ICON                   $'\uF241'              # 
+      BATTERY_ICON                   $'\uF241 '             # 
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   $'\uE757'              # 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -130,6 +130,61 @@ case $POWERLEVEL9K_MODE in
       SWIFT_ICON                     ''
     )
   ;;
+  'nerd-patched-complete')
+    # nerd-font patched (complete) font required! See
+    # https://github.com/ryanoasis/nerd-fonts
+    icons=(
+      LEFT_SEGMENT_SEPARATOR         $'\uE0B0'              # 
+      RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'              # 
+      LEFT_SEGMENT_END_SEPARATOR     ' '                    # Whitespace
+      LEFT_SUBSEGMENT_SEPARATOR      $'\uE0B1'              # 
+      RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
+      CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
+      ROOT_ICON                      $'\u26A1'              # ⚡
+      RUBY_ICON                      $'\uF219 '             # 
+      AWS_ICON                       $'\uE7AD'              # 
+      AWS_EB_ICON                    $'\U1F331 '            # 🌱
+      BACKGROUND_JOBS_ICON           $'\uF013 '             # 
+      TEST_ICON                      $'\uF188'              # 
+      TODO_ICON                      $'\u2611'              # ☑
+      BATTERY_ICON                   $'\U1F50B'             # 🔋
+      OK_ICON                        $'\u2713'              # ✓
+      FAIL_ICON                      $'\u2718'              # ✘
+      SYMFONY_ICON                   $'\uE757'              # 
+      NODE_ICON                      $'\u2B22'              # ⬢
+      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
+      APPLE_ICON                     $'\uF179'              # 
+      FREEBSD_ICON                   $'\U1F608 '            # 😈
+      LINUX_ICON                     $'\uF17C'              # 
+      SUNOS_ICON                     $'\uF185 '             # 
+      HOME_ICON                      $'\uF015'              # 
+      HOME_SUB_ICON                  $'\uF07C'              # 
+      FOLDER_ICON                    $'\uF115'              # 
+      NETWORK_ICON                   $'\uF1EB'              # 
+      LOAD_ICON                      $'\uF080 '             # 
+      SWAP_ICON                      $'\uF464'              # 
+      RAM_ICON                       $'\uF0E4'              # 
+      SERVER_ICON                    $'\uF0AE'              # 
+      VCS_UNTRACKED_ICON             $'\uF059'              # 
+      VCS_UNSTAGED_ICON              $'\uF06A'              # 
+      VCS_STAGED_ICON                $'\uF055'              # 
+      VCS_STASH_ICON                 $'\uF01C '             # 
+      VCS_INCOMING_CHANGES_ICON      $'\uF01A '             # 
+      VCS_OUTGOING_CHANGES_ICON      $'\uF01B '             # 
+      VCS_TAG_ICON                   $'\uF02B '             # 
+      VCS_BOOKMARK_ICON              $'\uF462'              # 
+      VCS_COMMIT_ICON                $'\uE729 '             # 
+      VCS_BRANCH_ICON                $'\uF126'              # 
+      VCS_REMOTE_BRANCH_ICON         $'\uE728 '             # 
+      VCS_GIT_ICON                   $'\uF113 '             # 
+      VCS_HG_ICON                    $'\uF0C3 '             # 
+      VCS_SVN_ICON                   '(svn) '
+      RUST_ICON                      $'\uE7A8'              # 
+      PYTHON_ICON                    $'\U1F40D'             # 🐍
+      SWIFT_ICON                     $'\uE755'              # 
+    )
+  ;;
   *)
     # Powerline-Patched Font required!
     # See https://github.com/Lokaltog/powerline-fonts
@@ -182,7 +237,7 @@ case $POWERLEVEL9K_MODE in
       VCS_SVN_ICON                   ''
 	    RUST_ICON                      ''
       PYTHON_ICON                    ''
-      SWIFT_ICON                     'Swift'
+      SWIFT_ICON                     ''
     )
   ;;
 esac


### PR DESCRIPTION
This doesn't do anything regarding the bigger issues of #97, but it's a short-term fix for people using patched/complete nerd fonts. I added the 'nerd-patched-complete' method to the icons with updated codepoints that reflect the current state of the nerdfonts with relocated octoicons. Maybe until things settle down this can just remain open and people can pull it in as a patch. I haven't tested this extensively, but the few pre-patched nerd fonts whose codepoints I checked against seemed to line up correctly.