### PR TITLE
Adding option POWERLEVEL9K_PROMPT_ADD_NEWLINE

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1014,7 +1014,7 @@ powerlevel9k_prepare_prompts() {
   RETVAL=$?
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
-    PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
+    PROMPT="\n$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
 $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
     if [[ "$POWERLEVEL9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1014,7 +1014,7 @@ powerlevel9k_prepare_prompts() {
   RETVAL=$?
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
-    PROMPT="\n$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
+    PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
 $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
     if [[ "$POWERLEVEL9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left
@@ -1038,6 +1038,9 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
   if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
     RPROMPT="$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX"
   fi
+NEWLINE='
+'
+  [[ $POWERLEVEL9K_PROMPT_ADD_NEWLINE == true ]] && PROMPT="$NEWLINE$PROMPT"
 }
 
 powerlevel9k_init() {


### PR DESCRIPTION
This is a simple request to add option POWERLEVEL9K_PROMPT_ADD_NEWLINE.  Solving 

When set to True, we can have this nice tidy blank line between each prompt:
![image](https://cloud.githubusercontent.com/assets/13166286/23095963/5b3d05da-f64e-11e6-8334-58e9cb1da3ab.png)

Before forking, I tried using '\n' as left prompt leading char.  It doesn't work since `echo -n` eliminates trailing new line.  So I referenced the option from [bullet-train.zsh](https://github.com/caiogondim/bullet-train.zsh).
