### PR TITLE
Public ip segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The segments that are currently available are:
 * [`dir`](#dir) - Your current working directory.
 * `history` - The command number for the current line.
 * [`ip`](#ip) - Shows the current IP address.
+* [`public_ip`](#public_ip) - Shows your public IP address.
 * `load` - Your machine's load averages.
 * `os_icon` - Display a nice little icon, depending on your operating system.
 * `ram` - Show free RAM.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ segment will not be displayed.
 |----------|---------------|-------------|
 |`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p8k_public_ip'|This is the file your public IP is cached in.|
 |`POWERLEVEL9K_PUBLIC_IP_HOST`|'http://ident.me'|This is the default host to get your public IP.|
-|`POWERLEVEL9K_PUBLIC_IP_TIEMOUT`|300|The amount of time in seconds between refreshing your cached IP.|
+|`POWERLEVEL9K_PUBLIC_IP_TIMEOUT`|300|The amount of time in seconds between refreshing your cached IP.|
 |`POWERLEVEL9K_PUBLIC_IP_METHOD`|None|You can set this to any of 'dig', 'curl', or 'wget' to only use that method to refresh your IP.|
 |`POWERLEVEL9K_PUBLIC_IP_NONE`|None|The string displayed when an IP was not obtained|
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ segment will not be displayed.
 |----------|---------------|-------------|
 |`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p8k_public_ip'|This is the file your public IP is cached in.|
 |`POWERLEVEL9K_PUBLIC_IP_HOST`|'http://ident.me'|This is the default host to get your public IP.|
-|`POWERLEVEL9K_PUBLIC_IP_TIMOUT`|300|The amount of time in seconds between refreshing your cached IP.|
+|`POWERLEVEL9K_PUBLIC_IP_TIEMOUT`|300|The amount of time in seconds between refreshing your cached IP.|
 |`POWERLEVEL9K_PUBLIC_IP_METHOD`|None|You can set this to any of 'dig', 'curl', or 'wget' to only use that method to refresh your IP.|
 |`POWERLEVEL9K_PUBLIC_IP_NONE`|None|The string displayed when an IP was not obtained|
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,29 @@ specify the correct network interface by setting:
 |----------|---------------|-------------|
 |`POWERLEVEL9K_IP_INTERFACE`|None|The NIC for which you wish to display the IP address. Example: `eth0`.|
 
+##### public_ip
+
+This segment will display your public IP address. There are several methods of obtaining this
+information and by default it will try all of them starting with the most efficient. You can
+also specify which method you would like it to use. The methods available are dig using opendns,
+curl, or wget. The host used for wget and curl is http://ident.me by default but can be set to
+another host if you prefer.
+
+The public_ip segment will attempt to update your public IP address every 5 minutes by default(also
+configurable by the user). If you lose connection your cached IP address will be displayed until
+your timeout expires at which point every time your prompt is generated a new attempt will be made.
+Until an IP is successfully pulled the value of $POWERLEVEL9K_PUBLIC_IP_NONE will be displayed for
+this segment. If this value is empty(the default)and $POWERLEVEL9K_PUBLIC_IP_FILE is empty the
+segment will not be displayed.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p8k_public_ip'|This is the file your public IP is cached in.|
+|`POWERLEVEL9K_PUBLIC_IP_HOST`|'http://ident.me'|This is the default host to get your public IP.|
+|`POWERLEVEL9K_PUBLIC_IP_TIMOUT`|300|The amount of time in seconds between refreshing your cached IP.|
+|`POWERLEVEL9K_PUBLIC_IP_METHOD`|None|You can set this to any of 'dig', 'curl', or 'wget' to only use that method to refresh your IP.|
+|`POWERLEVEL9K_PUBLIC_IP_NONE`|None|The string displayed when an IP was not obtained|
+
 ##### rbenv
 
 This segment shows the version of Ruby being used when using `rbenv` to change your current Ruby stack.

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -76,6 +76,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      ''
       PYTHON_ICON                    $'\U1F40D'             # 🐍
       SWIFT_ICON                     ''
+      PUBLIC_IP_ICON                 ''
     )
   ;;
   'awesome-fontconfig')
@@ -131,9 +132,10 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            $'\uF296 '             # 
       VCS_HG_ICON                    $'\uF0C3 '             # 
       VCS_SVN_ICON                   '(svn) '
-      RUST_ICON                      $'\uE6A8'              #  
+      RUST_ICON                      $'\uE6A8'              # 
       PYTHON_ICON                    $'\U1F40D'             # 🐍
       SWIFT_ICON                     ''
+      PUBLIC_IP_ICON                 ''
     )
   ;;
   *)
@@ -192,6 +194,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      ''
       PYTHON_ICON                    ''
       SWIFT_ICON                     'Swift'
+      PUBLIC_IP_ICON                 ''
     )
   ;;
 esac

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -132,7 +132,7 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            $'\uF296 '             # 
       VCS_HG_ICON                    $'\uF0C3 '             # 
       VCS_SVN_ICON                   '(svn) '
-      RUST_ICON                      $'\uE6A8'              # 
+      RUST_ICON                      $'\uE6A8'              #  
       PYTHON_ICON                    $'\U1F40D'             # 🐍
       SWIFT_ICON                     ''
       PUBLIC_IP_ICON                 ''

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -428,7 +428,7 @@ prompt_battery() {
 
 prompt_public_ip() {
   # set default values for segment
-  set_default POWERLEVEL9K_PUBLIC_IP_TIMOUT "300"
+  set_default POWERLEVEL9K_PUBLIC_IP_TIMEOUT "300"
   set_default POWERLEVEL9K_PUBLIC_IP_NONE ""
   set_default POWERLEVEL9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
@@ -439,9 +439,10 @@ prompt_public_ip() {
     typeset -i timediff
     # if saved IP is more than
     timediff=$(($(date +%s) - $(date -r $POWERLEVEL9K_PUBLIC_IP_FILE +%s)))
-    [[ $timediff -gt $POWERLEVEL9K_PUBLIC_IP_TIMOUT ]] && refresh_ip=true
+    [[ $timediff -gt $POWERLEVEL9K_PUBLIC_IP_TIMEOUT ]] && refresh_ip=true
     # If tmp file is empty get a fresh IP
-    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) || $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ "$POWERLEVEL9K_PUBLIC_IP_NONE" ]] && refresh_ip=true
+    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) ]] && refresh_ip=true
+    [[ -n $POWERLEVEL9K_PUBLIC_IP_NONE ]] && [[ $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ "$POWERLEVEL9K_PUBLIC_IP_NONE" ]] && refresh_ip=true
   else
     touch $POWERLEVEL9K_PUBLIC_IP_FILE && refresh_ip=true
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -429,7 +429,7 @@ prompt_battery() {
 prompt_public_ip() {
   # set default values for segment
   set_default POWERLEVEL9K_PUBLIC_IP_TIMOUT "300"
-  set_default POWERLEVEL9K_PUBLIC_IP_NONE "none"
+  set_default POWERLEVEL9K_PUBLIC_IP_NONE ""
   set_default POWERLEVEL9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -429,7 +429,7 @@ prompt_battery() {
 prompt_public_ip() {
   # set default values for segment
   set_default POWERLEVEL9K_PUBLIC_IP_TIMOUT "300"
-  set_default POWERLEVEL9K_PUBLIC_IP_NONE ""
+  set_default POWERLEVEL9K_PUBLIC_IP_NONE "none"
   set_default POWERLEVEL9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
 
@@ -441,7 +441,7 @@ prompt_public_ip() {
     timediff=$(($(date +%s) - $(date -r $POWERLEVEL9K_PUBLIC_IP_FILE +%s)))
     [[ $timediff -gt $POWERLEVEL9K_PUBLIC_IP_TIMOUT ]] && refresh_ip=true
     # If tmp file is empty get a fresh IP
-    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) || $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ '$POWERLEVEL9K_PUBLIC_IP_NONE' ]] && refresh_ip=true
+    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) || $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ "$POWERLEVEL9K_PUBLIC_IP_NONE" ]] && refresh_ip=true
   else
     touch $POWERLEVEL9K_PUBLIC_IP_FILE && refresh_ip=true
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -433,21 +433,21 @@ prompt_public_ip() {
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
 
   # Do we need a fresh IP?
-  local refresh_ip=FALSE
+  local refresh_ip=false
   if [[ -f $POWERLEVEL9K_PUBLIC_IP_FILE ]]; then
     typeset -i timediff
     timediff=$(($(date +%s) - $(date -r $POWERLEVEL9K_PUBLIC_IP_FILE +%s)))
-    [[ $timediff -gt '500' ]] && refresh_ip=TRUE
+    [[ $timediff -gt '500' ]] && refresh_ip=true
     # this will run the IP refresh with each new prompt while disconnected
     # but will get a new IP immediately once reconnected rather than waiting
     # for the timeout, not sure if this is ideal behavior or not
-    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) ]] && refresh_ip=TRUE
+    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) ]] && refresh_ip=true
   else
-    touch $POWERLEVEL9K_PUBLIC_IP_FILE && refresh_ip=TRUE
+    touch $POWERLEVEL9K_PUBLIC_IP_FILE && refresh_ip=true
   fi
 
   # grab a fresh IP if needed
-  if [[ $refresh_ip =~ 'TRUE' && -w $POWERLEVEL9K_PUBLIC_IP_FILE ]]; then
+  if [[ $refresh_ip =~ true && -w $POWERLEVEL9K_PUBLIC_IP_FILE ]]; then
     if type -p dig >/dev/null; then
         fresh_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
         [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -441,7 +441,7 @@ prompt_public_ip() {
     timediff=$(($(date +%s) - $(date -r $POWERLEVEL9K_PUBLIC_IP_FILE +%s)))
     [[ $timediff -gt $POWERLEVEL9K_PUBLIC_IP_TIMOUT ]] && refresh_ip=true
     # If tmp file is empty get a fresh IP
-    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) || $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ $POWERLEVEL9K_PUBLIC_IP_NONE ]] && refresh_ip=true
+    [[ -z $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) || $(cat $POWERLEVEL9K_PUBLIC_IP_FILE) =~ '$POWERLEVEL9K_PUBLIC_IP_NONE' ]] && refresh_ip=true
   else
     touch $POWERLEVEL9K_PUBLIC_IP_FILE && refresh_ip=true
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -467,7 +467,7 @@ prompt_public_ip() {
   local public_ip=$(cat $POWERLEVEL9K_PUBLIC_IP_FILE)
 
   if [[ -n $public_ip ]]; then
-    $1_prompt_segment "$0" "$2" "black" "249" "${public_ip}" 'PUBLIC_IP_ICON'
+    $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" 'PUBLIC_IP_ICON'
   fi
 }
 


### PR DESCRIPTION
@bhilburn mentioned in #365 that he would be interested in a public ip segment, i hacked one together for review/discussion on behavior/icons/etc. Currently it will only poll for a new IP every 5 minutes which is configurable by the user. It saves the IP to a tmp file also configurable by the user. It will attempt to use dig to get your IP if it's installed, if not it will use either curl or wget to poll an IP checker host in the same manner that neofetch uses. Let me know what you all think.