### PR TITLE
Sort the output of `get_icon_names` alphabetically

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -301,7 +301,8 @@ function print_icon() {
 }
 
 get_icon_names() {
-  for key in ${(@k)icons}; do
+  # Iterate over a ordered list of keys of the icons array
+  for key in ${(@kon)icons}; do
     echo "POWERLEVEL9K_$key: ${icons[$key]}"
   done
 }

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -300,9 +300,20 @@ function print_icon() {
   fi
 }
 
+# Get a list of configured icons
+#   * $1 string - If "original", then the original icons are printed,
+#                 otherwise "print_icon" is used, which takes the users
+#                 overrides into account.
 get_icon_names() {
   # Iterate over a ordered list of keys of the icons array
   for key in ${(@kon)icons}; do
-    echo "POWERLEVEL9K_$key: ${icons[$key]}"
+    echo -n "POWERLEVEL9K_$key: "
+    if [[ "${1}" == "original" ]]; then
+      # print the original icons as they are defined in the array above
+      echo "${icons[$key]}"
+    else
+      # print the icons as they are configured by the user
+      echo "$(print_icon "$key")"
+    fi
   done
 }


### PR DESCRIPTION
Now the icons are sorted alphabetically, and the users icon overrides are taken into account (by default). If `get_icon_names` is called with "original" as parameter, it prints the original icons.
![bildschirmfoto 2017-03-19 um 17 54 41](https://cloud.githubusercontent.com/assets/1544760/24082919/c04e2194-0ccd-11e7-97fb-8343fb56b629.png)
