### PR TITLE
Preliminary fix for p3wnage exploit

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1282,8 +1282,13 @@ powerlevel9k_prepare_prompts() {
   _P9K_TIMER_START=99999999999
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
-    PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
-$(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
+    local PROMPT_P1="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')"
+    local PROMPT_P2="$(build_left_prompt)"
+    local PROMPT_P3="$(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
+    #PROMPT="$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
+#$(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
+    PROMPT="${PROMPT_P1}%f%b%k${PROMPT_P2}
+${PROMPT_P3}"
     if [[ "$POWERLEVEL9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left
       # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
@@ -1298,13 +1303,17 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
       RPROMPT_SUFFIX=''
     fi
   else
-    PROMPT="%f%b%k$(build_left_prompt)"
+    local PROMPT_P2="$(build_left_prompt)"
+    #PROMPT="%f%b%k$(build_left_prompt)"
+    PROMPT="%f%b%k${PROMPT_P2}"
     RPROMPT_PREFIX=''
     RPROMPT_SUFFIX=''
   fi
 
   if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
-    RPROMPT="$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX"
+    #RPROMPT="$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX"
+    local RPROMPT_P1="$(build_right_prompt)"
+    RPROMPT="$RPROMPT_PREFIX%f%b%k${RPROMPT_P1}%{$reset_color%}$RPROMPT_SUFFIX"
   fi
 NEWLINE='
 '


### PR DESCRIPTION
* TODO:
- [ ] Need testing by others
- [ ] Does it break other `prompts`?
- [ ] Review by p3wange reporter or original author
- [ ] Remove commented code
- [ ] Thoughts on good names for the local variables such as `${PROMPT_P1}`?
- [ ] Fix coding style. I use `${}` inside double quotes for variable reuse
- [ ] Should those variables be _non-local_ to be consistent with overall coding style? 

* Details:

The construction of `${RPROMPT}` and `${PROMPT}` uses shell expansion
via `$()` that I believe is at the root of exploit.

I have extracted out the relevant expansions into a local variable, and
the construction of the prompt variables reuses those strings.