### PR TITLE
Anion155's hdd_usage segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Added an option to configure the path separator. If you want something
 else than an ordinary slash, you could set
 `POWERLEVEL9K_DIR_PATH_SEPARATOR` to whatever you want.
 
+### New segment 'hdd_usage' added
+
+This segment will show the usage level of your current partition.
+
 ## v0.5.0
 
 ### `load` and `ram` changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Added an option to configure the path separator. If you want something
 else than an ordinary slash, you could set
 `POWERLEVEL9K_DIR_PATH_SEPARATOR` to whatever you want.
 
-### New segment 'hdd_usage' added
+### New segment 'disk_usage' added
 
 This segment will show the usage level of your current partition.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The segments that are currently available are:
 * [`battery`](#battery) - Current battery status.
 * [`context`](#context) - Your username and host.
 * [`dir`](#dir) - Your current working directory.
-* [`hdd_usage`](#hdd_usage) - Disk usage of your current partition.
+* [`disk_usage`](#disk_usage) - Disk usage of your current partition.
 * `history` - The command number for the current line.
 * [`ip`](#ip) - Shows the current IP address.
 * [`public_ip`](#public_ip) - Shows your public IP address.
@@ -307,15 +307,15 @@ If you want to customize the directory separator, you could set:
 POWERLEVEL9K_DIR_PATH_SEPARATOR="%f "$'\uE0B1'" %F"
 ```
 
-##### hdd_usage
+##### disk_usage
 
-The `hdd_usage` segment will show the usage level of the partition that your current working directory resides in. It can be configured with the following variables.
+The `disk_usage` segment will show the usage level of the partition that your current working directory resides in. It can be configured with the following variables.
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|POWERLEVEL9K_HDD_USAGE_ONLY_WARNING|false|Hide the segment except when usage levels have hit warning or critical levels.|
-|POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL|90|The usage level that triggers a warning state.|
-|POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL|95|The usage level that triggers a critical state.|
+|POWERLEVEL9K_DISK_USAGE_ONLY_WARNING|false|Hide the segment except when usage levels have hit warning or critical levels.|
+|POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL|90|The usage level that triggers a warning state.|
+|POWERLEVEL9K_DISK_USAGE_CRITICAL_LEVEL|95|The usage level that triggers a critical state.|
 
 ##### ip
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The segments that are currently available are:
 * [`battery`](#battery) - Current battery status.
 * [`context`](#context) - Your username and host.
 * [`dir`](#dir) - Your current working directory.
+* [`hdd_usage`](#hdd_usage) - Disk usage of your current partition.
 * `history` - The command number for the current line.
 * [`ip`](#ip) - Shows the current IP address.
 * [`public_ip`](#public_ip) - Shows your public IP address.
@@ -305,6 +306,16 @@ If you want to customize the directory separator, you could set:
 # You'll need patched awesome-terminal fonts for that example
 POWERLEVEL9K_DIR_PATH_SEPARATOR="%f "$'\uE0B1'" %F"
 ```
+
+##### hdd_usage
+
+The `hdd_usage` segment will show the usage level of the partition that your current working directory resides in. It can be configured with the following variables.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|POWERLEVEL9K_HDD_USAGE_ONLY_WARNING|false|Hide the segment except when usage levels have hit warning or critical levels.|
+|POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL|90|The usage level that triggers a warning state.|
+|POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL|95|The usage level that triggers a critical state.|
 
 ##### ip
 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -34,7 +34,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uE891'              # 
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\uE894'              # 
-      HDD_ICON                       $'\uF0A0 '             # 
+      DISK_ICON                      $'\uE1AE '             # 
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -98,7 +98,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uF291'              # 
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\U1F50B'             # 🔋
-      HDD_ICON                       $'\uF0A0 '             # 
+      DISK_ICON                      $'\uF0A0 '             # 
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -158,7 +158,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      ''
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\U1F50B'             # 🔋
-      HDD_ICON                       $'HDD '
+      DISK_ICON                      $'hdd '
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -34,7 +34,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uE891'              # 
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\uE894'              # 
-      HDD_ICON                       $'\uD83D\uDDB4'        # 🖴
+      HDD_ICON                       $'\uF0A0 '             # 
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -158,6 +158,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      ''
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\U1F50B'             # 🔋
+      HDD_ICON                       $'HDD '
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -34,6 +34,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uE891'              # 
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\uE894'              # 
+      HDD_ICON                       $'\uD83D\uDDB4'        # 🖴
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
@@ -97,6 +98,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uF291'              # 
       TODO_ICON                      $'\u2611'              # ☑
       BATTERY_ICON                   $'\U1F50B'             # 🔋
+      HDD_ICON                       $'\uF0A0 '             # 
       OK_ICON                        $'\u2713'              # ✓
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -372,7 +372,7 @@ prompt_hdd_usage() {
   fi
 
   current_state='normal'
-  local message="$level%"
+  local message="$level% "
 
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
     current_state='warning'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -337,10 +337,10 @@ prompt_background_jobs() {
   fi
 }
 
-# Segment to indicate hdd available level.
+# Segment that indicates usage level of current partition.
 set_default POWERLEVEL9K_HDD_USAGE_ONLY_WARNING false
-set_default POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL 10
-set_default POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL 5
+set_default POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL 90
+set_default POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL 95
 prompt_hdd_usage() {
   local current_state="unknown"
   typeset -AH hdd_usage_forecolors
@@ -356,28 +356,20 @@ prompt_hdd_usage() {
     'critical'      'red'
   )
 
-  # local df="$(df -k . | sed -n '2p')"
-  # local size="$(echo $df | awk '{ print $2 }')"
-  # local avail="$(echo $df | awk '{ print $4 }')"
-  # local level="$(printf %.0f $(( avail * 100.0 / size )))"
-
   local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
-  level="$(( 100 - level ))"
 
-  if [ "$level" -gt "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
-    # Default behavior: Show message always
-    if [[ "$POWERLEVEL9K_HDD_USAGE_ONLY_WARNING" != false ]]; then
-      return
-    fi
-  fi
-
-  if [ "$level" -le "$POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL" ]; then
-    current_state='critical'
-  elif [ "$level" -le "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
+  if [ "$level" -ge "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
     current_state='warning'
+    if [ "$level" -ge "$POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL" ]; then
+        current_state='critical'
+    fi
   else
+    if [[ "$POWERLEVEL9K_HDD_USAGE_ONLY_WARNING" != false ]]; then
+        return
+    fi
     current_state='normal'
   fi
+
   local message="${level}%%"
 
   # Draw the prompt_segment

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -338,6 +338,9 @@ prompt_background_jobs() {
 }
 
 # Segment to indicate hdd available level.
+set_default POWERLEVEL9K_HDD_USAGE_ONLY_WARNING false
+set_default POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL 10
+set_default POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL 5
 prompt_hdd_usage() {
   local current_state="unknown"
   typeset -AH hdd_usage_forecolors
@@ -357,28 +360,28 @@ prompt_hdd_usage() {
   # local size="$(echo $df | awk '{ print $2 }')"
   # local avail="$(echo $df | awk '{ print $4 }')"
   # local level="$(printf %.0f $(( avail * 100.0 / size )))"
-  local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
-  level="$(( 100 - level ))"
 
-  set_default POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL 10
-  set_default POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL 5
+  # local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
+  # level="$(( 100 - level ))"
+  # level="3"
 
-  if [ $level -gt $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
+  set_default level 10
+
+  if [ "$level" -gt "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
     # Default behavior: Show message always
-    set_default POWERLEVEL9K_HDD_USAGE_ONLY_WARNING false
     if [[ "$POWERLEVEL9K_HDD_USAGE_ONLY_WARNING" != false ]]; then
       return
     fi
   fi
 
-  current_state='normal'
-  local message="${level}%"
-
-  if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
-    current_state='warning'
-  elif [ $level -le $POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL ]; then
+  if [ "$level" -le "$POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL" ]; then
     current_state='critical'
+  elif [ "$level" -le "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
+    current_state='warning'
+  else
+    current_state='normal'
   fi
+  local message="${level}%%"
 
   # Draw the prompt_segment
   if [[ -n $level ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -376,10 +376,8 @@ prompt_hdd_usage() {
 
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
     current_state='warning'
-    message="$message left"
   elif [ $level -le $POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL ]; then
     current_state='critical'
-    message="$message left"
   fi
 
   # Draw the prompt_segment

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -340,9 +340,15 @@ prompt_background_jobs() {
 # Segment to indicate hdd available level.
 prompt_hdd_usage() {
   local current_state="unknown"
-  typeset -AH hdd_usage_states
-  hdd_usage_states=(
-    'normal'        'green'
+  typeset -AH hdd_usage_forecolors
+  hdd_usage_forecolors=(
+    'normal'        'yellow'
+    'warning'       "$DEFAULT_COLOR"
+    'critical'      'white'
+  )
+  typeset -AH hdd_usage_backcolors
+  hdd_usage_backcolors=(
+    'normal'        $DEFAULT_COLOR
     'warning'       'yellow'
     'critical'      'red'
   )
@@ -366,18 +372,20 @@ prompt_hdd_usage() {
   fi
 
   current_state='normal'
+  local message="$level%"
+
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
     current_state='warning'
+    message="$message left"
   fi
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL ]; then
     current_state='critical'
+    message="$message left"
   fi
-
-  local message="$level"
 
   # Draw the prompt_segment
   if [[ -n $level ]]; then
-    "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${hdd_usage_states[$current_state]}" "$message" 'HDD_ICON'
+    "$1_prompt_segment" "${0}_${current_state}" "$2" "${hdd_usage_backcolors[$current_state]}" "${hdd_usage_forecolors[$current_state]}" "$message" 'HDD_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -377,8 +377,7 @@ prompt_hdd_usage() {
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
     current_state='warning'
     message="$message left"
-  fi
-  if [ $level -le $POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL ]; then
+  elif [ $level -le $POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL ]; then
     current_state='critical'
     message="$message left"
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -338,10 +338,10 @@ prompt_background_jobs() {
 }
 
 # Segment that indicates usage level of current partition.
-set_default POWERLEVEL9K_HDD_USAGE_ONLY_WARNING false
-set_default POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL 90
-set_default POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL 95
-prompt_hdd_usage() {
+set_default POWERLEVEL9K_DISK_USAGE_ONLY_WARNING false
+set_default POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL 90
+set_default POWERLEVEL9K_DISK_USAGE_CRITICAL_LEVEL 95
+prompt_disk_usage() {
   local current_state="unknown"
   typeset -AH hdd_usage_forecolors
   hdd_usage_forecolors=(
@@ -356,25 +356,26 @@ prompt_hdd_usage() {
     'critical'      'red'
   )
 
-  local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
+  local disk_usage="${$(\df -P . | sed -n '2p' | awk '{ print $5 }')%%\%}"
 
-  if [ "$level" -ge "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
+  if [ "$disk_usage" -ge "$POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL" ]; then
     current_state='warning'
-    if [ "$level" -ge "$POWERLEVEL9K_HDD_USAGE_CRITICAL_LEVEL" ]; then
+    if [ "$disk_usage" -ge "$POWERLEVEL9K_DISK_USAGE_CRITICAL_LEVEL" ]; then
         current_state='critical'
     fi
   else
-    if [[ "$POWERLEVEL9K_HDD_USAGE_ONLY_WARNING" != false ]]; then
+    if [[ "$POWERLEVEL9K_DISK_USAGE_ONLY_WARNING" == true ]]; then
+        current_state=''
         return
     fi
     current_state='normal'
   fi
 
-  local message="${level}%%"
+  local message="${disk_usage}%%"
 
   # Draw the prompt_segment
-  if [[ -n $level ]]; then
-    "$1_prompt_segment" "${0}_${current_state}" "$2" "${hdd_usage_backcolors[$current_state]}" "${hdd_usage_forecolors[$current_state]}" "$message" 'HDD_ICON'
+  if [[ -n $disk_usage ]]; then
+    "$1_prompt_segment" "${0}_${current_state}" "$2" "${hdd_usage_backcolors[$current_state]}" "${hdd_usage_forecolors[$current_state]}" "$message" 'DISK_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -372,7 +372,7 @@ prompt_hdd_usage() {
   fi
 
   current_state='normal'
-  local message="$level% "
+  local message="${level}%"
 
   if [ $level -le $POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL ]; then
     current_state='warning'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -361,11 +361,8 @@ prompt_hdd_usage() {
   # local avail="$(echo $df | awk '{ print $4 }')"
   # local level="$(printf %.0f $(( avail * 100.0 / size )))"
 
-  # local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
-  # level="$(( 100 - level ))"
-  # level="3"
-
-  set_default level 10
+  local level="${$(df -k . | sed -n '2p' | awk '{ print $5 }')%%\%}"
+  level="$(( 100 - level ))"
 
   if [ "$level" -gt "$POWERLEVEL9K_HDD_USAGE_WARNING_LEVEL" ]; then
     # Default behavior: Show message always


### PR DESCRIPTION
Okay, this is the revamped version of #352. I cherry-picked @anion155's commits onto a new branch and modified the behavior somewhat. It currently shows the usage level of the partition that your CWD resides on. I think it would be nice to make it possible for users to peg the segment to a specific partition, but that can be a future enhancement. Here is what it looks like:

![hdd_usage](https://cloud.githubusercontent.com/assets/569571/22171633/e7abcb38-df5f-11e6-8ee1-35aaa27a92e1.png)

It's working fine on my Linux system. It would be great to have a test from an OSX user, as well as a general code review.