### PR TITLE
Added support for customizable context segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,19 @@ it, but only display it if you are not your normal user or on a remote host
 (basically, only print it when it's likely you need it).
 
 To use this feature, make sure the `context` segment is enabled in your prompt
-elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`:
+elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`.
+
+You can customize the `context` segment. For example, you can make it to print the
+full hostname by setting
+```
+POWERLEVEL9K_CONTEXT_TEMPLATE="%n@`hostname -f`"
+```
+
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`DEFAULT_USER`|None|Username to consider a "default context" (you can also use `$USER`)|
+|`POWERLEVEL9K_CONTEXT_TEMPLATE`|%n@%m|Default context prompt (username@machine). Refer to the [ZSH Documentation](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html) for all possible expansions|
 
 ##### dir
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -433,15 +433,16 @@ prompt_battery() {
   fi
 }
 
+set_default POWERLEVEL9K_CONTEXT_TEMPLATE "%n@%m"
 # Context: user@hostname (who am I and where am I)
 # Note that if $DEFAULT_USER is not set, this prompt segment will always print
 prompt_context() {
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
     if [[ $(print -P "%#") == '#' ]]; then
       # Shell runs as root
-      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$USER@%m"
+      "$1_prompt_segment" "$0_ROOT" "$2" "$DEFAULT_COLOR" "yellow" "$POWERLEVEL9K_CONTEXT_TEMPLATE"
     else
-      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$USER@%m"
+      "$1_prompt_segment" "$0_DEFAULT" "$2" "$DEFAULT_COLOR" "011" "$POWERLEVEL9K_CONTEXT_TEMPLATE"
     fi
   fi
 }


### PR DESCRIPTION
I noticed that the context segment lacks support for customization. It uses `"%n@%m"`, which is username@machine. Machine is usually not including the `FQDN`, so when I have several machines which are named `www1` but have other `FQDNs` (like `www1.foo.example.org` and `www1.bar.example.org`) I don't have a clue if I'm on the correct machine.

This patch allows the user to change the `context` template to their desires. I included the new option in the `README` file and gave an example on how to print the full hostname.
