### PR TITLE
Document generation from comments using sh2md (Against NEXT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 test-vm/.vagrant
+
+powerlevel9k.zsh
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "shunit2"]
 	path = shunit2
-	url = https://github.com/kward/shunit2.git
+	url = https://github.com/kward/shunit2
+[submodule "sh2md"]
+	path = sh2md
+	url = https://onaforeignshore/sh2md

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/kward/shunit2
 [submodule "sh2md"]
 	path = sh2md
-	url = https://onaforeignshore/sh2md
+	url = https://github.com/onaforeignshore/sh2md

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -1,13 +1,24 @@
 # vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
 ################################################################
-# Color functions
-# This file holds some color-functions for
-# the powerlevel9k-ZSH-theme
-# https://github.com/bhilburn/powerlevel9k
-################################################################
+# @title Color functions
+# @source https://github.com/bhilburn/powerlevel9k
+# @info
+# This file holds some color-functions for the powerlevel9k-ZSH-theme
+##
 
-# Get numerical color codes. That way we translate ANSI codes
-# into ZSH-Style color codes.
+################################################################
+# @description
+# Get numerical color codes. That way we translate ANSI codes ZSH-Style color codes.
+##
+# @example
+#   getColorCode 'black'
+#
+# @args
+#   $1 string|number If string, ANSI color code.
+#
+# @returns
+#   Zsh style color code.
+##
 function getColorCode() {
   # Check if given value is already numerical
   if [[ "$1" = <-> ]]; then
@@ -42,7 +53,24 @@ function getColorCode() {
   fi
 }
 
-# Check if two colors are equal, even if one is specified as ANSI code.
+################################################################
+# @description
+# Check if two colors are equal, even if one is specified as an ANSI code.
+##
+# @examples isSameColor 'black' 0
+#   isSameColor 'white' 0
+#
+# @args
+#   $1 string|number First color.
+#   $2 string|number Second color.
+#
+# @returns
+#   true if they are the same color.
+#   false if they are different colors.
+#
+# @see
+#   getColorCode
+##
 function isSameColor() {
   if [[ "$1" == "NONE" || "$2" == "NONE" ]]; then
     return 1

--- a/powerlevel9k.zsh
+++ b/powerlevel9k.zsh
@@ -1,0 +1,1 @@
+/Users/chris/.dotfiles/zsh/powerlevel9k.zsh

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1,13 +1,15 @@
 # vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
 ################################################################
-# powerlevel9k Theme
-# https://github.com/bhilburn/powerlevel9k
+# @title powerlevel9k Theme
+# @source https://github.com/bhilburn/powerlevel9k
 #
-# This theme was inspired by agnoster's Theme:
-# https://gist.github.com/3712874
-################################################################
-
-################################################################
+# @authors
+#   Ben Hilburn
+#   Dominic Ritter
+#
+# @info
+# This theme was inspired by [agnoster's Theme](https://gist.github.com/3712874)
+#
 # For basic documentation, please refer to the README.md in the top-level
 # directory. For more detailed documentation, refer to the project wiki, hosted
 # on Github: https://github.com/bhilburn/powerlevel9k/wiki


### PR DESCRIPTION
# Project Documentation / File Commenting

## Synopsis

I was thinking about the documenting part of this project, and thought it might be useful to have a reference of all the functions and their calls on the project wiki for our and others' reference.

I searched online for any converters that would convert bash comments into GitHub markdown, and only found one - [shdoc](https://github.com/reconquest/shdoc). In my opinion, it is lacking a lot, even with the PR that is on the project. So, I have spent the last 3 days rewriting it from scratch.

I have named my version [sh2md](https://github.com/onaforeignshore/sh2md). Can you guys please take a look at it, and give me comments, as I think it would be useful to start commenting the files and functions in this way. As I have written the converter myself, it will be easy to add / change as required for the project.

I have included two files in this PR that have been commented in this way - `powerlevel9k.zsh-theme` and `functions/colors.zsh`. I have attached the output to the bottom of this post for you to preview as well.

## Requirements

The converter uses Gnu AWK. As this is available on most systems (and can be installed on Mac using Homebrew), I think it would be available to the majority of the contributors to use to create documentation for their files.

## TODO
- [ ] discuss the requirements for `powerlevel9k`
- [ ] discuss the styles and tags we would like to use
- [x] add a function to convert multiple line comments into paragraphs
- [ ] add more section tags as required

## Examples

### File level comment block

```sh
################################################################
# @title powerlevel9k Theme
# @source https://github.com/bhilburn/powerlevel9k
#
# @authors
#   Ben Hilburn
#   Dominic Ritter
#
# @info
# This theme was inspired by [agnoster's Theme](https://gist.github.com/3712874)
#
# For basic documentation, please refer to the README.md in the top-level
# directory. For more detailed documentation, refer to the
# [project wiki](https://github.com/bhilburn/powerlevel9k/wiki), hosted
# on Github.
#
# There are a lot of easy ways you can customize your prompt segments and
# theming with simple variables defined in your `~/.zshrc`.
################################################################
```

---

# powerlevel9k Theme

### Source(s)

[https://github.com/bhilburn/powerlevel9k](#https://github.com/bhilburn/powerlevel9k)

### Author(s)

- Ben Hilburn
- Dominic Ritter

### File Description


_This theme was inspired by [agnoster's Theme](https://gist.github.com/3712874)_

_For basic documentation, please refer to the README.md in the top-level directory. For more detailed documentation, refer to the [project wiki](https://github.com/bhilburn/powerlevel9k/wiki), hosted on Github._

_There are a lot of easy ways you can customize your prompt segments and theming with simple variables defined in your `~/.zshrc`._

---

### Function comment blocks

```sh
#!/usr/bin/env zsh
# vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
################################################################
# @title Color functions
# @source https://github.com/bhilburn/powerlevel9k
# @info
# This file holds some color-functions for the powerlevel9k-ZSH-theme
##

################################################################
# @description
# Get numerical color codes. That way we translate ANSI codes ZSH-Style color codes.
#
# @example
#   getColorCode 'black'
#
# @args
#   $1 string|number If string, ANSI color code.
#
# @returns
#   Zsh style color code.
##
function getColorCode() {
  # ...
}

################################################################
# @description
# Check if two colors are equal, even if one is specified as ANSI code.
#
# @examples isSameColor 'black' 0
#   isSameColor 'white' 0
#
# @args
#   $1 string|number First color.
#   $2 string|number Second color.
#
# @returns
#   true if they are the same color.
#   false if they are different colors.
#
# @see
#   getColorCode
##
function isSameColor() {
  # ...
}
```

---

# Color functions

### Source(s)

[https://github.com/bhilburn/powerlevel9k](#https://github.com/bhilburn/powerlevel9k)

### File Description


_This file holds some color-functions for the powerlevel9k-ZSH-theme_


## Table of Contents

- [getColorCode()](#getColorCode)
- [isSameColor()](#isSameColor)

## getColorCode()

Get numerical color codes. That way we translate ANSI codes ZSH-Style color codes.

### Example

```sh
getColorCode 'black'
```

### Arguments

- **$1** (string|number) If string, ANSI color code.

### Returns

- Zsh style color code.

## isSameColor()

Check if two colors are equal, even if one is specified as ANSI code.

### Example

```sh
isSameColor 'black' 0
isSameColor 'white' 0
```

### Arguments

- **$1** (string|number) First color.
- **$2** (string|number) Second color.

### Returns

- true if they are the same color.
- false if they are different colors.

### See also

- [getColorCode](#getColorCode)

---
