### PR TITLE
Protect special characters in various modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ script:
   - test/powerlevel9k.spec
   - test/functions/utilities.spec
   - test/functions/colors.spec
+  - test/functions/icons.spec
   - test/segments/command_execution_time.spec
   - test/segments/dir.spec
   - test/segments/rust_version.spec
   - test/segments/go_version.spec
   - test/segments/vcs.spec
-

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -86,6 +86,8 @@ case $POWERLEVEL9K_MODE in
   'awesome-fontconfig')
     # fontconfig with awesome-font required! See
     # https://github.com/gabrielelana/awesome-terminal-fonts
+    # Set the right locale to protect special characters
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
     icons=(
       LEFT_SEGMENT_SEPARATOR         $'\uE0B0'              # 
       RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'              # 
@@ -149,6 +151,8 @@ case $POWERLEVEL9K_MODE in
   'nerdfont-fontconfig')
     # nerd-font patched (complete) font required! See
     # https://github.com/ryanoasis/nerd-fonts
+    # Set the right locale to protect special characters
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
     icons=(
       LEFT_SEGMENT_SEPARATOR         $'\uE0B0'              # 
       RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'              # 
@@ -205,6 +209,8 @@ case $POWERLEVEL9K_MODE in
   *)
     # Powerline-Patched Font required!
     # See https://github.com/Lokaltog/powerline-fonts
+    # Set the right locale to protect special characters
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
     icons=(
       LEFT_SEGMENT_SEPARATOR         $'\uE0B0'              # 
       RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'              # 
@@ -270,6 +276,8 @@ esac
 # Override the above icon settings with any user-defined variables.
 case $POWERLEVEL9K_MODE in
   'flat')
+    # Set the right locale to protect special characters
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
     icons[LEFT_SEGMENT_SEPARATOR]=''
     icons[RIGHT_SEGMENT_SEPARATOR]=''
     icons[LEFT_SUBSEGMENT_SEPARATOR]='|'

--- a/test/functions/icons.spec
+++ b/test/functions/icons.spec
@@ -1,0 +1,74 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+    # Store old value for LC_CTYPE
+    _OLD_LC_CTYPE="${LC_CTYPE}"
+    # Reset actual LC_CTYPE
+    unset LC_CTYPE
+
+    # Store old P9K mode
+    _OLD_P9K_MODE="${POWERLEVEL9K_MODE}"
+}
+
+function tearDown() {
+    # Restore LC_CTYPE
+    LC_CTYPE="${_OLD_LC_CTYPE}"
+
+    # Restore old P9K mode
+    POWERLEVEL9K_MODE="${_OLD_P9K_MODE}"
+}
+
+function testLcCtypeIsSetCorrectlyInDefaultMode() {
+  POWERLEVEL9K_MODE="default"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+function testLcCtypeIsSetCorrectlyInAwesomePatchedMode() {
+  POWERLEVEL9K_MODE="awesome-patched"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+function testLcCtypeIsSetCorrectlyInAwesomeFontconfigMode() {
+  POWERLEVEL9K_MODE="awesome-fontconfig"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+function testLcCtypeIsSetCorrectlyInNerdfontFontconfigMode() {
+  POWERLEVEL9K_MODE="nerdfont-fontconfig"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+function testLcCtypeIsSetCorrectlyInFlatMode() {
+  POWERLEVEL9K_MODE="flat"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+function testLcCtypeIsSetCorrectlyInCompatibleMode() {
+  POWERLEVEL9K_MODE="compatible"
+  # Load Powerlevel9k
+  source functions/icons.zsh
+
+  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/functions/icons.spec
+++ b/test/functions/icons.spec
@@ -71,4 +71,256 @@ function testLcCtypeIsSetCorrectlyInCompatibleMode() {
   assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
 }
 
+# Go through all icons defined in default mode, and
+# check if all of them are defined in the other modes.
+function testAllIconsAreDefinedLikeInDefaultMode() {
+  # Always compare against this mode
+  local _P9K_TEST_MODE="default"
+  POWERLEVEL9K_MODE="${_P9K_TEST_MODE}"
+  source functions/icons.zsh
+  # _ICONS_UNDER_TEST is an array of just the keys of $icons.
+  # We later check via (r) "subscript" flag that our key
+  # is in the values of our flat array.
+  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+
+  # Switch to "awesome-patched" mode
+  POWERLEVEL9K_MODE="awesome-patched"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    # Iterate over all keys found in the _ICONS_UNDER_TEST
+    # array and compare it with the icons array of the
+    # current POWERLEVEL9K_MODE.
+    # Use parameter expansion, to directly check if the
+    # key exists in the flat current array of keys. That
+    # is quite complicated, but there seems no easy way
+    # to check the mere existance of a key in an array.
+    # The usual way would always return the value, so that
+    # would do the wrong thing as we have some (on purpose)
+    # empty values.
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "awesome-fontconfig" mode
+  POWERLEVEL9K_MODE="awesome-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "nerdfont-fontconfig" mode
+  POWERLEVEL9K_MODE="nerdfont-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "flat" mode
+  POWERLEVEL9K_MODE="flat"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "compatible" mode
+  POWERLEVEL9K_MODE="compatible"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+}
+
+# Go through all icons defined in awesome-patched mode, and
+# check if all of them are defined in the other modes.
+function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
+  # Always compare against this mode
+  local _P9K_TEST_MODE="awesome-patched"
+  POWERLEVEL9K_MODE="$_P9K_TEST_MODE"
+  source functions/icons.zsh
+  # _ICONS_UNDER_TEST is an array of just the keys of $icons.
+  # We later check via (r) "subscript" flag that our key
+  # is in the values of our flat array.
+  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+
+  # Switch to "default" mode
+  POWERLEVEL9K_MODE="default"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    # Iterate over all keys found in the _ICONS_UNDER_TEST
+    # array and compare it with the icons array of the
+    # current POWERLEVEL9K_MODE.
+    # Use parameter expansion, to directly check if the
+    # key exists in the flat current array of keys. That
+    # is quite complicated, but there seems no easy way
+    # to check the mere existance of a key in an array.
+    # The usual way would always return the value, so that
+    # would do the wrong thing as we have some (on purpose)
+    # empty values.
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "awesome-fontconfig" mode
+  POWERLEVEL9K_MODE="awesome-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "nerdfont-fontconfig" mode
+  POWERLEVEL9K_MODE="nerdfont-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "flat" mode
+  POWERLEVEL9K_MODE="flat"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "compatible" mode
+  POWERLEVEL9K_MODE="compatible"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+}
+
+# Go through all icons defined in awesome-fontconfig mode, and
+# check if all of them are defined in the other modes.
+function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
+  # Always compare against this mode
+  local _P9K_TEST_MODE="awesome-fontconfig"
+  POWERLEVEL9K_MODE="$_P9K_TEST_MODE"
+  source functions/icons.zsh
+  # _ICONS_UNDER_TEST is an array of just the keys of $icons.
+  # We later check via (r) "subscript" flag that our key
+  # is in the values of our flat array.
+  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+
+  # Switch to "default" mode
+  POWERLEVEL9K_MODE="default"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    # Iterate over all keys found in the _ICONS_UNDER_TEST
+    # array and compare it with the icons array of the
+    # current POWERLEVEL9K_MODE.
+    # Use parameter expansion, to directly check if the
+    # key exists in the flat current array of keys. That
+    # is quite complicated, but there seems no easy way
+    # to check the mere existance of a key in an array.
+    # The usual way would always return the value, so that
+    # would do the wrong thing as we have some (on purpose)
+    # empty values.
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "awesome-patched" mode
+  POWERLEVEL9K_MODE="awesome-patched"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "nerdfont-fontconfig" mode
+  POWERLEVEL9K_MODE="nerdfont-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "flat" mode
+  POWERLEVEL9K_MODE="flat"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "compatible" mode
+  POWERLEVEL9K_MODE="compatible"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+}
+
+# Go through all icons defined in nerdfont-fontconfig mode, and
+# check if all of them are defined in the other modes.
+function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
+  # Always compare against this mode
+  local _P9K_TEST_MODE="nerdfont-fontconfig"
+  POWERLEVEL9K_MODE="$_P9K_TEST_MODE"
+  source functions/icons.zsh
+  # _ICONS_UNDER_TEST is an array of just the keys of $icons.
+  # We later check via (r) "subscript" flag that our key
+  # is in the values of our flat array.
+  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+
+  # Switch to "default" mode
+  POWERLEVEL9K_MODE="default"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    # Iterate over all keys found in the _ICONS_UNDER_TEST
+    # array and compare it with the icons array of the
+    # current POWERLEVEL9K_MODE.
+    # Use parameter expansion, to directly check if the
+    # key exists in the flat current array of keys. That
+    # is quite complicated, but there seems no easy way
+    # to check the mere existance of a key in an array.
+    # The usual way would always return the value, so that
+    # would do the wrong thing as we have some (on purpose)
+    # empty values.
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "awesome-patched" mode
+  POWERLEVEL9K_MODE="awesome-patched"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "awesome-fontconfig" mode
+  POWERLEVEL9K_MODE="awesome-fontconfig"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "flat" mode
+  POWERLEVEL9K_MODE="flat"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+
+  # Switch to "compatible" mode
+  POWERLEVEL9K_MODE="compatible"
+  source functions/icons.zsh
+  local -a current_icons=(${(k)icons[@]})
+  for key in ${_ICONS_UNDER_TEST}; do
+    assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
+  done
+}
+
 source shunit2/source/2.1/src/shunit2

--- a/test/functions/icons.spec
+++ b/test/functions/icons.spec
@@ -81,12 +81,14 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
   # is in the values of our flat array.
-  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+  typeset -ah _ICONS_UNDER_TEST
+  _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "awesome-patched" mode
   POWERLEVEL9K_MODE="awesome-patched"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     # Iterate over all keys found in the _ICONS_UNDER_TEST
     # array and compare it with the icons array of the
@@ -104,7 +106,8 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   # Switch to "awesome-fontconfig" mode
   POWERLEVEL9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -112,7 +115,8 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   # Switch to "nerdfont-fontconfig" mode
   POWERLEVEL9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -120,7 +124,8 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   # Switch to "flat" mode
   POWERLEVEL9K_MODE="flat"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -128,10 +133,14 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   # Switch to "compatible" mode
   POWERLEVEL9K_MODE="compatible"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
+
+  unset current_icons
+  unset _ICONS_UNDER_TEST
 }
 
 # Go through all icons defined in awesome-patched mode, and
@@ -144,12 +153,14 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
   # is in the values of our flat array.
-  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+  typeset -ah _ICONS_UNDER_TEST
+  _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
   POWERLEVEL9K_MODE="default"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     # Iterate over all keys found in the _ICONS_UNDER_TEST
     # array and compare it with the icons array of the
@@ -167,7 +178,8 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # Switch to "awesome-fontconfig" mode
   POWERLEVEL9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -175,7 +187,8 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # Switch to "nerdfont-fontconfig" mode
   POWERLEVEL9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -183,7 +196,8 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # Switch to "flat" mode
   POWERLEVEL9K_MODE="flat"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -191,10 +205,14 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # Switch to "compatible" mode
   POWERLEVEL9K_MODE="compatible"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
+
+  unset current_icons
+  unset _ICONS_UNDER_TEST
 }
 
 # Go through all icons defined in awesome-fontconfig mode, and
@@ -207,12 +225,14 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
   # is in the values of our flat array.
-  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+  typeset -ah _ICONS_UNDER_TEST
+  _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
   POWERLEVEL9K_MODE="default"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     # Iterate over all keys found in the _ICONS_UNDER_TEST
     # array and compare it with the icons array of the
@@ -230,7 +250,8 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # Switch to "awesome-patched" mode
   POWERLEVEL9K_MODE="awesome-patched"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -238,7 +259,8 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # Switch to "nerdfont-fontconfig" mode
   POWERLEVEL9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -246,7 +268,8 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # Switch to "flat" mode
   POWERLEVEL9K_MODE="flat"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -254,10 +277,14 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # Switch to "compatible" mode
   POWERLEVEL9K_MODE="compatible"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
+
+  unset current_icons
+  unset _ICONS_UNDER_TEST
 }
 
 # Go through all icons defined in nerdfont-fontconfig mode, and
@@ -270,12 +297,14 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
   # is in the values of our flat array.
-  local -a _ICONS_UNDER_TEST=(${(k)icons[@]})
+  typeset -ah _ICONS_UNDER_TEST
+  _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
   POWERLEVEL9K_MODE="default"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     # Iterate over all keys found in the _ICONS_UNDER_TEST
     # array and compare it with the icons array of the
@@ -293,7 +322,8 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # Switch to "awesome-patched" mode
   POWERLEVEL9K_MODE="awesome-patched"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -301,7 +331,8 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # Switch to "awesome-fontconfig" mode
   POWERLEVEL9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -309,7 +340,8 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # Switch to "flat" mode
   POWERLEVEL9K_MODE="flat"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
@@ -317,10 +349,14 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # Switch to "compatible" mode
   POWERLEVEL9K_MODE="compatible"
   source functions/icons.zsh
-  local -a current_icons=(${(k)icons[@]})
+  typeset -ah current_icons
+  current_icons=(${(k)icons[@]})
   for key in ${_ICONS_UNDER_TEST}; do
     assertTrue "The key ${key} does exist in ${_P9K_TEST_MODE} mode, but not in ${POWERLEVEL9K_MODE}!" "(( ${+current_icons[(r)$key]} ))"
   done
+
+  unset current_icons
+  unset _ICONS_UNDER_TEST
 }
 
 source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
I added a default `LC_CTYPE` setting to protect special characters. Interestingly we had such settings already in `functions/icons.zsh`, but for some modes this setting got lost.

This should fix #442 (already fixed by workaround).

In addition I added some tests to check if Icons were added in all modes (see #448 ). The tests fail because of that. Once the missing icons got added, the tests should work. ;)
![bildschirmfoto 2017-03-20 um 00 31 26](https://cloud.githubusercontent.com/assets/1544760/24085920/d7922b34-0d04-11e7-8040-f7b87bfa16c0.png)
