### PR TITLE
Fix theme for use with plain "prompt" command

### DIFF
--- a/prompt_powerlevel9k_setup
+++ b/prompt_powerlevel9k_setup
@@ -1,0 +1,1 @@
+powerlevel9k.zsh-theme


### PR DESCRIPTION
ZSH has the ability to preview and set themes directly from the `prompt`
builtin. To do so, the theme must be in FPATH and named
"prompt_theme_setup".

This PR adds a symlink pointing `powerlevel9k.zsh-theme` to `prompt_powerlevel9k_setup`. For full compatibility with `prompt` builtin, we still need to add our functions to `FPATH` though.