### PR TITLE
Added kubectl config's current context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - test/segments/rust_version.spec
   - test/segments/go_version.spec
   - test/segments/vcs.spec
+  - test/segments/kubecontext.spec

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -84,6 +84,7 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\UE89C'              # 
       SSH_ICON                       '(ssh)'
+      KUBERNETES_ICON                $'\U2388'              # ⎈
     )
   ;;
   'awesome-fontconfig')
@@ -152,6 +153,7 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\uF253'
       SSH_ICON                       '(ssh)'
+      KUBERNETES_ICON                $'\U2388'              # ⎈
     )
   ;;
   'nerdfont-complete'|'nerdfont-fontconfig')
@@ -220,6 +222,7 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UF023'              #  
       EXECUTION_TIME_ICON            $'\uF252'              #  
       SSH_ICON                       $'\uF489'              #  
+      KUBERNETES_ICON                $'\U2388'              # ⎈
     )
   ;;
   *)
@@ -288,6 +291,7 @@ case $POWERLEVEL9K_MODE in
       LOCK_ICON                      $'\UE0A2'
       EXECUTION_TIME_ICON            'Dur'
       SSH_ICON                       '(ssh)'
+      KUBERNETES_ICON                $'\U2388'              # ⎈
     )
   ;;
 esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1362,6 +1362,10 @@ prompt_kubecontext() {
     local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
     # Get the current Kuberenetes context
     local k8s_context=$(kubectl config current-context)
+
+    if [[ -z "$k8s_namespace" ]]; then
+      k8s_namespace="default"
+    fi
     "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context/$k8s_namespace" "KUBERNETES_ICON"
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1362,7 +1362,7 @@ prompt_kubecontext() {
     local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
     # Get the current Kuberenetes context
     local k8s_context=$(kubectl config current-context)
-    "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context/$k8s_namespace \u2388"
+    "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context/$k8s_namespace" "KUBERNETES_ICON"
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1355,9 +1355,9 @@ prompt_dir_writable() {
 
 # Kubernetes Current Context
 prompt_kubecontext() {
-  local kubectl=$(kubectl version 2>/dev/null)
+  local kubectl_version=$(kubectl version 2>/dev/null)
 
-  if [[ -n "kubectl_version" ]]; then
+  if [[ -n "$kubectl_version" ]]; then
     # Get the current Kubernetes config context's namespaece
     local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
     # Get the current Kuberenetes context

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1353,6 +1353,20 @@ prompt_dir_writable() {
   fi
 }
 
+# Kubernetes Current Context
+prompt_kubecontext() {
+  local kubectl=$(kubectl version 2>/dev/null)
+
+  if [[ -n "kubectl_version" ]]; then
+    # Get the current Kubernetes config context's namespaece
+    local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
+    # Get the current Kuberenetes context
+    local k8s_context=$(kubectl config current-context)
+    "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_context/$k8s_namespace \u2388"
+  fi
+}
+
+
 ################################################################
 # Prompt processing and drawing
 ################################################################

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -1,0 +1,80 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function mockKubectl() {
+  case "$1" in
+    'version')
+      echo 'non-empty text'
+      ;;
+    'config')
+      case "$2" in
+        'current-context')
+          echo 'minikube'
+          ;;
+        'get-contexts')
+          echo '* minikube minikube minikube '
+          ;;
+      esac
+      ;;
+  esac
+}
+
+function mockKubectlOtherNamespace() {
+  case "$1" in
+    'version')
+      echo 'non-empty text'
+      ;;
+    'config')
+      case "$2" in
+        'current-context')
+          echo 'minikube'
+          ;;
+        'get-contexts')
+          echo '* minikube minikube minikube kube-system'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+function testKubeContext() {
+  alias kubectl=mockKubectl
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
+
+  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unalias kubectl
+}
+function testKubeContextOtherNamespace() {
+  alias kubectl=mockKubectlOtherNamespace
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
+
+  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unalias kubectl
+}
+function testKubeContextPrintsNothingIfKubectlNotAvailable() {
+  alias kubectl=noKubectl
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world kubecontext)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias kubectl
+}
+
+source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
I created this little addition locally and thought someone else might enjoy this. It's the current context of your `kubectl` config. Whatever your current is set to it will show in the prompt with the Unicode [Helm](http://www.fileformat.info/info/unicode/char/2388/index.htm) symbol.

Let me know if I need to add anything else or change the function!