### PR TITLE
Unset variables that interfere with named directories

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -86,6 +86,10 @@ source $script_location/functions/colors.zsh
 
 source $script_location/functions/vcs.zsh
 
+# variables now unneeded: forget them
+# they could interfere with named directories
+unset filename script_location
+
 ################################################################
 # Color Scheme
 ################################################################


### PR DESCRIPTION
If left defined, `~script_location` appears in the prompt when navigating to
powerlevel9k's checkout directory (due to `setopt autonamedirs`, it's a named
directory)