### PR TITLE
Make home shorthand configurable for dir prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,12 @@ POWERLEVEL9K_DIR_PATH_SEPARATOR="%F{red} $(print_icon 'LEFT_SUBSEGMENT_SEPARATOR
 To omit the first character (usually a slash that gets replaced if you set `POWERLEVEL9K_DIR_PATH_SEPARATOR`),
 you could set `POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true`.
 
+You can also customize the leading tilde character when you are in `$HOME` using:
+```zsh
+# Double quotes are important here!
+POWERLEVEL9K_HOME_FOLDER_ABBREVIATION="%F{red} $(print_icon 'HOME_ICON') %F{black}"
+```
+
 
 ##### disk_usage
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -613,6 +613,7 @@ prompt_command_execution_time() {
 
 # Dir: current working directory
 set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
+set_default POWERLEVEL9K_HOME_FOLDER_ABBREVIATION "~"
 prompt_dir() {
   local current_path="$(print -P "%~")"
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" || "$POWERLEVEL9K_SHORTEN_STRATEGY" == "truncate_with_folder_marker" ]]; then
@@ -715,6 +716,10 @@ prompt_dir() {
 
   if [[ "${POWERLEVEL9K_DIR_PATH_SEPARATOR}" != "/" ]]; then
     current_path="$( echo "${current_path}" | sed "s/\//${POWERLEVEL9K_DIR_PATH_SEPARATOR}/g")"
+  fi
+
+  if [[ "${POWERLEVEL9K_HOME_FOLDER_ABBREVIATION}" != "~" ]]; then
+    current_path="$( echo "${current_path}" | sed "s/^~/${POWERLEVEL9K_HOME_FOLDER_ABBREVIATION}/")"
   fi
 
   typeset -AH dir_states


### PR DESCRIPTION
Replaces `~` at the beginning of the directory for `dir` prompt, just like `/`. Not sure about the variable name, please tell me if you have a better idea :)