### PR TITLE
Merging onaforeignshore's new `date` segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The segments that are currently available are:
 * [`background_jobs`](#background_jobs) - Indicator for background jobs.
 * [`battery`](#battery) - Current battery status.
 * [`context`](#context) - Your username and host, conditionalized based on $USER and SSH status.
+* [`date`](#date) - System date.
 * [`dir`](#dir) - Your current working directory.
 * `dir_writable` - Displays a lock icon, if you do not have write permissions on the current folder.
 * [`disk_usage`](#disk_usage) - Disk usage of your current partition.
@@ -330,6 +331,14 @@ end of the hostname.
 |`POWERLEVEL9K_ALWAYS_SHOW_USER`|false|Always show the username, but conditionalize the hostname.|
 |`POWERLEVEL9K_CONTEXT_TEMPLATE`|%n@%m|Default context prompt (username@machine). Refer to the [ZSH Documentation](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html) for all possible expansions, including deeper host depths.|
 
+##### date
+
+The `date` segment shows the current system date.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_DATE_FORMAT`|`%D{%d.%m.%y}`|[ZSH time format](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html) to use in this segment.|
+
 ##### dir
 
 The `dir` segment shows the current working directory. When using the "Awesome
@@ -383,7 +392,7 @@ The `truncate_with_package_name` strategy gives your directory path relative to 
 }
 ```
 
-the path shown would be `my-cool-project`.  If you navigate to `$HOME/projects/my-project/src`, then the path shown would be `my-cool-project/src`.  Please note that this currently looks for `.git` directory to determine the root of the project.
+The path shown would be `my-cool-project`.  If you navigate to `$HOME/projects/my-project/src`, then the path shown would be `my-cool-project/src`.  Please note that this currently looks for `.git` directory to determine the root of the project.
 
 If you want to customize the directory separator, you could set:
 ```zsh
@@ -398,7 +407,6 @@ You can also customize the leading tilde character when you are in `$HOME` using
 # Double quotes are important here!
 POWERLEVEL9K_HOME_FOLDER_ABBREVIATION="%F{red} $(print_icon 'HOME_ICON') %F{black}"
 ```
-
 
 ##### disk_usage
 
@@ -502,6 +510,7 @@ segment, as well:
 # Output time, date, and a symbol from the "Awesome Powerline Font" set
 POWERLEVEL9K_TIME_FORMAT="%D{%H:%M:%S \uE868  %d.%m.%y}"
 ```
+
 ##### vcs
 
 By default, the `vcs` segment will provide quite a bit of information. Further

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -84,6 +84,8 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\UE89C'              # 
       SSH_ICON                       '(ssh)'
+      DATE_ICON                      $'\uE184'              # 
+      TIME_ICON                      $'\uE12E'              # 
     )
   ;;
   'awesome-fontconfig')
@@ -152,6 +154,8 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\uF253'
       SSH_ICON                       '(ssh)'
+      DATE_ICON                      $'\uF073 '             # 
+      TIME_ICON                      $'\uF017 '             # 
     )
   ;;
   'nerdfont-complete'|'nerdfont-fontconfig')
@@ -220,6 +224,8 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UF023'              #  
       EXECUTION_TIME_ICON            $'\uF252'              #  
       SSH_ICON                       $'\uF489'              #  
+      DATE_ICON                      $'\uF073 '             # 
+      TIME_ICON                      $'\uF017 '             # 
     )
   ;;
   *)
@@ -288,6 +294,8 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE0A2'
       EXECUTION_TIME_ICON            'Dur'
       SSH_ICON                       '(ssh)'
+      DATE_ICON                      $''                    #
+      TIME_ICON                      $''                    #
     )
   ;;
 esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1130,6 +1130,16 @@ build_test_stats() {
   (( ratio < 50 )) && "$1_prompt_segment" "$2_BAD" "$3" "red" "$DEFAULT_COLOR" "$headline: $ratio%%" "$6"
 }
 
+# System date
+prompt_date() {
+  local date_format "%D{%d.%m.%y}"
+  if [[ -n "$POWERLEVEL9K_DATE_FORMAT" ]]; then
+    date_format="$POWERLEVEL9K_DATE_FORMAT"
+  fi
+
+  "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "${date_format}" "DATE_ICON"
+}
+
 # System time
 prompt_time() {
   local time_format="%D{%H:%M:%S}"
@@ -1137,7 +1147,7 @@ prompt_time() {
     time_format="$POWERLEVEL9K_TIME_FORMAT"
   fi
 
-  "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "$time_format"
+  "$1_prompt_segment" "$0" "$2" "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" "$time_format" "TIME_ICON"
 }
 
 # todo.sh: shows the number of tasks in your todo.sh file


### PR DESCRIPTION
This continues @onaforeignshore's work in #499.

It includes his commits as well as some changes I've made on top of them. The actual new segment code is very simple, but this PR includes a re-organization of all of the icon definitions to clean them up and make them alphabetical. This is a worthwhile change, but in retrospect, really shouldn't be in this PR because it unnecessarily complicates the merge of an otherwise very simple segment.

@dritter - I believe you made a test to confirm that each font configuration has all of the font definitions that all of the others have, so part of the reason I'm filing this PR is to trigger that CI test.

If the icons are just too much of a mess to include in this PR, I'll pull out the other changes and break this apart.