### PR TITLE
Add ability to omit the first character in dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,12 @@ the path shown would be `my-cool-project`.  If you navigate to `$HOME/projects/m
 
 If you want to customize the directory separator, you could set:
 ```zsh
-# You'll need patched awesome-terminal fonts for that example
-POWERLEVEL9K_DIR_PATH_SEPARATOR="%f "$'\uE0B1'" %F"
+# Double quotes are important here!
+POWERLEVEL9K_DIR_PATH_SEPARATOR="%F{red} $(print_icon 'LEFT_SUBSEGMENT_SEPARATOR') %F{black}"
 ```
+To omit the first character (usually a slash that gets replaced if you set `POWERLEVEL9K_DIR_PATH_SEPARATOR`),
+you could set `POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true`.
+
 
 ##### disk_usage
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -611,7 +611,7 @@ prompt_dir() {
         fi
       ;;
       *)
-        current_path="%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c"
+        current_path="$(print -P "%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c")"
       ;;
     esac
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -570,7 +570,7 @@ prompt_custom() {
 # Dir: current working directory
 set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
 prompt_dir() {
-  local current_path='%~'
+  local current_path="$(print -P "%~")"
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" ]]; then
 
     set_default POWERLEVEL9K_SHORTEN_DELIMITER $'\U2026'
@@ -621,7 +621,7 @@ prompt_dir() {
   fi
 
   if [[ "${POWERLEVEL9K_DIR_PATH_SEPARATOR}" != "/" ]]; then
-    current_path=$(print -P "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")
+    current_path="$( echo "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")"
   fi
 
   typeset -AH dir_states

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -616,6 +616,10 @@ prompt_dir() {
     esac
   fi
 
+  if [[ "${POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER}" == "true" ]]; then
+    current_path="${current_path[2,-1]}"
+  fi
+
   if [[ "${POWERLEVEL9K_DIR_PATH_SEPARATOR}" != "/" ]]; then
     current_path=$(print -P "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")
   fi

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -10,86 +10,108 @@ function setUp() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source functions/*
+
+  # Unset mode, so that user settings
+  # do not interfere with tests
+  unset POWERLEVEL9K_MODE
 }
 
 function testJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
+  cd /tmp
 
-  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black}%F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black}%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  cd -
 }
 
 function testTransitiveJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
+  cd /tmp
 
-  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black}%F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black}%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  cd -
 }
 
 function testJoiningWithConditionalSegment() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
+  cd /tmp
 
-  assertEquals "%K{blue} %F{black}%~ %K{blue}%F{black} %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  cd -
 }
 
 function testDynamicColoringOfSegmentsWork() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
-  POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND='red'
+  POWERLEVEL9K_DIR_DEFAULT_BACKGROUND='red'
+  cd /tmp
 
-  assertEquals "%K{red} %F{black}%~ %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{black}/tmp %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
+  unset POWERLEVEL9K_DIR_DEFAULT_BACKGROUND
+  cd -
 }
 
 function testDynamicColoringOfVisualIdentifiersWork() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
-  POWERLEVEL9K_MODE='awesome-patched'
-  POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR='green'
+  POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR='green'
+  POWERLEVEL9K_FOLDER_ICON="icon-here"
 
-  # Re-Source the icons, as the POWERLEVEL9K_MODE is directly
-  # evaluated there.
-  source functions/icons.zsh
+  cd /tmp
 
-  assertEquals "%K{blue} %F{green%}%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{green%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_MODE
-  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR
+  unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
+  unset POWERLEVEL9K_FOLDER_ICON
+  cd -
 }
 
 function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
-  POWERLEVEL9K_MODE='awesome-patched'
-  POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR='green'
-  POWERLEVEL9K_DIR_HOME_SUBFOLDER_FOREGROUND='red'
-  POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND='yellow'
+  POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR='green'
+  POWERLEVEL9K_DIR_DEFAULT_FOREGROUND='red'
+  POWERLEVEL9K_DIR_DEFAULT_BACKGROUND='yellow'
+  POWERLEVEL9K_FOLDER_ICON="icon-here"
 
   # Re-Source the icons, as the POWERLEVEL9K_MODE is directly
   # evaluated there.
   source functions/icons.zsh
 
-  assertEquals "%K{yellow} %F{green%}%f %F{red}%~ %k%F{yellow}%f " "$(build_left_prompt)"
+  cd /tmp
+
+  assertEquals "%K{yellow} %F{green%}icon-here%f %F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_MODE
-  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_VISUAL_IDENTIFIER_COLOR
-  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_FOREGROUND
-  unset POWERLEVEL9K_DIR_HOME_SUBFOLDER_BACKGROUND
+  unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
+  unset POWERLEVEL9K_DIR_DEFAULT_FOREGROUND
+  unset POWERLEVEL9K_DIR_DEFAULT_BACKGROUND
+  unset POWERLEVEL9K_FOLDER_ICON
+  cd -
 }
 
 function testOverwritingIconsWork() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
-  POWERLEVEL9K_HOME_SUB_ICON='icon-here'
+  POWERLEVEL9K_FOLDER_ICON='icon-here'
+  #local testFolder=$(mktemp -d -p p9k)
+  # Move testFolder under home folder
+  #mv testFolder ~
+  # Go into testFolder
+  #cd ~/$testFolder
 
-  assertEquals "%K{blue} %F{black%}icon-here%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  cd /tmp
+  assertEquals "%K{blue} %F{black%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_DIR_HOME_SUB_ICON
+  unset POWERLEVEL9K_DIR_FOLDER_ICON
+  cd -
+  # rm -fr ~/$testFolder
 }
 
 source shunit2/source/2.1/src/shunit2

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -9,10 +9,16 @@ function setUp() {
   export TERM="xterm-256color"
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
+
+  # Every test should at least use the dir segment
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+}
+
+function tearDown() {
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
 }
 
 function testTruncateFoldersWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_folders'
 
@@ -20,19 +26,17 @@ function testTruncateFoldersWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}%3(c:…/:)%2c %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}…/12345678/123456789 %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
 
   unset FOLDER
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
   unset POWERLEVEL9K_SHORTEN_STRATEGY
 }
 
 function testTruncateMiddleWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_middle'
 
@@ -47,12 +51,10 @@ function testTruncateMiddleWorks() {
 
   unset FOLDER
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
   unset POWERLEVEL9K_SHORTEN_STRATEGY
 }
 
 function testTruncationFromRightWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_from_right'
 
@@ -66,52 +68,45 @@ function testTruncationFromRightWorks() {
   rm -fr /tmp/powerlevel9k-test
 
   unset FOLDER
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
   unset POWERLEVEL9K_SHORTEN_STRATEGY
 }
 
 function testHomeFolderDetectionWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_HOME_ICON='home-icon'
 
   cd ~
-  assertEquals "%K{blue} %F{black%}home-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}home-icon%f %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_HOME_ICON
 }
 
 function testHomeSubfolderDetectionWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_HOME_SUB_ICON='sub-icon'
 
   FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}sub-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}sub-icon%f %F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
   unset FOLDER
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_HOME_SUB_ICON
 }
 
 function testOtherFolderDetectionWorks() {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
   POWERLEVEL9K_FOLDER_ICON='folder-icon'
 
   FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}%~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
   unset FOLDER
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_FOLDER_ICON
 }
 

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -110,4 +110,107 @@ function testOtherFolderDetectionWorks() {
   unset POWERLEVEL9K_FOLDER_ICON
 }
 
+function testChangingDirPathSeparator() {
+  POWERLEVEL9K_DIR_PATH_SEPARATOR='xXx'
+  local FOLDER="/tmp/powerlevel9k-test/1/2"
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{blue} %F{black}xXxtmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  unset FOLDER
+  rm -fr /tmp/powerlevel9k-test
+  unset POWERLEVEL9K_DIR_PATH_SEPARATOR
+}
+
+function testOmittingFirstCharacterWorks() {
+  POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
+  POWERLEVEL9K_FOLDER_ICON='folder-icon'
+  cd /tmp
+
+  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  unset POWERLEVEL9K_FOLDER_ICON
+  unset POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER
+}
+
+function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
+  POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
+  POWERLEVEL9K_DIR_PATH_SEPARATOR='xXx'
+  POWERLEVEL9K_FOLDER_ICON='folder-icon'
+  mkdir -p /tmp/powerlevel9k-test/1/2
+  cd /tmp/powerlevel9k-test/1/2
+
+  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+  unset POWERLEVEL9K_FOLDER_ICON
+  unset POWERLEVEL9K_DIR_PATH_SEPARATOR
+  unset POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER
+}
+
+# This test makes it obvious that combining a truncation strategy
+# that cuts off folders from the left and omitting the the first
+# character does not make much sense. The truncation strategy
+# comes first, prints an ellipsis and that gets then cut off by
+# POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER..
+# But it does more sense in combination with other truncation
+# strategies.
+function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndDefaultTruncation() {
+  POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
+  POWERLEVEL9K_DIR_PATH_SEPARATOR='xXx'
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_folders'
+  mkdir -p /tmp/powerlevel9k-test/1/2
+  cd /tmp/powerlevel9k-test/1/2
+
+  assertEquals "%K{blue} %F{black}xXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+  unset POWERLEVEL9K_DIR_PATH_SEPARATOR
+  unset POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
+function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndMiddleTruncation() {
+  POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
+  POWERLEVEL9K_DIR_PATH_SEPARATOR='xXx'
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_middle'
+  mkdir -p /tmp/powerlevel9k-test/1/2
+  cd /tmp/powerlevel9k-test/1/2
+
+  assertEquals "%K{blue} %F{black}tmpxXxpo…stxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+  unset POWERLEVEL9K_DIR_PATH_SEPARATOR
+  unset POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
+function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndRightTruncation() {
+  POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
+  POWERLEVEL9K_DIR_PATH_SEPARATOR='xXx'
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  POWERLEVEL9K_SHORTEN_STRATEGY='truncate_from_right'
+  mkdir -p /tmp/powerlevel9k-test/1/2
+  cd /tmp/powerlevel9k-test/1/2
+
+  assertEquals "%K{blue} %F{black}tmpxXxpo…xXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+  unset POWERLEVEL9K_DIR_PATH_SEPARATOR
+  unset POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+  unset POWERLEVEL9K_SHORTEN_STRATEGY
+}
+
 source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
As @Hebgbs suggested in the chat, here is the option to omit the first character in dir segment.

Before (with `POWERLEVEL9K_DIR_PATH_SEPARATOR` set):
![bildschirmfoto 2017-01-30 um 21 13 02](https://cloud.githubusercontent.com/assets/1544760/22439730/1901272c-e731-11e6-947e-705a5430cde9.png)

After:
![bildschirmfoto 2017-01-30 um 20 52 48](https://cloud.githubusercontent.com/assets/1544760/22439745/22000672-e731-11e6-8991-babe8194c897.png)

@Hebgbs Could you confirm that this is what you wanted?