### PR TITLE
Bring back space after branch indicator in default mode

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -265,7 +265,7 @@ case $POWERLEVEL9K_MODE in
       VCS_TAG_ICON                   ''
       VCS_BOOKMARK_ICON              $'\u263F'              # ☿
       VCS_COMMIT_ICON                ''
-      VCS_BRANCH_ICON                $'\uE0A0'              # 
+      VCS_BRANCH_ICON                $'\uE0A0 '             # 
       VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
       VCS_GIT_ICON                   ''
       VCS_GIT_GITHUB_ICON            ''

--- a/test/segments/vcs.spec
+++ b/test/segments/vcs.spec
@@ -21,7 +21,7 @@ function testColorOverridingForCleanStateWorks() {
   cd $FOLDER
   git init 1>/dev/null
 
-  assertEquals "%K{white} %F{cyan}master %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{white} %F{cyan} master %k%F{white}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -47,7 +47,7 @@ function testColorOverridingForModifiedStateWorks() {
   git commit -m "test" 1>/dev/null
   echo "test" > testfile
 
-  assertEquals "%K{yellow} %F{red}master ● %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{yellow} %F{red} master ● %k%F{yellow}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -68,7 +68,7 @@ function testColorOverridingForUntrackedStateWorks() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{yellow} %F{cyan}master ? %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{yellow} %F{cyan} master ? %k%F{yellow}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test


### PR DESCRIPTION
I don't understand why it got removed, it looks so ugly D: