### PR TITLE
Add FreeBSD VM

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -12,3 +12,11 @@ Tests in separate files under `test/functions`.
 
 These Tests tend to be more complex in setup than the basic tests. To avoid ending
 up in a huge single file, there is one file per segment in `test/segments`.
+
+# Test-VMs
+
+If unit tests are not sufficient (e.g. you have an issue with your prompt that
+occurs only in a specific ZSH framework), then you could use our Test-VMs!
+Currently there are two test VMs. `test-vm` is an Ubuntu machine with several
+pre-installed ZSH frameworks. And there is `test-bsd-vm` which is a FreeBSD!
+For how to run the machines see [here](test-vm/README.md).

--- a/test-bsd-vm/Vagrantfile
+++ b/test-bsd-vm/Vagrantfile
@@ -38,6 +38,13 @@ Vagrant.configure("2") do |config|
   # your network.
   #config.vm.network "public_network"
 
+  # The BSD base box does not define a MAC address. Whysoever.
+  config.vm.base_mac = "8AAB4975994A"
+
+  # There is no BASH for root on BSD. We need to set another shell.
+  # See https://www.freebsd.org/doc/en/articles/linux-users/shells.html
+  config.ssh.shell = "/bin/csh"
+
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third

--- a/test-bsd-vm/Vagrantfile
+++ b/test-bsd-vm/Vagrantfile
@@ -1,0 +1,79 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "freebsd/FreeBSD-11.0-STABLE"
+
+  # Bootstrap
+  config.vm.provision :shell, path: "bootstrap-zero.sh", privileged: true
+  config.vm.provision :shell, path: "bootstrap.sh", privileged: false
+  config.vm.provision :shell, path: "../test-vm-providers/plain.sh", privileged: false
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  #config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "..", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  config.vm.provider "virtualbox" do |vb|
+
+     # Change name to "powerlevel9k-bsd"
+     vb.name = "powerlevel9k-bsd"
+
+     # Display the VirtualBox GUI when booting the machine
+     #vb.gui = true
+  
+     # Customize the amount of memory on the VM:
+     vb.memory = "256"
+  end
+  
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/test-bsd-vm/Vagrantfile
+++ b/test-bsd-vm/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.33.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -43,13 +43,14 @@ Vagrant.configure("2") do |config|
 
   # There is no BASH for root on BSD. We need to set another shell.
   # See https://www.freebsd.org/doc/en/articles/linux-users/shells.html
-  config.ssh.shell = "/bin/csh"
+  config.ssh.shell = "/bin/sh"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "..", "/vagrant_data"
+  config.vm.synced_folder "..", "/vagrant_data", type: "nfs"
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/test-bsd-vm/bootstrap-zero.sh
+++ b/test-bsd-vm/bootstrap-zero.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pkg install -y sudo

--- a/test-bsd-vm/bootstrap.sh
+++ b/test-bsd-vm/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Install ZSH
+sudo pkg install -y zsh
+sudo chsh -s `which zsh` vagrant

--- a/test-bsd-vm/bootstrap.sh
+++ b/test-bsd-vm/bootstrap.sh
@@ -3,3 +3,6 @@
 # Install ZSH
 sudo pkg install -y zsh
 sudo chsh -s `which zsh` vagrant
+
+# Install git
+sudo pkg install -y git

--- a/test-vm-providers/plain.sh
+++ b/test-vm-providers/plain.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/zsh
+
+echo 'source /vagrant_data/powerlevel9k.zsh-theme' > ~/.zshrc

--- a/test-vm-providers/plain.sh
+++ b/test-vm-providers/plain.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/zsh
 
-echo 'source /vagrant_data/powerlevel9k.zsh-theme' > ~/.zshrc
+echo 'LANG=en_US.UTF-8' !> ~/.zshrc
+echo 'source /vagrant_data/powerlevel9k.zsh-theme' >> ~/.zshrc

--- a/test-vm/Vagrantfile
+++ b/test-vm/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
 
   # Bootstrap
   config.vm.provision :shell, path: "bootstrap.sh", privileged: false
-  config.vm.provision :shell, path: "plain.sh", privileged: false
+  config.vm.provision :shell, path: "../test-vm-providers/plain.sh", privileged: false
   config.vm.provision :shell, path: "antigen.sh"
   config.vm.provision :shell, path: "prezto.sh"
   config.vm.provision :shell, path: "omz.sh"

--- a/test-vm/plain.sh
+++ b/test-vm/plain.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/zsh
-
-echo 'source /vagrant_data/powerlevel9k.zsh-theme' > ~/.zshrc


### PR DESCRIPTION
This PR adds a BSD box, so we can easily test P9K there (like #415 and #422). Works the same as the ubuntu VM.

## TODO
I want to move the other ZSH-Framework-Providers into the share `test-vm-providers`, so that we can install that frameworks in the BSD machine as well.

## Prerequisites
You need to install [vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/).

## Working with the VM
  1. Go into the according directory (either `test-vm` or `test-bsd-vm`)
  2. Type `vagrant up` in your terminal (may take a while at first startup)
  3. SSH into the machine via `vagrant ssh`
  4. When you are done, log out of the machine and type `vagrant halt`