### PR TITLE
"newline" segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The segments that are currently available are:
 * [`command_execution_time`](#command_execution_time) - Display the time the current command took to execute.
 * [`todo`](http://todotxt.com/) - Shows the number of tasks in your todo.txt tasks file.
 * `detect_virt` - Virtualization detection with systemd
+* `newline` - Continues the prompt on a new line.
 
 ---------------------------------------------------------------------------------
 
@@ -441,6 +442,13 @@ segment will not be displayed.
 |`POWERLEVEL9K_PUBLIC_IP_TIMEOUT`|300|The amount of time in seconds between refreshing your cached IP.|
 |`POWERLEVEL9K_PUBLIC_IP_METHODS`|(dig curl wget)| These methods in that order are used to refresh your IP.|
 |`POWERLEVEL9K_PUBLIC_IP_NONE`|None|The string displayed when an IP was not obtained|
+
+##### newline
+
+Puts a newline in your prompt so you can continue using segments on the next line.
+
+This allows you to use segments on both lines, unlike `POWERLEVEL9K_PROMPT_ON_NEWLINE` and
+`POWERLEVEL9K_RPROMPT_ON_NEWLINE`.
 
 ##### rbenv
 

--- a/README.md
+++ b/README.md
@@ -447,8 +447,9 @@ segment will not be displayed.
 
 Puts a newline in your prompt so you can continue using segments on the next line.
 
-This allows you to use segments on both lines, unlike `POWERLEVEL9K_PROMPT_ON_NEWLINE` and
-`POWERLEVEL9K_RPROMPT_ON_NEWLINE`.
+This allows you to use segments on both lines, unlike `POWERLEVEL9K_PROMPT_ON_NEWLINE`.
+
+This only works on the left side.  On the right side it does nothing.
 
 ##### rbenv
 

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -39,8 +39,9 @@ case $POWERLEVEL9K_MODE in
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
       NODE_ICON                      $'\u2B22'              # ⬢
-      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'
-      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '
+      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_NEWLINE_PROMPT_PREFIX  $'\u251C'$'\U2500'   # ├─
+      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uE26E'              # 
       WINDOWS_ICON                   $'\uE26F'              # 
       FREEBSD_ICON                   $'\U1F608 '            # 😈
@@ -111,6 +112,7 @@ case $POWERLEVEL9K_MODE in
       SYMFONY_ICON                   'SF'
       NODE_ICON                      $'\u2B22'              # ⬢
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_NEWLINE_PROMPT_PREFIX  $'\u251C'$'\U2500'   # ├─
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
       WINDOWS_ICON                   $'\uF17A'              # 
@@ -178,6 +180,7 @@ case $POWERLEVEL9K_MODE in
       SYMFONY_ICON                   $'\uE757'              # 
       NODE_ICON                      $'\uE617 '             # 
       MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_NEWLINE_PROMPT_PREFIX  $'\u251C'$'\U2500'   # ├─
       MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     $'\uF179'              # 
       WINDOWS_ICON                   $'\uF17A'              # 
@@ -244,8 +247,9 @@ case $POWERLEVEL9K_MODE in
       FAIL_ICON                      $'\u2718'              # ✘
       SYMFONY_ICON                   'SF'
       NODE_ICON                      $'\u2B22'              # ⬢
-      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\u2500'
-      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\u2500 '
+      MULTILINE_FIRST_PROMPT_PREFIX  $'\u256D'$'\U2500'     # ╭─
+      MULTILINE_NEWLINE_PROMPT_PREFIX  $'\u251C'$'\U2500'   # ├─
+      MULTILINE_SECOND_PROMPT_PREFIX $'\u2570'$'\U2500 '    # ╰─
       APPLE_ICON                     'OSX'
       WINDOWS_ICON                   'WIN'
       FREEBSD_ICON                   'BSD'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -337,6 +337,21 @@ prompt_background_jobs() {
   fi
 }
 
+# A newline in your prompt, so you can segments on multiple lines.
+prompt_newline() {
+  local lws rws
+  lws=$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
+  rws=$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS
+  POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=
+  POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS=
+  "$1_prompt_segment" \
+    "$0" \
+    "$2" \
+    "NONE" "NONE" $'\n'
+  POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=$lws
+  POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS=$rws
+}
+
 # Segment that indicates usage level of current partition.
 set_default POWERLEVEL9K_DISK_USAGE_ONLY_WARNING false
 set_default POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL 90

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -339,17 +339,15 @@ prompt_background_jobs() {
 
 # A newline in your prompt, so you can segments on multiple lines.
 prompt_newline() {
-  local lws rws
+  local lws
+  [[ "$1" == "right" ]] && return
   lws=$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
-  rws=$POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS
   POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=
-  POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS=
   "$1_prompt_segment" \
     "$0" \
     "$2" \
     "NONE" "NONE" $'\n'
   POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=$lws
-  POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS=$rws
 }
 
 # Segment that indicates usage level of current partition.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -339,14 +339,18 @@ prompt_background_jobs() {
 
 # A newline in your prompt, so you can segments on multiple lines.
 prompt_newline() {
-  local lws
+  local lws newline
   [[ "$1" == "right" ]] && return
+  newline=$'\n'
   lws=$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
+  if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
+    newline="${newline}$(print_icon 'MULTILINE_NEWLINE_PROMPT_PREFIX')"
+  fi
   POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=
   "$1_prompt_segment" \
     "$0" \
     "$2" \
-    "NONE" "NONE" $'\n'
+    "NONE" "NONE" "${newline}"
   POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=$lws
 }
 


### PR DESCRIPTION
This works only for `POWERLEVEL9K_LEFT_PROMPT_ELEMENTS`.

It can't work for the right-hand prompt (`RPROMPT`) because multi-line is handled
via terminal trickery (moving the cursor and restoring it).

This is against the `next` branch as requested by @bhilburn on #518

@bhilburn asked:

> 1. What happens if the user turns this on and also turns on PROMPT_ON_NEWLINE?
> 1. Can you file against `next`? ;)
> 1. We should be sure to add a bit about this to the Wiki once it is merged.
> 1. Is there any limit to the number of times you can use this segment in a prompt?

1. It works, but it doesn't have the appropriate ansi art in first two characters... Let me see if I can fix that.
1. Done!
1. 👍 😃 
1. Nope.  It works all you want, though it it can look silly. :smiley: