### PR TITLE
Provide support for a prompt option for kubernetes-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The segments that are currently available are:
     * [`aws`](#aws) - The current AWS profile, if active.
     * `aws_eb_env` - The current Elastic Beanstalk Environment.
 * `docker_machine` - The current Docker Machine.
+* `kubernetes` - The current Kubernetes Cluster.
 
 **Other:**
 * [`custom_command`](#custom_command) - Create a custom segment to display the

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -768,6 +768,16 @@ prompt_history() {
   "$1_prompt_segment" "$0" "$2" "244" "$DEFAULT_COLOR" '%h'
 }
 
+# Kubernetes
+prompt_kubernetes() {
+  # Get current context
+  local context="$( cat ~/.kube/config 2>/dev/null | grep "current-context:" | sed "s/current-context: //" ) "
+
+  if [[ -n "$context" ]]; then
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$context" 'SERVER_ICON'
+  fi
+}
+
 # Detection for virtualization (systemd based systems only)
 prompt_detect_virt() {
   if ! command -v systemd-detect-virt > /dev/null; then


### PR DESCRIPTION
The current context is useful information much like docker_machine and current working directory.
The current context configured inside .kube/config directory points to the current k8s cluster.