### PR TITLE
Gracefully handle `echotc Co` failure

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1317,8 +1317,8 @@ prompt_powerlevel9k_setup() {
 
   # Display a warning if the terminal does not support 256 colors
   local term_colors
-  term_colors=$(echotc Co)
-  if (( $term_colors < 256 )); then
+  term_colors=$(echotc Co 2>/dev/null)
+  if (( ! $? && ${term_colors:-0} < 256 )); then
     print -P "%F{red}WARNING!%f Your terminal appears to support less than 256 colors!"
     print -P "If your terminal supports 256 colors, please export the appropriate environment variable"
     print -P "_before_ loading this theme in your \~\/.zshrc. In most terminal emulators, putting"


### PR DESCRIPTION
In Emacs, `M-x shell` creates a shell buffer with *very* rudimentary terminal capabilities. `$TERM` is set to `dumb`, and `echotc Co` fails after printing `echotc: no such capability: Co` to standard error. If our goal was to determine whether the terminal supports 256 colors, we really have no information to go on. I recommend that we trust the user and hope for the best. That means we should (1) discard any `echotc Co` error output, and (2) forego the warning message about having fewer than 256 colors if `echotc Co` failed.