### PR TITLE
Hide error when no origin in git repo

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -111,7 +111,7 @@ function +vi-hg-bookmarks() {
 function +vi-vcs-detect-changes() {
   if [[ "${hook_com[vcs]}" == "git" ]]; then
 
-    local remote=`git ls-remote --get-url`
+    local remote=$(git ls-remote --get-url 2> /dev/null)
     if [[ "$remote" =~ "github" ]] then
       vcs_visual_identifier='VCS_GIT_GITHUB_ICON'
     elif [[ "$remote" =~ "bitbucket" ]] then


### PR DESCRIPTION
Hi,

Sorry for coming with this so late in time. But  I missed some details when calling `git ls-remote`, this fix git ls-remote call; match [suggested code](https://github.com/bhilburn/powerlevel9k/pull/360#discussion_r93804449) for redirect errors to null when no origin is in git repo.

Related to [PR 360](https://github.com/bhilburn/powerlevel9k/pull/360)

thanks!