### PR TITLE
Icons for Windows/Cygwin + Refixes 32-bit support

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -42,6 +42,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '
       APPLE_ICON                     $'\uE26E'              # 
+      WINDOWS_ICON                   $'\uE26F'              # 
       FREEBSD_ICON                   $'\U1F608 '            # 😈
       ANDROID_ICON                   $'\uE270'              # 
       LINUX_ICON                     $'\uE271'              # 
@@ -112,6 +113,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
+      WINDOWS_ICON                   $'\uF17A'              # 
       FREEBSD_ICON                   $'\U1F608 '            # 😈
       ANDROID_ICON                   $'\uE17B'              # 
       LINUX_ICON                     $'\uF17C'              # 
@@ -178,6 +180,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
+      WINDOWS_ICON                   $'\uF17A'              # 
       FREEBSD_ICON                   $'\UF30E '             # 
       ANDROID_ICON                   $'\uF17B'              # 
       LINUX_ICON                     $'\uF17C'              # 
@@ -244,6 +247,7 @@ case $POWERLEVEL9K_MODE in
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\u2500'
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\u2500 '
       APPLE_ICON                     'OSX'
+      WINDOWS_ICON                   'WIN'
       FREEBSD_ICON                   'BSD'
       ANDROID_ICON                   'And'
       LINUX_ICON                     'Lx'

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -85,6 +85,10 @@ case $(uname) in
       OS='OSX'
       OS_ICON=$(print_icon 'APPLE_ICON')
       ;;
+    CYGWIN_NT-*)
+      OS='Windows'
+      OS_ICON=$(print_icon 'WINDOWS_ICON')
+      ;;
     FreeBSD)
       OS='BSD'
       OS_ICON=$(print_icon 'FREEBSD_ICON')

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1295,7 +1295,7 @@ powerlevel9k_prepare_prompts() {
   _P9K_COMMAND_DURATION=$((EPOCHREALTIME - _P9K_TIMER_START))
 
   # Reset start time
-  _P9K_TIMER_START=0xFFFFFFFF
+  _P9K_TIMER_START=0x7FFFFFFF
 
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
     PROMPT='$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
@@ -1328,12 +1328,12 @@ NEWLINE='
 }
 
 prompt_powerlevel9k_setup() {
-  # I decided to use the value below for better supporting 32-bit CPUs, since the previous value "99999999999" was causing issues on my Android phone, which is powered by an armv7l
-  # We don't have to change that until 19 January of 2038! :)
+  # The value below was set to better support 32-bit CPUs.
+  # It's the maximum _signed_ integer value on 32-bit CPUs.
+  # Please don't change it until 19 January of 2038. ;)
 
   # Disable false display of command execution time
-  # Maximum integer on 32-bit CPUs
-  _P9K_TIMER_START=2147483647
+  _P9K_TIMER_START=0x7FFFFFFF
 
   # The prompt function will set these prompt_* options after the setup function
   # returns. We need prompt_subst so we can safely run commands in the prompt


### PR DESCRIPTION
Windows icons! See my comment here about the 32-bit refix:

https://github.com/bhilburn/powerlevel9k/pull/480#issuecomment-299676867

![cygwin](https://cloud.githubusercontent.com/assets/27077338/25781609/0e95cf36-3312-11e7-8e3f-61fa270fcead.png)
