### PR TITLE
Simplify `public_ip` segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ segment will not be displayed.
 |`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p8k_public_ip'|This is the file your public IP is cached in.|
 |`POWERLEVEL9K_PUBLIC_IP_HOST`|'http://ident.me'|This is the default host to get your public IP.|
 |`POWERLEVEL9K_PUBLIC_IP_TIMEOUT`|300|The amount of time in seconds between refreshing your cached IP.|
-|`POWERLEVEL9K_PUBLIC_IP_METHOD`|None|You can set this to any of 'dig', 'curl', or 'wget' to only use that method to refresh your IP.|
+|`POWERLEVEL9K_PUBLIC_IP_METHODS`|(dig curl wget)| These methods in that order are used to refresh your IP.|
 |`POWERLEVEL9K_PUBLIC_IP_NONE`|None|The string displayed when an IP was not obtained|
 
 ##### rbenv

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -475,6 +475,7 @@ prompt_public_ip() {
   set_default POWERLEVEL9K_PUBLIC_IP_NONE ""
   set_default POWERLEVEL9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
+  defined POWERLEVEL9K_PUBLIC_IP_METHODS || POWERLEVEL9K_PUBLIC_IP_METHODS=(wget curl dig)
 
   # Do we need a fresh IP?
   local refresh_ip=false
@@ -491,51 +492,33 @@ prompt_public_ip() {
   fi
 
   # grab a fresh IP if needed
+  local fresh_ip
   if [[ $refresh_ip =~ true && -w $POWERLEVEL9K_PUBLIC_IP_FILE ]]; then
-    # if method specified, don't use fallback methods
-    if [[ -n $POWERLEVEL9K_PUBLIC_IP_METHOD ]] && [[ $POWERLEVEL9K_PUBLIC_IP_METHOD =~ 'wget|curl|dig' ]]; then
-      local method=$POWERLEVEL9K_PUBLIC_IP_METHOD
-    fi
-    if [[ -n $method ]]; then
+    for method in "${POWERLEVEL9K_PUBLIC_IP_METHODS[@]}"; do
       case $method in
         'dig')
-          if type -p dig >/dev/null; then
-              fresh_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
-              [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip
-          fi
+            fresh_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
+            [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip
           ;;
         'curl')
-          if [[ -z "$fresh_ip" ]] && type -p curl >/dev/null; then
-              fresh_ip="$(curl --max-time 10 -w '\n' "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
-          fi
+            fresh_ip="$(curl --max-time 10 -w '\n' "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
           ;;
         'wget')
-          if [[ -z "$fresh_ip" ]] && type -p wget >/dev/null; then
-              fresh_ip="$(wget -T 10 -qO- "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
-          fi
+            fresh_ip="$(wget -T 10 -qO- "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
           ;;
       esac
-    else
-      if type -p dig >/dev/null; then
-          fresh_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
-          [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip
+      # If we found a fresh IP, break loop.
+      if [[ -n "${fresh_ip}" ]]; then
+        break;
       fi
-
-      if [[ -z "$fresh_ip" ]] && type -p curl >/dev/null; then
-          fresh_ip="$(curl --max-time 10 -w '\n' "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
-      fi
-
-      if [[ -z "$fresh_ip" ]] && type -p wget >/dev/null; then
-          fresh_ip="$(wget -T 10 -qO- "$POWERLEVEL9K_PUBLIC_IP_HOST" 2> /dev/null)"
-      fi
-    fi
+    done
 
     # write IP to tmp file or clear tmp file if an IP was not retrieved
     [[ -n $fresh_ip ]] && echo $fresh_ip > $POWERLEVEL9K_PUBLIC_IP_FILE || echo $POWERLEVEL9K_PUBLIC_IP_NONE > $POWERLEVEL9K_PUBLIC_IP_FILE
   fi
 
   # read public IP saved to tmp file
-  local public_ip=$(cat $POWERLEVEL9K_PUBLIC_IP_FILE)
+  local public_ip="$(cat $POWERLEVEL9K_PUBLIC_IP_FILE)"
 
   if [[ -n $public_ip ]]; then
     $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" 'PUBLIC_IP_ICON'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -475,7 +475,7 @@ prompt_public_ip() {
   set_default POWERLEVEL9K_PUBLIC_IP_NONE ""
   set_default POWERLEVEL9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   set_default POWERLEVEL9K_PUBLIC_IP_HOST "http://ident.me"
-  defined POWERLEVEL9K_PUBLIC_IP_METHODS || POWERLEVEL9K_PUBLIC_IP_METHODS=(wget curl dig)
+  defined POWERLEVEL9K_PUBLIC_IP_METHODS || POWERLEVEL9K_PUBLIC_IP_METHODS=(dig curl wget)
 
   # Do we need a fresh IP?
   local refresh_ip=false


### PR DESCRIPTION
I changed the `POWERLEVEL9K_PUBLIC_IP_METHOD` to an array. That way the code could be simplified a lot.

/cc @rjorgenson 