### PR TITLE
Adds Android icon/battery plugin support

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -43,6 +43,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '
       APPLE_ICON                     $'\uE26E'              # 
       FREEBSD_ICON                   $'\U1F608 '            # 😈
+      ANDROID_ICON                   $'\uE270'              # 
       LINUX_ICON                     $'\uE271'              # 
       SUNOS_ICON                     $'\U1F31E '            # 🌞
       HOME_ICON                      $'\uE12C'              # 
@@ -112,6 +113,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
       FREEBSD_ICON                   $'\U1F608 '            # 😈
+      ANDROID_ICON                   $'\uE17B'              # 
       LINUX_ICON                     $'\uF17C'              # 
       SUNOS_ICON                     $'\uF185 '             # 
       HOME_ICON                      $'\uF015'              # 
@@ -177,6 +179,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
       FREEBSD_ICON                   $'\UF30E '             # 
+      ANDROID_ICON                   $'\uF17B'              # 
       LINUX_ICON                     $'\uF17C'              # 
       SUNOS_ICON                     $'\uF185 '             # 
       HOME_ICON                      $'\uF015'              # 
@@ -242,6 +245,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\u2500 '
       APPLE_ICON                     'OSX'
       FREEBSD_ICON                   'BSD'
+      ANDROID_ICON                   'And'
       LINUX_ICON                     'Lx'
       SUNOS_ICON                     'Sun'
       HOME_ICON                      ''

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -100,6 +100,14 @@ case $(uname) in
     Linux)
       OS='Linux'
       OS_ICON=$(print_icon 'LINUX_ICON')
+
+      # Check if we're running on Android
+      case $(uname -o 2>/dev/null) in
+        Android)
+          OS='Android'
+          OS_ICON=$(print_icon 'ANDROID_ICON')
+          ;;
+      esac
       ;;
     SunOS)
       OS='Solaris'
@@ -108,15 +116,6 @@ case $(uname) in
     *)
       OS=''
       OS_ICON=''
-      ;;
-esac
-
-# Not all OSes support the '-o' parameter
-# That's why this second condition is needed 
-case $(uname -o 2>/dev/null) in
-    Android)
-      OS='Android'
-      OS_ICON=$(print_icon 'ANDROID_ICON')
       ;;
 esac
 

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -111,6 +111,15 @@ case $(uname) in
       ;;
 esac
 
+# Not all OSes support the '-o' parameter
+# That's why this second condition is needed 
+case $(uname -o 2>/dev/null) in
+    Android)
+      OS='Android'
+      OS_ICON=$(print_icon 'ANDROID_ICON')
+      ;;
+esac
+
 # Determine the correct sed parameter.
 #
 # `sed` is unfortunately not consistent across OSes when it comes to flags.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -425,11 +425,16 @@ prompt_battery() {
     esac
   fi
 
-  if [[ $OS =~ Linux ]]; then
+  if [[ "$OS" == 'Linux' ]] || [[ "$OS" == 'Android' ]]; then
     local sysp="/sys/class/power_supply"
+
     # Reported BAT0 or BAT1 depending on kernel version
     [[ -a $sysp/BAT0 ]] && local bat=$sysp/BAT0
     [[ -a $sysp/BAT1 ]] && local bat=$sysp/BAT1
+
+    # Android-related
+    # Tested on: Moto G falcon (CM 13.0)
+    [[ -a $sysp/battery ]] && local bat=$sysp/battery
 
     # Return if no battery found
     [[ -z $bat ]] && return
@@ -1278,8 +1283,9 @@ powerlevel9k_prepare_prompts() {
   RETVAL=$?
 
   _P9K_COMMAND_DURATION=$((EPOCHREALTIME - _P9K_TIMER_START))
+
   # Reset start time
-  _P9K_TIMER_START=99999999999
+  _P9K_TIMER_START=2147483647
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
     PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
@@ -1312,8 +1318,11 @@ NEWLINE='
 }
 
 prompt_powerlevel9k_setup() {
+  # I decided to use the value below for better supporting 32-bit CPUs, since the previous value "99999999999" was causing issues on my Android phone, which is powered by an armv7l
+  # We don't have to change that until 19 January of 2038! :)
+
   # Disable false display of command execution time
-  _P9K_TIMER_START=99999999999
+  _P9K_TIMER_START=2147483647
 
   # Display a warning if the terminal does not support 256 colors
   local term_colors

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1285,6 +1285,7 @@ powerlevel9k_prepare_prompts() {
   _P9K_COMMAND_DURATION=$((EPOCHREALTIME - _P9K_TIMER_START))
 
   # Reset start time
+  # Maximum integer on 32-bit CPUs
   _P9K_TIMER_START=2147483647
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
@@ -1322,6 +1323,7 @@ prompt_powerlevel9k_setup() {
   # We don't have to change that until 19 January of 2038! :)
 
   # Disable false display of command execution time
+  # Maximum integer on 32-bit CPUs
   _P9K_TIMER_START=2147483647
 
   # Display a warning if the terminal does not support 256 colors


### PR DESCRIPTION
Plus fixes bhilburn/powerlevel9k#479, which was causing integer overflow on 32-bit CPUs.

![screenshot_20170412-162318](https://cloud.githubusercontent.com/assets/27077338/24976318/5755e124-1f9f-11e7-94a5-2c1718d7aed8.png)
