### PR TITLE
test-in-docker: quickly test frameworks in docker

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -26,7 +26,21 @@ This is the easiest to use _if_ you have Docker already installed and running.
 The command `./test-in-docker` should make it fairly easy to get into a running
 container with the framework of your choice.
 
+Examples:
+
+``` zsh
+# Test Antigen with the oldest version of ZSH
+$ ./test-in-docker antigen
+```
+
+``` zsh
+# Test Prezto with ZSH version 5.2
+$ ./test-in-docker --zsh 5.2 prezto
+```
+
 You can get Docker at <https://www.docker.com/community-edition>.
+
+**Note:** Not all frameworks work with all versions of ZSH (or the underlying OS).
 
 ## Vagrant
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -13,10 +13,23 @@ Tests in separate files under `test/functions`.
 These Tests tend to be more complex in setup than the basic tests. To avoid ending
 up in a huge single file, there is one file per segment in `test/segments`.
 
-# Test-VMs
+# Manual Testing
 
 If unit tests are not sufficient (e.g. you have an issue with your prompt that
-occurs only in a specific ZSH framework), then you could use our Test-VMs!
+occurs only in a specific ZSH framework) then you can use either Docker or
+or our Vagrant.
+
+## Docker
+
+This is the easiest to use _if_ you have Docker already installed and running.
+
+The command `./test-in-docker` should make it fairly easy to get into a running
+container with the framework of your choice.
+
+You can get Docker at <https://www.docker.com/community-edition>.
+
+## Vagrant
+
 Currently there are two test VMs. `test-vm` is an Ubuntu machine with several
 pre-installed ZSH frameworks. And there is `test-bsd-vm` which is a FreeBSD!
 For how to run the machines see [here](test-vm/README.md).

--- a/docker/antibody/Dockerfile
+++ b/docker/antibody/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/antibody/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/antibody/zshrc .zshrc

--- a/docker/antibody/Dockerfile
+++ b/docker/antibody/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/antibody/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/antibody/install.zsh
+++ b/docker/antibody/install.zsh
@@ -1,0 +1,1 @@
+curl -sL https://git.io/antibody | bash -s

--- a/docker/antibody/zshrc
+++ b/docker/antibody/zshrc
@@ -1,0 +1,2 @@
+source <(antibody init)
+antibody bundle ~/p9k/

--- a/docker/antigen/Dockerfile
+++ b/docker/antigen/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/antigen/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/antigen/zshrc .zshrc

--- a/docker/antigen/Dockerfile
+++ b/docker/antigen/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/antigen/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/antigen/install.zsh
+++ b/docker/antigen/install.zsh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+mkdir ~/antigen
+
+curl \
+  -qLsSf \
+  -o ~/antigen/antigen.zsh \
+  https://git.io/antigen
+
+source ~/antigen/antigen.zsh
+
+# EOF

--- a/docker/antigen/zshrc
+++ b/docker/antigen/zshrc
@@ -1,0 +1,4 @@
+source ~/antigen/antigen.zsh
+
+antigen theme "${HOME}/p9k" powerlevel9k --no-local-clone
+antigen apply

--- a/docker/base-4.3.11/Dockerfile
+++ b/docker/base-4.3.11/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:6
+
+RUN \
+  yum install -y \
+  curl \
+  git \
+  zsh \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  node \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo
+
+RUN adduser --shell /bin/zsh --comment 'fred' --user-group fred
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.0.3/Dockerfile
+++ b/docker/base-5.0.3/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:14.04
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  node \
+  ruby \
+  python \
+  python-virtualenv
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.1.1/Dockerfile
+++ b/docker/base-5.1.1/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:16.04
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.2/Dockerfile
+++ b/docker/base-5.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:17.04
 
 RUN \
   apt-get update && \
@@ -11,10 +11,12 @@ RUN \
   subversion \
   golang \
   jq \
-  node \
+  nodejs \
   ruby \
   python \
-  python-virtualenv
+  python-virtualenv \
+  sudo \
+  locales
 
 RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
 RUN locale-gen "en_US.UTF-8"

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:trusty
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  node \
+  ruby \
+  python \
+  python-virtualenv
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/dotfile/Dockerfile
+++ b/docker/dotfile/Dockerfile
@@ -1,0 +1,4 @@
+FROM p9k:base
+
+COPY ./ p9k/
+COPY docker/dotfile/zshrc .zshrc

--- a/docker/dotfile/Dockerfile
+++ b/docker/dotfile/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY ./ p9k/
 COPY docker/dotfile/zshrc .zshrc

--- a/docker/dotfile/zshrc
+++ b/docker/dotfile/zshrc
@@ -1,0 +1,1 @@
+source "${HOME}/p9k/prompt_powerlevel9k_setup"

--- a/docker/fred-sudoers
+++ b/docker/fred-sudoers
@@ -1,0 +1,2 @@
+Defaults:fred !requiretty
+fred ALL=(ALL) NOPASSWD: ALL

--- a/docker/omz/Dockerfile
+++ b/docker/omz/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/omz/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY docker/omz/zshrc .zshrc
+COPY ./ p9k/

--- a/docker/omz/Dockerfile
+++ b/docker/omz/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/omz/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/omz/install.zsh
+++ b/docker/omz/install.zsh
@@ -1,0 +1,4 @@
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+
+mkdir -p ~/.oh-my-zsh/custom/themes
+ln -nsf ~/p9k/ ~/.oh-my-zsh/custom/themes/powerlevel9k

--- a/docker/omz/zshrc
+++ b/docker/omz/zshrc
@@ -1,0 +1,5 @@
+export ZSH=$HOME/.oh-my-zsh
+ZSH_THEME="powerlevel9k/powerlevel9k"
+plugins=(git rake ruby)
+
+source $ZSH/oh-my-zsh.sh

--- a/docker/prezto/Dockerfile
+++ b/docker/prezto/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/prezto/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/prezto/Dockerfile
+++ b/docker/prezto/Dockerfile
@@ -1,0 +1,6 @@
+FROM p9k:base
+
+COPY docker/prezto/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/

--- a/docker/prezto/install.zsh
+++ b/docker/prezto/install.zsh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+set -eu
+
+git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
+
+setopt EXTENDED_GLOB
+for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
+  ln -nsf "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+done
+
+ln -s "${HOME}/p9k/powerlevel9k.zsh-theme" \
+  "${HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
+
+echo "zstyle ':prezto:module:prompt' theme 'powerlevel9k'" \
+  >> "${HOME}/.zpreztorc"
+
+# EOF

--- a/docker/zgen/Dockerfile
+++ b/docker/zgen/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zgen/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zgen/Dockerfile
+++ b/docker/zgen/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/zgen/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/zgen/zshrc .zshrc

--- a/docker/zgen/install.zsh
+++ b/docker/zgen/install.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+
+git clone https://github.com/tarjoilija/zgen.git "${HOME}/.zgen"
+
+# EOF

--- a/docker/zgen/zshrc
+++ b/docker/zgen/zshrc
@@ -1,0 +1,10 @@
+# load zgen
+source ~/.zgen/zgen.zsh
+
+# if the init scipt doesn't exist
+if ! zgen saved; then
+  zgen load ~/p9k/powerlevel9k.zsh-theme
+
+  # generate the init script from plugins above
+  zgen save
+fi

--- a/docker/zim/Dockerfile
+++ b/docker/zim/Dockerfile
@@ -1,0 +1,6 @@
+FROM p9k:base
+
+COPY docker/zim/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/

--- a/docker/zim/Dockerfile
+++ b/docker/zim/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zim/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zim/install.zsh
+++ b/docker/zim/install.zsh
@@ -1,0 +1,21 @@
+#!zsh
+
+git clone --recursive https://github.com/Eriner/zim.git "${ZDOTDIR:-${HOME}}/.zim"
+
+setopt EXTENDED_GLOB
+for template_file ( ${ZDOTDIR:-${HOME}}/.zim/templates/* ); do
+  user_file="${ZDOTDIR:-${HOME}}/.${template_file:t}"
+  touch ${user_file}
+  ( print -rn "$(<${template_file})$(<${user_file})" >! ${user_file} ) 2>/dev/null
+done
+
+source "${ZDOTDIR:-${HOME}}/.zlogin"
+
+ln -nsf \
+  ~/p9k/ \
+  ~/.zim/modules/prompt/external-themes/powerlevel9k
+ln -nsf \
+  ~/.zim/modules/prompt/external-themes/powerlevel9k/powerlevel9k.zsh-theme \
+  ~/.zim/modules/prompt/functions/prompt_powerlevel9k_setup
+
+sed -i "s/zprompt_theme='steeef'/zprompt_theme='powerlevel9k'/g" ~/.zimrc

--- a/docker/zplug/Dockerfile
+++ b/docker/zplug/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zplug/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zplug/Dockerfile
+++ b/docker/zplug/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/zplug/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/zplug/zshrc .zshrc

--- a/docker/zplug/install.zsh
+++ b/docker/zplug/install.zsh
@@ -1,0 +1,5 @@
+#!zsh
+
+curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh| zsh
+
+# git clone https://github.com/zplug/zplug "${HOME}/.zplug"

--- a/docker/zplug/zshrc
+++ b/docker/zplug/zshrc
@@ -1,0 +1,5 @@
+#!zsh
+
+source ~/.zplug/init.zsh
+zplug "${HOME}/p9k", use:"powerlevel9k.zsh-theme", from:local, as:theme
+zplug load --verbose

--- a/docker/zplugin/Dockerfile
+++ b/docker/zplugin/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/zplugin/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/zplugin/zshrc.plugins .zshrc.plugins

--- a/docker/zplugin/Dockerfile
+++ b/docker/zplugin/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zplugin/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zplugin/install.zsh
+++ b/docker/zplugin/install.zsh
@@ -1,0 +1,12 @@
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/psprint/zplugin/master/doc/install.sh)"
+
+# The 'zplugin snippet' only copies the .zsh-theme file, not everything else.
+mkdir -p ~/.zplugin/snippets
+ln -nsf \
+  ~/p9k/ \
+~/.zplugin/snippets/--SLASH--home--SLASH--fred--SLASH--p9k--SLASH--powerlevel9k--DOT--zsh-theme
+
+{
+  echo
+  echo "source ~/.zshrc.plugins"
+} >> ~/.zshrc

--- a/docker/zplugin/zshrc.plugins
+++ b/docker/zplugin/zshrc.plugins
@@ -1,0 +1,5 @@
+#!zsh
+
+zplugin load psprint zsh-navigation-tools
+zplugin load psprint---zprompts
+zplugin snippet ~/p9k/powerlevel9k.zsh-theme

--- a/docker/zpm/Dockerfile
+++ b/docker/zpm/Dockerfile
@@ -1,0 +1,7 @@
+FROM p9k:base
+
+COPY docker/zpm/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/
+COPY docker/zpm/zshrc .zshrc

--- a/docker/zpm/Dockerfile
+++ b/docker/zpm/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zpm/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zpm/install.zsh
+++ b/docker/zpm/install.zsh
@@ -1,0 +1,6 @@
+# install zpm
+git clone --recursive https://github.com/zpm-zsh/zpm.git ~/.zpm
+
+# Install powerlevel9k
+mkdir ~/.zpm/plugins/powerlevel9k
+ln -s ~/p9k/powerlevel9k.zsh-theme ~/.zpm/plugins/powerlevel9k/powerlevel9k.plugin.zsh

--- a/docker/zpm/zshrc
+++ b/docker/zpm/zshrc
@@ -1,0 +1,3 @@
+source ~/.zpm/zpm.zsh
+
+zpm load powerlevel9k

--- a/docker/zulu/Dockerfile
+++ b/docker/zulu/Dockerfile
@@ -1,0 +1,6 @@
+FROM p9k:base
+
+COPY docker/zulu/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/

--- a/docker/zulu/Dockerfile
+++ b/docker/zulu/Dockerfile
@@ -1,4 +1,5 @@
-FROM p9k:base
+ARG base
+FROM p9k:${base}
 
 COPY docker/zulu/install.zsh /tmp/
 RUN zsh /tmp/install.zsh

--- a/docker/zulu/install.zsh
+++ b/docker/zulu/install.zsh
@@ -1,0 +1,10 @@
+#!zsh
+
+# install zulu https://github.com/zulu-zsh/zulu
+curl -L https://git.io/zulu-install | zsh && zsh
+
+{
+echo 'zulu fpath add ~/p9k'
+echo 'zulu fpath add ~/p9k/functions'
+echo 'zulu theme powerlevel9k'
+} >> ~/.zshrc

--- a/test-in-docker
+++ b/test-in-docker
@@ -1,0 +1,85 @@
+#!/usr/bin/env zsh
+
+set -eu
+
+setopt extendedglob
+cd "${${(%):-%x}:A:h}"
+
+# TODO: Crazy Logic to munge TERM to something supported in Ubuntu 14.04
+term=screen-256color
+
+frameworks()
+{
+  for path in docker/*/Dockerfile(N.); do
+    framework=${path:h:t}
+    if [[ "$framework" == base ]]; then continue; fi
+    echo "$framework"
+  done
+}
+
+show-help()
+{
+  echo "Usage: ${(%):-%x} <framework>|--list"
+  echo
+  echo "Loads up a docker image with powershell9k configured in <framework>"
+  echo
+  echo " --list  Lists all available framework containers."
+  echo
+  echo "Framework containers:"
+  for f in $(frameworks); do
+    echo " - $f"
+  done
+}
+
+build-and-run()
+{
+  local framework="$1" ; shift
+
+  print -P "%F{green}Preparing ${framework} container...%f"
+
+  if [[ "$framework" != "base" ]]; then
+    echo -n "p9k:base: "
+    docker build \
+      --quiet \
+      --tag p9k:base \
+      --file docker/base/Dockerfile \
+      .
+  fi
+  echo -n "p9k:${framework}: "
+  docker build \
+    --quiet \
+    --tag "p9k:${framework}" \
+    --file "docker/${framework}/Dockerfile" \
+    .
+
+
+  print -P "%F{green}Starting ${framework} container...%f"
+  exec docker run \
+    --rm \
+    --interactive \
+    --tty \
+    --hostname="${framework}" \
+    --env="TERM=${term}" \
+    "$@" \
+    "p9k:${framework}"
+}
+
+arg1="${1:-}"; if (( $# > 0 )); then shift; fi
+
+if [[ -z "$arg1" ]] || [[ "$arg1" == "help" ]]; then
+  show-help
+  exit 0
+elif [[ "$arg1" == '--list' ]]; then
+  frameworks
+  exit 0
+elif [[ -d "docker/${arg1}" ]]; then
+  build-and-run "$arg1"
+elif [[ -n "docker/${arg1}"*/Dockerfile(#qN) ]]; then
+  # Allow globbing
+  build-and-run "docker/${arg1}"*(Y1:t)
+else
+  show-help
+  exit 1
+fi
+
+# EOF

--- a/test-in-docker
+++ b/test-in-docker
@@ -2,84 +2,156 @@
 
 set -eu
 
-setopt extendedglob
+# The default ZSH to use.
+default_version='4.3.11'
+
+setopt extended_glob glob_subst numeric_glob_sort
 cd "${${(%):-%x}:A:h}"
 
 # TODO: Crazy Logic to munge TERM to something supported in Ubuntu 14.04
 term=screen-256color
 
-frameworks()
+# Note: If versions and frameworks looks complicated, it isn't that bad...
+# ...see Modifiers in zshexpn(1) for details.
+
+# List of ZSH versions
+typeset -a versions
+versions=( docker/base-*/Dockerfile(N.on:h:t:s/base-//) )
+
+# List of frameworks
+typeset -a frameworks
+frameworks=( docker/*/Dockerfile(N.on:h:t) )
+frameworks=${(@)frameworks:#base-*}
+
+err()
 {
-  for path in docker/*/Dockerfile(N.); do
-    framework=${path:h:t}
-    if [[ "$framework" == base ]]; then continue; fi
-    echo "$framework"
-  done
+  print -P "%F{red}Error:%f $*"
+  exit 2
 }
 
-show-help()
-{
-  echo "Usage: ${(%):-%x} <framework>|--list"
-  echo
-  echo "Loads up a docker image with powershell9k configured in <framework>"
-  echo
-  echo " --list  Lists all available framework containers."
-  echo
-  echo "Framework containers:"
-  for f in $(frameworks); do
-    echo " - $f"
-  done
-}
-
-build-and-run()
-{
-  local framework="$1" ; shift
-
-  print -P "%F{green}Preparing ${framework} container...%f"
-
-  if [[ "$framework" != "base" ]]; then
-    echo -n "p9k:base: "
-    docker build \
-      --quiet \
-      --tag p9k:base \
-      --file docker/base/Dockerfile \
-      .
+resolve_framework() {
+  local f=$1 found
+  found=${frameworks[(In:-1:)$f*]}
+  if (( found <= $#frameworks )); then
+    echo "${frameworks[$found]}"
   fi
-  echo -n "p9k:${framework}: "
+}
+
+resolve_version() {
+  local v=$1 found
+  found=${versions[(In:-1:)$v*]}
+  if (( found <= $#versions )); then
+    echo "${versions[$found]}"
+  fi
+}
+
+build_and_run() {
+  local version="$1"
+  local framework="$2"
+  local name="${version}-${framework}"
+
+  print -P "%F{green}Preparing containers...%f"
+
+  echo -n "p9k:base-${version}: "
   docker build \
     --quiet \
-    --tag "p9k:${framework}" \
+    --tag "p9k:base-${version}" \
+    --file "docker/base-${version}/Dockerfile" \
+    .
+
+  echo -n "p9k:${version}-${framework}: "
+  docker build \
+    --quiet \
+    --build-arg="base=base-${version}" \
+    --tag "p9k:${version}-${framework}" \
     --file "docker/${framework}/Dockerfile" \
     .
 
-
-  print -P "%F{green}Starting ${framework} container...%f"
+  print -P "%F{green}Starting ${name} container...%f"
   exec docker run \
     --rm \
     --interactive \
     --tty \
-    --hostname="${framework}" \
+    --hostname="${name//./_}" \
     --env="TERM=${term}" \
-    "$@" \
-    "p9k:${framework}"
+    "p9k:${version}-${framework}"
 }
 
-arg1="${1:-}"; if (( $# > 0 )); then shift; fi
+show_help() {
+  local f v
+  echo "Usage: ${(%):-%x} <framework>|--list"
+  echo
+  echo "Loads up a docker image with powershell9k configured in <framework>"
+  echo
+  echo "  --frameworks  Lists all available frameworks, newline separated."
+  echo "  --versions    Lists all available ZSH versions, newline separated."
+  echo "  --zsh VER     Uses ZSH with version VER."
+  echo "  --help        You're soaking in it."
+  echo
+  echo "ZSH versions:"
+  for v in "${(@)versions}"; do
+    echo "  $v"
+  done
+  echo
+  echo "Framework containers:"
+  for f in "${(@)frameworks}"; do
+    echo "  $f"
+  done
+}
 
-if [[ -z "$arg1" ]] || [[ "$arg1" == "help" ]]; then
-  show-help
-  exit 0
-elif [[ "$arg1" == '--list' ]]; then
-  frameworks
-  exit 0
-elif [[ -d "docker/${arg1}" ]]; then
-  build-and-run "$arg1"
-elif [[ -n "docker/${arg1}"*/Dockerfile(#qN) ]]; then
-  # Allow globbing
-  build-and-run "docker/${arg1}"*(Y1:t)
-else
-  show-help
-  exit 1
+# No arguments
+if (( $# == 0 )); then
+  show_help
+  exit
 fi
+
+# Parse flags and such.
+use_version=$default_version
+use_framework=
+while (( $# > 0 )); do
+  case "$1" in
+    -f | --frameworks )
+      print -l "${(@)frameworks}"
+      exit
+      ;;
+    -v | --versions )
+      print -l "${(@)versions}"
+      exit
+      ;;
+    -z | --zsh )
+      shift
+      local v="$(resolve_version "$1")"
+      if [[ -n "$v" ]]; then
+        use_version=$v
+      else
+        err "No such ZSH version '${1}'"
+      fi
+      ;;
+    -h | --help )
+      show_help
+      exit
+      ;;;
+    -* )
+      err "Unknown option ${1}"
+      show_help
+      exit 1
+      ;;
+    * )
+      if [[ -z "$use_framework" ]]; then
+        local f="$(resolve_framework "$1")"
+        if [[ -n "$f" ]]; then
+          use_framework=$f
+        else
+          err "No such framework '${1}'"
+        fi
+      else
+        err "You can only specify one framework at a time; you already specified '${use_framework}'"
+      fi
+      ;;
+  esac
+  shift
+done
+
+build_and_run "$use_version" "$use_framework"
 
 # EOF


### PR DESCRIPTION
This adds `./test-in-docker` for quickly playing with various frameworks.

All the containers are based off Ubuntu 14.04 which has ZSH 5.0.2.

Thanks to @dritter for figuring out all the framework installation
methods.