### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,28 +29,28 @@ else than an ordinary slash, you could set
 Now `composer.json` files are searched as well. By default `package.json` still takes
 precedence. If you want to change that, set `POWERLEVEL9K_DIR_PACKAGE_FILES=(composer.json package.json)`.
 
-### New segment 'command_execution_time' added
+### New segment `command_execution_time` added
 
 Shows the duration a command needed to run. By default only durations over 3 seconds
 are shown (can be adjusted by setting POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD).
 
-### New segment 'dir_writable' added
+### New segment `dir_writable` added
 
 This segment displays a lock icon if your user has no write permissions in the current folder.
 
-### New segment 'disk_usage' added
+### New segment `disk_usage` added
 
 This segment will show the usage level of your current partition.
 
-### New segment 'public_ip' added
+### New segment `public_ip` added
 
 Fetches your Public IP (using ident.me) and displays it in your prompt.
 
-### New segment 'swift_version' added
+### New segment `swift_version` added
 
 This segment displays the version of Swift that is installed / in your path.
 
-### New segment 'detect_virt' added
+### New segment `detect_virt` added
 
 Detects and reports if you are in a virtualized session using `systemd`.
 


### PR DESCRIPTION
Just a little formatting fix for the changelog, so that it reads beautiful on [github](https://github.com/dritter/powerlevel9k/blob/fix_changelog/CHANGELOG.md) ([master for comparison](https://github.com/bhilburn/powerlevel9k/blob/master/CHANGELOG.md)).

Btw. this belongs to master, but is not very important. That's why I based it against `next`.