### PR TITLE
add function to disable powerlevel9k hooks

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1412,4 +1412,9 @@ prompt_powerlevel9k_setup() {
   add-zsh-hook preexec powerlevel9k_preexec
 }
 
+prompt_powerlevel9k_teardown() {
+  add-zsh-hook -D precmd powerlevel9k_\*
+  add-zsh-hook -D preexec powerlevel9k_\*
+}
+
 prompt_powerlevel9k_setup "$@"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1415,6 +1415,8 @@ prompt_powerlevel9k_setup() {
 prompt_powerlevel9k_teardown() {
   add-zsh-hook -D precmd powerlevel9k_\*
   add-zsh-hook -D preexec powerlevel9k_\*
+  PROMPT='%m%# '
+  RPROPT=
 }
 
 prompt_powerlevel9k_setup "$@"


### PR DESCRIPTION
This disables the hooks.  If you try to change the prompt (e.g. `PROMPT='$ '`) then
it'll revert right back to powerlevel9k because the hooks rebuild the `PROMPT`s.


Usage:

``` sh
 OSX > ~/.zgen/bhilburn/powerlevel9k-master > pr/teardown ↑1 >
 ✓ > prompt_powerlevel9k_teardown
lithium% echo "look ma, no powerlevel9k prompt"
look ma, no powerlevel9k prompt
lithium% prompt_powerlevel9k_setup
 OSX > ~/.zgen/bhilburn/powerlevel9k-master > pr/teardown ↑1 >
 ✓ >
```