### PR TITLE
added ssh support and POWERLEVEL9K_HIDE_HOST feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 |----------|---------------|-------------|
 |`DEFAULT_USER`|None|Username to consider a "default context" (you can also use `$USER`)|
 
+You can use POWERLEVEL9K_HIDE_HOST for hiding the hostname in the prompt
+when you are not in a ssh session. For example:
+
+    POWERLEVEL9K_HIDE_HOST="yes"
+
 ##### dir
 
 The `dir` segment shows the current working directory. When using the "Awesome

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -434,29 +434,27 @@ prompt_battery() {
 # Context: user@hostname (who am I and where am I)
 # Note that if $DEFAULT_USER is not set, this prompt segment will always print
 prompt_context() {
+  local current_state="DEFAULT"
+  declare -A context_states
+  context_states=(
+    "ROOT"      "yellow"
+    "DEFAULT"   "011"
+  )
+  local content="$USER"
   if [[ "$USER" != "$DEFAULT_USER" ]]; then
     if [[ $(print -P "%#") == '#' ]]; then
-      # Shell runs as root
+      current_state="ROOT"
+    fi
+    if [[ -z "$SSH_CLIENT" && -z "$SSH_TTY" ]]; then
       if [[ -z "$POWERLEVEL9K_HIDE_HOST" ]]; then
-        "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+        content="${content}@%m"
       else
-        if [[ -z "$SSH_CLIENT" && -z "$SSH_TTY" ]]; then
-          "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER"
-        else
-          "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
-        fi
+        content="${content}"
       fi
     else
-      if [[ -z "$POWERLEVEL9K_HIDE_HOST" ]]; then
-        "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
-      else
-        if [[ -z "$SSH_CLIENT" && -z "$SSH_TTY" ]]; then
-          "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER"
-        else
-          "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
-        fi
-      fi
+      content="${content}@%m"
     fi
+    "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${context_states[$current_state]}" "${content}"
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -434,12 +434,28 @@ prompt_battery() {
 # Context: user@hostname (who am I and where am I)
 # Note that if $DEFAULT_USER is not set, this prompt segment will always print
 prompt_context() {
-  if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
+  if [[ "$USER" != "$DEFAULT_USER" ]]; then
     if [[ $(print -P "%#") == '#' ]]; then
       # Shell runs as root
-      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+      if [[ -z "$POWERLEVEL9K_HIDE_HOST" ]]; then
+        "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+      else
+        if [[ -z "$SSH_CLIENT" && -z "$SSH_TTY" ]]; then
+          "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER"
+        else
+          "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+        fi
+      fi
     else
-      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+      if [[ -z "$POWERLEVEL9K_HIDE_HOST" ]]; then
+        "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+      else
+        if [[ -z "$SSH_CLIENT" && -z "$SSH_TTY" ]]; then
+          "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER"
+        else
+          "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+        fi
+      fi
     fi
   fi
 }


### PR DESCRIPTION
Heyho,
here is the ssh support. It's now possible to hide the hostname.  When you SSH on another host you will see the full prompt with username@hostname. On your localmachine you will just see $USER

This should satisfy https://github.com/bhilburn/powerlevel9k/issues/335

TODO: Adding a SSH identifier in the right prompt for users who doesn't want the hide host feature.
