### PR TITLE
nvm: improve default detection

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -889,13 +889,16 @@ prompt_node_version() {
 # Node version from NVM
 # Only prints the segment if different than the default value
 prompt_nvm() {
-  [[ ! $(type nvm) =~ 'nvm is a shell function'* ]] && return
-  local node_version=$(nvm current)
-  [[ -z "${node_version}" ]] || [[ ${node_version} = "none" ]] && return
-  local nvm_default=$(cat $NVM_DIR/alias/default)
+  local node_version nvm_default
+  (( $+functions[nvm_version] )) || return
+
+  node_version=$(nvm_version current)
+  [[ -z "${node_version}" || ${node_version} == "none" ]] && return
+
+  nvm_default=$(nvm_version default)
   [[ "$node_version" =~ "$nvm_default" ]] && return
 
-  $1_prompt_segment "$0" "$2" "green" "011" "${node_version:1}" 'NODE_ICON'
+  $1_prompt_segment "$0" "$2" "magenta" "black" "${node_version:1}" 'NODE_ICON'
 }
 
 # NodeEnv Prompt


### PR DESCRIPTION
This is also (marginally) faster than before.

As a side-effect of these changes, it won't trigger nvm if you're using the zsh-nvm plugin and have lazy loading set.

With the previous code, there was no point to setting lazy load because the prompt would load it immediately.

@bhilburn said on PR #516

> Not being a nvm user, or even a Node.js developer, myself, I'm not knowledgeable enough to review the code. That said, a couple of items:
>
> 1. Would you mind re-submitting this PR against next?
> 1. What happens if nvm isn't loaded due to the lazy loading bit you mentioned above? Does the segment just not print (fail gracefully)?
>
> I'd like to get @dritter's review on your new PR because I believe he is a Node.js user? ;)

1. Done!
1. Correct.  The segment isn't printed if `nvm` isn't available or is not loaded yet.