### PR TITLE
Update awesome-fontconfig SERVER_ICON to 

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -109,7 +109,7 @@ case $POWERLEVEL9K_MODE in
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF0E4'              # 
       RAM_ICON                       $'\uF0E4'              # 
-      SERVER_ICON                    $'\uF296'              # 
+      SERVER_ICON                    $'\uF233'              # 
       VCS_UNTRACKED_ICON             $'\uF059'              # 
       VCS_UNSTAGED_ICON              $'\uF06A'              # 
       VCS_STAGED_ICON                $'\uF055'              # 


### PR DESCRIPTION
Hey!

I've added the `docker_machine` segment to my prompt by the icon looked a bit odd ([gitlab](http://fontawesome.io/icon/gitlab/) icon). This change should changed it to  [server icon](http://fontawesome.io/icon/server/).

Thanks for the awesome prompt! 