### PR TITLE
Set necessary prompt expansion options as late as possible

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1290,6 +1290,12 @@ powerlevel9k_preexec() {
 
 set_default POWERLEVEL9K_PROMPT_ADD_NEWLINE false
 powerlevel9k_prepare_prompts() {
+  # The prompt function will set these prompt_* options after the setup function
+  # returns. We need prompt_subst so we can safely run commands in the prompt
+  # without them being double expanded and we need prompt_percent to expand the
+  # common percent escape sequences.
+  setopt PROMPT_SUBST PROMPT_PERCENT
+
   RETVAL=$?
 
   _P9K_COMMAND_DURATION=$((EPOCHREALTIME - _P9K_TIMER_START))
@@ -1334,12 +1340,6 @@ prompt_powerlevel9k_setup() {
   # Disable false display of command execution time
   # Maximum integer on 32-bit CPUs
   _P9K_TIMER_START=2147483647
-
-  # The prompt function will set these prompt_* options after the setup function
-  # returns. We need prompt_subst so we can safely run commands in the prompt
-  # without them being double expanded and we need prompt_percent to expand the
-  # common percent escape sequences.
-  prompt_opts=(subst percent)
 
   # Borrowed from promptinit, sets the prompt options in case the theme was
   # not initialized via promptinit.


### PR DESCRIPTION
Set PROMPT_SUBST and PROMPT_PERCENT right before we set PROMPT and
RPROMPT variables. This should fix the prompt even if you did not set PROMPT_SUBST yourself (or the used ZSH framework).

I don't know why I did not found this issue when I tested #496 , and it is still a mystery to me how PROMPT_SUBST is inherited to later called functions..

This should fix #506 

FYI: printing icons like `POWERLEVEL9K_DIR_PATH_SEPARATOR=' $(print_icon "LEFT_SUBSEGMENT_SEPARATOR") '` as @bhilburn explains in https://github.com/bhilburn/powerlevel9k/issues/506#issuecomment-298022553 can't be used any more, so this is not a fix for that.

I haven't had much time to test it carefully, so please double check it!
Btw. I'll have a look at the failing tests when I am back from vacation..

@onaforeignshore Could you confirm this fixes your issue?

//cc @belak 