### PR TITLE
Fix swift segment

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1065,11 +1065,9 @@ prompt_pyenv() {
 
 # Swift version
 prompt_swift_version() {
-  local swift_version=($(swift --version 2>/dev/null))
+  # Get the first number as this is probably the "main" version number..
+  local swift_version=$(swift --version 2>/dev/null | grep -o -E "[0-9.]+" | head -n 1)
   [[ -z "${swift_version}" ]] && return
-
-  # Extract semantic version
-  swift_version=$(echo ${swift_version} | sed -e 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
   "$1_prompt_segment" "$0" "$2" "magenta" "white" "${swift_version}" 'SWIFT_ICON'
 }


### PR DESCRIPTION
The regex for the swift segment matches too much (matched the "86" from `x86` as second). Here I simplified it to match the first number as this is probably the "main" version number. I assume the original creator of this segment (@thomaspaulmann) wanted the first number only (see https://twitter.com/thomaspaulmann/status/806078915546664960).

Before it matched:
![bildschirmfoto 2017-01-22 um 01 50 58](https://cloud.githubusercontent.com/assets/1544760/22178957/48317008-e045-11e6-83a2-09c2de9a38d9.png)

The new one just matches:
![bildschirmfoto 2017-01-22 um 01 52 00](https://cloud.githubusercontent.com/assets/1544760/22178963/6b2b851c-e045-11e6-8c0c-f0c22ed73fdb.png)

@thomaspaulmann This is probably the reason, why you coded `swift_version` as array. But this way it is simpler IMHO.

Disclaimer:
I found this issue in #344 and couldn't reproduce it there in a proper unit test. But it prevented other segments from rendering.