### PR TITLE
Context host depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,17 @@ it, but only display it if you are not your normal user or on a remote host
 To use this feature, make sure the `context` segment is enabled in your prompt
 elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
 
+You can set the `POWERLEVEL9K_CONTEXT_HOST_DEPTH` variable to change how the
+hostname is displayed. See (ZSH Manual)[http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Login-information]
+for details. Default is set to %m which will show the hostname up to the first ‘.’
+You can set it to %{N}m where N is an integer to show that many segments of system
+hostname. Setting N to a negative integer will show that many segments from the
+end of the hostname.
+
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`DEFAULT_USER`|None|Username to consider a "default context" (you can also use `$USER`)|
+|`POWERLEVEL9K_CONTEXT_HOST_DEPTH`|%m|Customizable host depth on prompt|
 
 ##### dir
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -429,12 +429,13 @@ prompt_battery() {
 # Context: user@hostname (who am I and where am I)
 # Note that if $DEFAULT_USER is not set, this prompt segment will always print
 prompt_context() {
+  set_default POWERLEVEL9K_CONTEXT_HOST_DEPTH "%m"
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
     if [[ $(print -P "%#") == '#' ]]; then
       # Shell runs as root
-      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@$POWERLEVEL9K_CONTEXT_HOST_DEPTH"
     else
-      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@$POWERLEVEL9K_CONTEXT_HOST_DEPTH"
     fi
   fi
 }


### PR DESCRIPTION
I added a feature to the context segment to allow for customizable host depth on the prompt as outlined in the ZSH documentation here - http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Login-information. I use p9k across a range of servers across a range of sites at work and being able to customize the host depth to include the site is immensely helpful. Thought this might be useful to other folks too!