### PR TITLE
Fixed RVM segment for usernames with dashes

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -990,7 +990,7 @@ prompt_rvm() {
   local gemset=$(echo $GEM_HOME | awk -F'@' '{print $2}')
   [ "$gemset" != "" ] && gemset="@$gemset"
 
-  local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
+  local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $NF}')
 
   if [[ -n "$version$gemset" ]]; then
     "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$version$gemset" 'RUBY_ICON'


### PR DESCRIPTION
Having a username with a dash, such as mine, `d-side`, currently results in RVM segment displaying the wrong thing, e. g. `side/.rvm/rubies/ruby` (for `MY_RUBY_HOME=/home/d-side/.rvm/rubies/ruby-2.4.1`).

This is a kind of a dirty fix for the issue, I just forced `awk` to grab the last column, instead of 2nd. I'm not particularly fond of this approach, but this does work for my cases and doesn't (probably) introduce additional breakage.

Additional suggestions welcome.