### PR TITLE
Added Kubernetes current context with "helm" icon

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1241,6 +1241,17 @@ prompt_dir_writable() {
   fi
 }
 
+# Kubernetes Current Context
+prompt_kubecontext() {
+  local kubectl=$(kubectl version 2>/dev/null)
+
+  if [[ -n "kubectl_version" ]]; then
+     # Get the current Kuberenetes context
+     local k8s_context=$(kubectl config current-context)
+     "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context \u2388"
+  fi
+}
+
 ################################################################
 # Prompt processing and drawing
 ################################################################

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1246,9 +1246,11 @@ prompt_kubecontext() {
   local kubectl=$(kubectl version 2>/dev/null)
 
   if [[ -n "kubectl_version" ]]; then
-     # Get the current Kuberenetes context
-     local k8s_context=$(kubectl config current-context)
-     "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context \u2388"
+    # Get the current Kubernetes config context's namespaece
+    local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
+    # Get the current Kuberenetes context
+    local k8s_context=$(kubectl config current-context)
+    "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context/$k8s_namespace \u2388"
   fi
 }
 


### PR DESCRIPTION
I created this little addition locally and thought someone else might enjoy this. It's the current context of your `kubectl` config. Whatever your current is set to it will show in the prompt with the Unicode [Helm](http://www.fileformat.info/info/unicode/char/2388/index.htm) symbol.

Let me know if I need to add anything else or change the function!