### PR TITLE
Fixed no auth info in kubecontext

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1366,7 +1366,7 @@ prompt_dir_writable() {
 
 # Kubernetes Current Context
 prompt_kubecontext() {
-  local kubectl_version=$(kubectl version 2>/dev/null)
+  local kubectl_version=$(kubectl version --client 2>/dev/null)
 
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kubernetes config context's namespaece

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1370,7 +1370,7 @@ prompt_kubecontext() {
 
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kubernetes config context's namespaece
-    local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')
+    local k8s_namespace=$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $NF}')
     # Get the current Kuberenetes context
     local k8s_context=$(kubectl config current-context)
 

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -47,6 +47,24 @@ function mockKubectlOtherNamespace() {
   esac
 }
 
+function mockKubectlOtherNamespaceNoAuthInfo() {
+  case "$1" in
+    'version')
+      echo 'non-empty text'
+      ;;
+    'config')
+      case "$2" in
+        'current-context')
+          echo 'alternate'
+          ;;
+        'get-contexts')
+          echo '* alternate alternate   alternateNamespace'
+          ;;
+      esac
+      ;;
+  esac
+}
+
 function testKubeContext() {
   alias kubectl=mockKubectl
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
@@ -74,6 +92,14 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias kubectl
+}
+function testKubeContextOtherNamespaceNoAuthInfo(){
+  alias kubectl=noKubectl
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
+
+  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}alternate/alternatenamespace %k%F{magenta}%f " "$(build_left_prompt)"
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
 }
 


### PR DESCRIPTION
Fixed when no auth info is inside the contexts