### PR TITLE
Fix error with truncating package name if repo is symlinked

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -587,7 +587,14 @@ prompt_dir() {
 
         # Get the path of the Git repo, which should have the package.json file
         if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == "true" ]]; then
-          package_path=$(git rev-parse --show-toplevel)
+          # Get path from the root of the git repository to the current dir
+          local gitPath=$(git rev-parse --show-prefix)
+          # Remove trailing slash from git path, so that we can
+          # remove that git path from the pwd.
+          gitPath=${gitPath%/}
+          package_path=${$(pwd)%%$gitPath}
+          # Remove trailing slash
+          package_path=${package_path%/}
         elif [[ $(git rev-parse --is-inside-git-dir 2> /dev/null) == "true" ]]; then
           package_path=${$(pwd)%%/.git*}
         fi


### PR DESCRIPTION
There is a bug with `truncate_with_package_name` truncation strategy if the repo is symlinked. I encountered this bug, when writing a test for that strategy in #344 , as the temp dir in OSX is actually a symlink to `/private/tmp`.
The problem is that `git rev-parse --show-toplevel` always shows the real path on the file system that, if symlinked, is not the root path to the repo. Despite that using `git` to find the root path of a repository, where potentially a `package.json` lies is not the best way, this PR just fixes the truncation problem. A better way would be going up a directory, until a package.json is dicovered (similar to @BenoitAverty approach in #353).

In a folder `/tmp/repo/1/12/123/1234/12345/123456/1234567/12345678/123456789`, with a `package.json` in `/tmp/repo` the truncation looked

before: `My_Package3/12…/12…/12…/12…/12…/123456789`
after: `My_Package/1/12/123/12…/12…/12…/12…/12…/123456789`
