### PR TITLE
battery icon set and color array

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,8 @@ your `~/.zshrc`:
 
 ##### battery
 
-This segment will display your current battery status (fails gracefully on
-systems without a battery). It is supported on both OSX and Linux (note that it
-requires `acpi` on Linux).
+The default settings for this segment will display your current battery status (fails gracefully on
+systems without a battery). It is supported on both OSX and Linux (note that it requires `acpi` on Linux).
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
@@ -200,6 +199,53 @@ requires `acpi` on Linux).
 Note that you can [modify the `_FOREGROUND`
 color](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization)
 without affecting the icon color.
+
+The battery segment can also be extended to change the icon automatically depending on the battery level.
+This will override the default battery icon. In order to do this, you need to define the 
+`POWERLEVEL9k_BATTERY_STAGES` variable.
+
+| Variable | Default Value | Description |
+| `POWERLEVEL9K_BATTERY_STAGES`|Unset|A string or array to indicate the stages.|
+
+If you want to use a string, you can declare the variable as follows:
+```zsh
+POWERLEVEL9K_BATTERY_STAGES="▁▂▃▄▅▆▇█"
+```
+
+If you require extra spacing after the icon, you will have to set it as an array,
+since spaces in the string will be used as one of the stages and you will get a
+missing icon. To do this, declare the variable as follows:
+```zsh
+POWERLEVEL9K_BATTERY_STAGES=($'\u2581 ' $'\u2582 ' $'\u2583 ' $'\u2584 ' $'\u2585 ' $'\u2586 ' $'\u2587 ' $'\u2588 ')
+```
+
+You can also use a multiple character "icon" if you want a longer battery icon. To do
+this, declare the variable as follows:
+```zsh
+POWERLEVEL9K_BATTERY_STAGES=(
+   $'▏    ▏' $'▎    ▏' $'▍    ▏' $'▌    ▏' $'▋    ▏' $'▊    ▏' $'▉    ▏' $'█    ▏'
+   $'█▏   ▏' $'█▎   ▏' $'█▍   ▏' $'█▌   ▏' $'█▋   ▏' $'█▊   ▏' $'█▉   ▏' $'██   ▏'
+   $'██   ▏' $'██▎  ▏' $'██▍  ▏' $'██▌  ▏' $'██▋  ▏' $'██▊  ▏' $'██▉  ▏' $'███  ▏'
+   $'███  ▏' $'███▎ ▏' $'███▍ ▏' $'███▌ ▏' $'███▋ ▏' $'███▊ ▏' $'███▉ ▏' $'████ ▏'
+   $'████ ▏' $'████▎▏' $'████▍▏' $'████▌▏' $'████▋▏' $'████▊▏' $'████▉▏' $'█████▏' )
+```
+
+It is now also possible to change the background of the segment automatically depending on
+the battery level. This will override the following variables: `POWERLEVEL9K_BATTERY_CHARGING`,
+`POWERLEVEL9K_BATTERY_CHARGED`, `POWERLEVEL9K_BATTERY_DISCONNECTED`, and `POWERLEVEL9K_BATTERY_LOW_COLOR`.
+In order to do this, we define a color array (from low to high) as follows:
+```zsh
+POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND=(196 202 208 214 220 226 190 154 118 82 46)
+```
+
+|Brightness|Possible Array|
+|Bright Colors|(196 202 208 214 220 226 190 154 118  82  46)|
+|Normal Colors|(124 130 136 142 148 112  76  40  34  28  22)|
+|Subdued Colors|( 88  94 100 106  70  34  28  22)|
+
+Please note the following:
+* an array declarations start with `(` and end with `)`.
+* both the icon and background changing levels are automatically calculated, so they can be any length.
 
 ##### command_execution_time
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -463,9 +463,24 @@ prompt_battery() {
     message="$bat_percent%%"
   fi
 
-  # Draw the prompt_segment
-  if [[ -n $bat_percent ]]; then
-    "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${battery_states[$current_state]}" "$message" 'BATTERY_ICON'
+  # override default icon if we are using battery stages
+  if [[ -n "$POWERLEVEL9K_BATTERY_STAGES" ]]; then
+    local segment=$(( 100.0 / (${#POWERLEVEL9K_BATTERY_STAGES} - 1 ) ))
+    if [[ $segment > 1 ]]; then
+      local offset=$(( ($bat_percent / $segment) + 1 ))
+      # check if the stages are in an array or a string
+      [[ "${(t)POWERLEVEL9K_BATTERY_STAGES}" =~ "array" ]] && POWERLEVEL9K_BATTERY_ICON="$POWERLEVEL9K_BATTERY_STAGES[$offset]" || POWERLEVEL9K_BATTERY_ICON=${POWERLEVEL9K_BATTERY_STAGES:$offset:1}
+    fi
+  fi
+
+  # override the default color if we are using a color level array
+  if [[ -n "$POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND" ]] && [[ "${(t)POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND}" =~ "array" ]]; then
+    local segment=$(( 100.0 / (${#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND} - 1 ) ))
+    local offset=$(( ($bat_percent / $segment) + 1 ))
+    "$1_prompt_segment" "$0_${current_state}" "$2" "${POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND[$offset]}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
+  else
+    # Draw the prompt_segment
+    "$1_prompt_segment" "$0_${current_state}" "$2" "${DEFAULT_COLOR}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
   fi
 }
 


### PR DESCRIPTION
This PR allows the user to set a battery icon set using a string or array for different levels, 

```
# POWERLEVEL9K_BATTERY_STAGES accepts either a string or an array.
# Note that if you use a string for characters that are wider than a single character will cause the icon to be very
# close to the remaining time. In this case, it is better to use the array version of `POWERLEVEL9K_BATTERY_STAGES`,
# so that you can add a space after.

# Uncomment only one of the following, or create your own

#POWERLEVEL9K_BATTERY_STAGES=""	#  \uF244  \uF243  \uF242  \uF241  \uF240
#POWERLEVEL9K_BATTERY_STAGES=("\uF244 " "\uF243 " "\uF242 " "\uF241 " "\uF240 ")

#POWERLEVEL9K_BATTERY_STAGES="▁▂▃▄▅▆▇█"
#POWERLEVEL9K_BATTERY_STAGES=("\u2581" "\u2582" "\u2583" "\u2584" "\u2585" "\u2586" "\u2587" "\u2588")

#POWERLEVEL9K_BATTERY_STAGES="▏▎▍▌▋▊▉█"
#POWERLEVEL9K_BATTERY_STAGES=("\u258F" "\u258E" "\u258D" "\u258C" "\u258B" "\u258A" "\u2589" "\u2588")

# Uncomment all 5 lines if you want to use this indicator
#POWERLEVEL9K_BATTERY_STAGES=(
#	"▏    ▏" "▎    ▏" "▍    ▏" "▌    ▏" "▋    ▏" "▊    ▏" "▉    ▏" "█    ▏"
#	"█▏   ▏" "█▎   ▏" "█▍   ▏" "█▌   ▏" "█▋   ▏" "█▊   ▏" "█▉   ▏" "██   ▏"
#	"██   ▏" "██▎  ▏" "██▍  ▏" "██▌  ▏" "██▋  ▏" "██▊  ▏" "██▉  ▏" "███  ▏"
#	"███  ▏" "███▎ ▏" "███▍ ▏" "███▌ ▏" "███▋ ▏" "███▊ ▏" "███▉ ▏" "████ ▏"
#	"████ ▏" "████▎▏" "████▍▏" "████▌▏" "████▋▏" "████▊▏" "████▉▏" "█████▏" )
```

It also allows the user to override the default color based on the current charge using a color array.

```
# *** choose from here for changing background by current battery level
# set if you want the background to change color with level. this overrides the state settings in the color selection.
# You can still specify foreground color and bold though.
#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND=(196 202 208 214 220 226 190 154 118  82  46) # bright
#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND=(124 130 136 142 148 112  76  40  34  28  22) # normal
#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND=(  88  94 100 106  70  34  28  22) # subdued
```

*NOTE* This automatically calculates the icon and color changes based on the length of the array/string provided