### PR TITLE
Only show go_version segment if inside GOPATH

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -746,7 +746,7 @@ prompt_go_version() {
   local go_version
   local go_path
   go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
-  go_path=$(go env GOPATH)
+  go_path=$(go env GOPATH 2>/dev/null)
 
   if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
     "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -744,9 +744,11 @@ prompt_docker_machine() {
 # GO prompt
 prompt_go_version() {
   local go_version
+  local go_path
   go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
+  go_path=$(go env GOPATH)
 
-  if [[ -n "$go_version" ]]; then
+  if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
     "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version"
   fi
 }

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -19,8 +19,11 @@ function testGo() {
   alias go=mockGo
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(go_version)
 
+  PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
+
   assertEquals "%K{green} %F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
 
+  unset PWD
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias go
 }

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -35,6 +35,17 @@ function testGo() {
   unalias go
 }
 
+function testGoSegmentPrintsNothingIfNotInGopath() {
+  alias go=mockGo
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+}
+
 function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   alias go=noGo
   POWERLEVEL9K_CUSTOM_WORLD='echo world'

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -12,7 +12,14 @@ function setUp() {
 }
 
 function mockGo() {
-  echo 'go version go1.5.3 darwin/amd64'
+  case "$1" in
+  'version')
+    echo 'go version go1.5.3 darwin/amd64'
+    ;;
+  'env')
+    echo "$HOME/go"
+    ;;
+  esac
 }
 
 function testGo() {

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -22,6 +22,17 @@ function mockGo() {
   esac
 }
 
+function mockGoEmptyGopath() {
+  case "$1" in
+  'version')
+    echo 'go version go1.5.3 darwin/amd64'
+    ;;
+  'env')
+    echo ""
+    ;;
+  esac
+}
+
 function testGo() {
   alias go=mockGo
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(go_version)
@@ -33,6 +44,18 @@ function testGo() {
   unset PWD
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias go
+}
+
+function testGoSegmentPrintsNothingIfEmptyGopath() {
+  alias go=mockGoEmptyGopath
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+
 }
 
 function testGoSegmentPrintsNothingIfNotInGopath() {


### PR DESCRIPTION
As of Go v1.8 GOPATH need not be set, as it will default to $HOME/go. By using `go env GOPATH` to retrieve the value first, this technique will work regardless of whether GOPATH is currently set by the user.