### PR TITLE
Merging Awesome Font Fix

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -13,6 +13,7 @@
 
 # Initialize the icon list according to the user's `POWERLEVEL9K_MODE`.
 typeset -gAH icons
+
 case $POWERLEVEL9K_MODE in
   'flat'|'awesome-patched')
     # Awesome-Patched Font required! See:
@@ -86,9 +87,8 @@ case $POWERLEVEL9K_MODE in
   'awesome-fontconfig')
     # fontconfig with awesome-font required! See
     # https://github.com/gabrielelana/awesome-terminal-fonts
-
     # if not defined, set recommended linux path
-    typeset -p "POWERLEVEL9K_FONTAWESOME_PATH" > /dev/null 2>&1  || POWERLEVEL9K_FONTAWESOME_PATH=~/.fonts  
+    typeset -p "POWERLEVEL9K_FONTAWESOME_PATH" > /dev/null 2>&1  || POWERLEVEL9K_FONTAWESOME_PATH=~/.fonts
 
     source "$POWERLEVEL9K_FONTAWESOME_PATH/fontawesome-regular.sh"
     # source "$POWERLEVEL9K_FONTAWESOME_PATH/devicons-regular.sh" # no named codepoints
@@ -97,7 +97,7 @@ case $POWERLEVEL9K_MODE in
     # Set the right locale to protect special characters
     local LC_ALL="" LC_CTYPE="en_US.UTF-8"
     icons=(
-      LEFT_SEGMENT_SEPARATOR         $'\uE0B0'                                      #        
+      LEFT_SEGMENT_SEPARATOR         $'\uE0B0'                                      # 
       RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'                                      # 
       LEFT_SEGMENT_END_SEPARATOR     ' '                                            # Whitespace
       LEFT_SUBSEGMENT_SEPARATOR      $'\uE0B1'                                      # 
@@ -106,7 +106,7 @@ case $POWERLEVEL9K_MODE in
       ROOT_ICON                      '\u'$CODEPOINT_OF_OCTICONS_ZAP                 # 
       RUBY_ICON                      '\u'$CODEPOINT_OF_OCTICONS_RUBY' '             # 
       AWS_ICON                       '\u'$CODEPOINT_OF_AWESOME_SERVER               # 
-      AWS_EB_ICON                    $'\U1F331 '                                    # 🌱     
+      AWS_EB_ICON                    $'\U1F331 '                                    # 🌱
       BACKGROUND_JOBS_ICON           '\u'$CODEPOINT_OF_AWESOME_COG' '               # 
       TEST_ICON                      '\u'$CODEPOINT_OF_AWESOME_BUG                  # 
       TODO_ICON                      '\u'$CODEPOINT_OF_AWESOME_CHECK_SQUARE_O       # 
@@ -114,12 +114,12 @@ case $POWERLEVEL9K_MODE in
       DISK_ICON                      '\u'$CODEPOINT_OF_AWESOME_HDD_O' '             # 
       OK_ICON                        '\u'$CODEPOINT_OF_AWESOME_CHECK                # 
       FAIL_ICON                      '\u'$CODEPOINT_OF_AWESOME_TIMES                # 
-      SYMFONY_ICON                   'SF'     
-      NODE_ICON                      $'\u2B22'                                      # ⬢     
-      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'                             # ╭─     
-      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '                            # ╰─     
+      SYMFONY_ICON                   'SF'
+      NODE_ICON                      $'\u2B22'                                      # ⬢
+      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'                             # ╭─
+      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '                            # ╰─
       APPLE_ICON                     '\u'$CODEPOINT_OF_AWESOME_APPLE                # 
-      FREEBSD_ICON                   $'\U1F608 '                                    # 😈     
+      FREEBSD_ICON                   $'\U1F608 '                                    # 😈
       LINUX_ICON                     '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       SUNOS_ICON                     '\u'$CODEPOINT_OF_AWESOME_SUN_O' '             # 
       HOME_ICON                      '\u'$CODEPOINT_OF_AWESOME_HOME                 # 
@@ -147,12 +147,75 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            '\u'$CODEPOINT_OF_AWESOME_GITLAB' '            # 
       VCS_HG_ICON                    '\u'$CODEPOINT_OF_AWESOME_FLASK' '             # 
       VCS_SVN_ICON                   '(svn) '
-      RUST_ICON                      $'\uE6A8'                                      #  
+      RUST_ICON                      $'\uE6A8'                                      # 
       PYTHON_ICON                    $'\U1F40D'                                     # 🐍
       SWIFT_ICON                     $'\uE655'                                      # 
-      PUBLIC_IP_ICON                 '\u'$CODEPOINT_OF_AWESOME_GLOBE                # 	  
+      PUBLIC_IP_ICON                 '\u'$CODEPOINT_OF_AWESOME_GLOBE                # 
       LOCK_ICON                      '\u'$CODEPOINT_OF_AWESOME_LOCK                 # 
       EXECUTION_TIME_ICON            '\u'$CODEPOINT_OF_AWESOME_HOURGLASS_END        # 
+      SSH_ICON                       '(ssh)'
+    )
+  ;;
+  'AdobeSourceCodePro')
+    # Set the right locale to protect special characters
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+    icons=(
+      LEFT_SEGMENT_SEPARATOR         $'\uE0B0'              # 
+      RIGHT_SEGMENT_SEPARATOR        $'\uE0B2'              # 
+      LEFT_SEGMENT_END_SEPARATOR     ' '                    # Whitespace
+      LEFT_SUBSEGMENT_SEPARATOR      $'\uE0B1'              # 
+      RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
+      CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
+      ROOT_ICON                      $'\uF201'              # 
+      RUBY_ICON                      $'\uF219 '             # 
+      AWS_ICON                       $'\uF270'              # 
+      AWS_EB_ICON                    $'\U1F331 '            # 🌱
+      BACKGROUND_JOBS_ICON           $'\uF013 '             # 
+      TEST_ICON                      $'\uF291'              # 
+      TODO_ICON                      $'\u2611'              # ☑
+      BATTERY_ICON                   $'\U1F50B'             # 🔋
+      DISK_ICON                      $'\uF0A0 '             # 
+      OK_ICON                        $'\u2713'              # ✓
+      FAIL_ICON                      $'\u2718'              # ✘
+      SYMFONY_ICON                   'SF'
+      NODE_ICON                      $'\u2B22'              # ⬢
+      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
+      APPLE_ICON                     $'\uF179'              # 
+      FREEBSD_ICON                   $'\U1F608 '            # 😈
+      LINUX_ICON                     $'\uF17C'              # 
+      SUNOS_ICON                     $'\uF185 '             # 
+      HOME_ICON                      $'\uF015'              # 
+      HOME_SUB_ICON                  $'\uF07C'              # 
+      FOLDER_ICON                    $'\uF115'              # 
+      NETWORK_ICON                   $'\uF09E'              # 
+      LOAD_ICON                      $'\uF080 '             # 
+      SWAP_ICON                      $'\uF0E4'              # 
+      RAM_ICON                       $'\uF0E4'              # 
+      SERVER_ICON                    $'\uF233'              # 
+      VCS_UNTRACKED_ICON             $'\uF059'              # 
+      VCS_UNSTAGED_ICON              $'\uF06A'              # 
+      VCS_STAGED_ICON                $'\uF055'              # 
+      VCS_STASH_ICON                 $'\uF01C '             # 
+      VCS_INCOMING_CHANGES_ICON      $'\uF01A '             # 
+      VCS_OUTGOING_CHANGES_ICON      $'\uF01B '             # 
+      VCS_TAG_ICON                   $'\uF217 '             # 
+      VCS_BOOKMARK_ICON              $'\uF27B'              # 
+      VCS_COMMIT_ICON                $'\uF221 '             # 
+      VCS_BRANCH_ICON                $'\uF126'              # 
+      VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
+      VCS_GIT_ICON                   $'\uF1D3 '             # 
+      VCS_GIT_GITHUB_ICON            $'\uF113 '             # 
+      VCS_GIT_BITBUCKET_ICON         $'\uF171 '             # 
+      VCS_GIT_GITLAB_ICON            $'\uF296 '             # 
+      VCS_HG_ICON                    $'\uF0C3 '             # 
+      VCS_SVN_ICON                   '(svn) '
+      RUST_ICON                      $'\uE6A8'              # 
+      PYTHON_ICON                    $'\U1F40D'             # 🐍
+      SWIFT_ICON                     ''
+      PUBLIC_IP_ICON                 ''
+      LOCK_ICON                      $'\UE138'              # 
+      EXECUTION_TIME_ICON            $'\uF253'
       SSH_ICON                       '(ssh)'
     )
   ;;
@@ -176,7 +239,7 @@ case $POWERLEVEL9K_MODE in
       TEST_ICON                      $'\uF188'              # 
       TODO_ICON                      $'\uF133'              # 
       BATTERY_ICON                   $'\UF240 '             # 
-      DISK_ICON                      $'\uF0A0'              #  
+      DISK_ICON                      $'\uF0A0'              # 
       OK_ICON                        $'\uF00C'              # 
       FAIL_ICON                      $'\uF00D'              # 
       SYMFONY_ICON                   $'\uE757'              # 
@@ -209,16 +272,16 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_ICON                   $'\uF113 '             # 
       VCS_GIT_GITHUB_ICON            $'\uE709 '             # 
       VCS_GIT_BITBUCKET_ICON         $'\uE703 '             # 
-      VCS_GIT_GITLAB_ICON            $'\uF296 '             #  
+      VCS_GIT_GITLAB_ICON            $'\uF296 '             # 
       VCS_HG_ICON                    $'\uF0C3 '             # 
       VCS_SVN_ICON                   $'\uE72D '             # 
       RUST_ICON                      $'\uE7A8 '             # 
       PYTHON_ICON                    $'\UE73C '             # 
       SWIFT_ICON                     $'\uE755'              # 
       PUBLIC_IP_ICON                 $'\UF0AC'              # 
-      LOCK_ICON                      $'\UF023'              #  
-      EXECUTION_TIME_ICON            $'\uF252'              #  
-      SSH_ICON                       $'\uF489'              #  
+      LOCK_ICON                      $'\UF023'              # 
+      EXECUTION_TIME_ICON            $'\uF252'              # 
+      SSH_ICON                       $'\uF489'              # 
     )
   ;;
   *)


### PR DESCRIPTION
This is the PR effort that merges @V1rgul's #385, which we need as soon as possible.

It is separate from #385 because I added a new icon set for `AdobeSourceCodePro`, for which we were previously telling users to use `awesome-fontconfig` since the codepoints lined up reasonably well. That was a mistake on my part, and now we are going to break this for those users.

More on this in the review that I'm about to leave. I would like to resolve my review comments before completing this merge.

@V1rgul - Your testing of this branch will be critical. It would also be great to get @protist testing this.