### PR TITLE
Change powerlevel9k_init to prompt_powerlevel9k_setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.5.0
+
+### `load` and `ram` changes
+
+These two segments now support BSD.
+
+### `vcs` changes
+
+- We implemented a huge speed improvement for this segment.
+- Now this segment supports Subversion repositories.
+- Add ability to hide tags by setting `POWERLEVEL9K_VCS_HIDE_TAGS` to true.
+
+## `anaconda` changes
+
+Speed improvements for `anaconda` segment.
+
 ## v0.4.0
 
 ### Development changes
@@ -76,6 +92,11 @@ Added new `docker_machine` segment that will show your Docker machine.
 
 A new segment `anaconda` was added that shows the current used
 anaconda environment.
+
+## New segment `pyenv` added
+
+This segment shows your active python version as reported by `pyenv`.
+
 
 ## v0.3.2
 

--- a/README.md
+++ b/README.md
@@ -412,4 +412,5 @@ portion of the wiki to get going.
 information!](https://github.com/bhilburn/powerlevel9k/wiki)
 
 ### License
-MIT
+Project: MIT
+Logo: CC-BY-SA. Source repository: https://github.com/bhilburn/powerlevel9k-logo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## powerlevel9k Theme for ZSH
-
+![](https://raw.githubusercontent.com/bhilburn/powerlevel9k-logo/master/logo-banner.png)
+---
 [![Build Status](https://travis-ci.org/bhilburn/powerlevel9k.svg?branch=next)](https://travis-ci.org/bhilburn/powerlevel9k)
 [![Join the chat at https://gitter.im/bhilburn/powerlevel9k](https://badges.gitter.im/bhilburn/powerlevel9k.svg)](https://gitter.im/bhilburn/powerlevel9k?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -412,5 +412,7 @@ portion of the wiki to get going.
 information!](https://github.com/bhilburn/powerlevel9k/wiki)
 
 ### License
+
 Project: MIT
+
 Logo: CC-BY-SA. Source repository: https://github.com/bhilburn/powerlevel9k-logo

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1040,7 +1040,7 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
   fi
 }
 
-powerlevel9k_init() {
+prompt_powerlevel9k_setup() {
   # Display a warning if the terminal does not support 256 colors
   local term_colors
   term_colors=$(echotc Co)
@@ -1092,5 +1092,5 @@ powerlevel9k_init() {
   add-zsh-hook precmd powerlevel9k_prepare_prompts
 }
 
-powerlevel9k_init "$@"
+prompt_powerlevel9k_setup "$@"
 


### PR DESCRIPTION
Changed init/setup function name to be compatible with zsh promptinit, zsh prompt function only lists themes with prompt_*_setup init/setup functions.

Allows use of this prompt directly with zsh's prompt system by running: 
`prompt powerlevel9k`
at the zsh command line