### PR TITLE
[SVN] removed %b identifier to fix color encoding

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1145,6 +1145,12 @@ powerlevel9k_vcs_init() {
   zstyle ':vcs_info:hg*:*' get-bookmarks true
   zstyle ':vcs_info:hg*+gen-hg-bookmark-string:*' hooks hg-bookmarks
 
+  # For svn, only
+  # TODO fix the %b (branch) format for svn. Using %b breaks
+  # color-encoding of the foreground for the rest of the powerline.
+  zstyle ':vcs_info:svn*:*' formats "$VCS_CHANGESET_PREFIX%c%u"
+  zstyle ':vcs_info:svn*:*' actionformats "$VCS_CHANGESET_PREFIX%c%u %F{${POWERLEVEL9K_VCS_ACTIONFORMAT_FOREGROUND}}| %a%f"
+
   if [[ "$POWERLEVEL9K_SHOW_CHANGESET" == true ]]; then
     zstyle ':vcs_info:*' get-revision true
   fi


### PR DESCRIPTION
This is a workaround for https://github.com/bhilburn/powerlevel9k/issues/312 I've just added custom svn prompts instead of using our primary ones. The problem is the `%b`-identifier. When we use the `%b`-identifier for svn it seems to break our color-encoding. I guess they use some chars in there or some custom color encoding that will  break ours. The `%b`-identifier will give for SVN the following output:
`<branch-name>:<revision number of branch>`

When I use `%b` everything after `<branch-name>` will be yellow..I tried to fix the color with it. But maybe someone else has more luck.

It's sad that we lose the branch-name for this feature. But I think most people use only one branch with svn and we still display the revision-number. So it shouldn't be that bad. Let's focus on `git`. :)

The only thing what I would still miss for SVN is a nicer icon. I thought about using the `VCS_BRANCH_ICON` for this or we wait for `nerdfonts`-support.. I guess they have some cool icon for svn.

tl;dr: The svn colors are fixed now, I just removed the`%b`-identifier from the svn-bar.