### PR TITLE
Fix some oddities with prompt options

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1336,10 +1336,14 @@ prompt_powerlevel9k_setup() {
   # Maximum integer on 32-bit CPUs
   _P9K_TIMER_START=2147483647
 
+  # The prompt function will set these prompt_* options after the setup function
+  # returns. We need prompt_subst so we can safely run commands in the prompt
+  # without them being double expanded and we need prompt_percent to expand the
+  # common percent escape sequences.
   prompt_opts=(subst percent)
 
-  # borrowed from promptinit, sets the prompt options in case pure was not
-  # initialized via promptinit.
+  # Borrowed from promptinit, sets the prompt options in case the theme was
+  # not initialized via promptinit.
   setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
 
   # Display a warning if the terminal does not support 256 colors
@@ -1372,12 +1376,6 @@ prompt_powerlevel9k_setup() {
     'longstatus'      'status'
   )
   print_deprecation_warning deprecated_segments
-
-  setopt prompt_subst
-
-  setopt LOCAL_OPTIONS
-  unsetopt XTRACE KSH_ARRAYS
-  setopt PROMPT_CR PROMPT_PERCENT PROMPT_SUBST MULTIBYTE
 
   # initialize colors
   autoload -U colors && colors

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1336,6 +1336,12 @@ prompt_powerlevel9k_setup() {
   # Maximum integer on 32-bit CPUs
   _P9K_TIMER_START=2147483647
 
+  prompt_opts=(subst percent)
+
+  # borrowed from promptinit, sets the prompt options in case pure was not
+  # initialized via promptinit.
+  setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+
   # Display a warning if the terminal does not support 256 colors
   local term_colors
   term_colors=$(echotc Co 2>/dev/null)


### PR DESCRIPTION
Firstly, `prompt_opts` needs to be set so `prompt_subst` and other prompt related options will be set consistently when this prompt is used. We also need to set them manually for when the script is executed directly (or when prompt_powerlevel9k_setup is called directly). This workaround is based off the same workaround in pure (https://github.com/sindresorhus/pure/blob/3a08df333d1a32b5be610f3cb688d5c773b8c650/pure.zsh#L397) which was based off the code from the prompt function in zsh, as seen below:

```
prompt () {
  local prompt_opts

  set_prompt "$@"

  (( $#prompt_opts )) &&
      setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"

  true
}
```

This introduces a complication... lots of prompts do this:

```
  setopt LOCAL_OPTIONS
  unsetopt XTRACE KSH_ARRAYS
```

I assume when starting off, powerlevel9k may have copied this from another prompt. However, because of the above workaround relating to `prompt_opts`, we cannot use local_options, so we need to look at removing the other options which have been set locally here.

Other parts of powerlevel9k currently rely on KSH_ARRAYS to not be set globally in the shell, and even some builtin functions start falling over if this is set, so I'm fairly sure this can be removed. In a similar fashion, it doesn't make a ton of sense to disable XTRACE locally for only prompt_powerlevel9k_setup, so it should be safe to disable that as well.

Sorry for the wall of text, but I felt like this was needed to explain where all these weird changes came from. On a side note, this fixes the issues some people were having with the pw3nage fix because it ensures prompt_subst will be set when using the powerlevel9k theme.

This supercedes #495