### PR TITLE
Attempt to fix powerlevel9k on systems where the perl fallback fails

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -45,6 +45,9 @@ fi
 if [[ -L "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
   # If this theme is sourced as a symlink, we need to locate the real URL
   filename="$(realpath -P $POWERLEVEL9K_INSTALLATION_PATH 2>/dev/null || readlink -f $POWERLEVEL9K_INSTALLATION_PATH 2>/dev/null || perl -MCwd=abs_path -le 'print abs_path readlink(shift);' $POWERLEVEL9K_INSTALLATION_PATH 2>/dev/null)"
+  if [[ -z "$filename" ]]; then
+    filename="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' $POWERLEVEL9K_INSTALLATION_PATH)"
+  fi
 elif [[ -d "$POWERLEVEL9K_INSTALLATION_PATH" ]]; then
   # Directory
   filename="${POWERLEVEL9K_INSTALLATION_PATH}/powerlevel9k.zsh-theme"
@@ -664,7 +667,7 @@ prompt_dir() {
             break;
           fi
         done
-        
+
         local packageName=$(jq '.name' ${pkgFile} 2> /dev/null \
           || node -e 'console.log(require(process.argv[1]).name);' ${pkgFile} 2>/dev/null \
           || cat "${pkgFile}" 2> /dev/null | grep -m 1 "\"name\"" | awk -F ':' '{print $2}' | awk -F '"' '{print $2}' 2>/dev/null \


### PR DESCRIPTION
This is a hacky workaround I've been playing with on OSX when messing with the prezto integration. readlink doesn't have -f and perl appears to return an empty string... so I fell back to python which may be relatively slow but it should be effective.

Please feel free to leave suggestions... I'm not really happy with how this looks at the moment, even if it works.