### PR TITLE
Set tick to color name green instead of color code

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1003,7 +1003,7 @@ prompt_status() {
       "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "" 'FAIL_ICON'
     fi
   elif [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true || "$POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
-    "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "046" "" 'OK_ICON'
+    "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "green" "" 'OK_ICON'
   fi
 }
 


### PR DESCRIPTION
So the tick will not be too bright in light background color scheme such
as Solarized Light.

<img width="702" alt="screen shot 2017-04-15 at 11 06 21 pm" src="https://cloud.githubusercontent.com/assets/1842626/25069240/4555ca3c-2230-11e7-8b42-8a112fbd48cf.png">
<img width="702" alt="screen shot 2017-04-15 at 11 06 43 pm" src="https://cloud.githubusercontent.com/assets/1842626/25069241/45570528-2230-11e7-9f1d-731f7a7f8c9d.png">