### PR TITLE
Added tests and replaced a sed call

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -811,7 +811,7 @@ prompt_dir() {
   fi
 
   if [[ "${POWERLEVEL9K_HOME_FOLDER_ABBREVIATION}" != "~" ]]; then
-    current_path="$( echo "${current_path}" | sed "s/^~/${POWERLEVEL9K_HOME_FOLDER_ABBREVIATION}/")"
+    current_path=${current_path/#\~/${POWERLEVEL9K_HOME_FOLDER_ABBREVIATION}}
   fi
 
   typeset -AH dir_states

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -272,6 +272,31 @@ function testChangingDirPathSeparator() {
   unset POWERLEVEL9K_DIR_PATH_SEPARATOR
 }
 
+function testHomeFolderAbbreviation() {
+  local POWERLEVEL9K_HOME_FOLDER_ABBREVIATION
+  local dir=$PWD
+
+  cd ~/
+  # default
+  POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='~'
+  assertEquals "%K{blue} %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  # substituted
+  POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
+  assertEquals "%K{blue} %F{black}qQq %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd /tmp
+  # default
+  POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='~'
+  assertEquals "%K{blue} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+
+  # substituted
+  POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
+  assertEquals "%K{blue} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+
+  cd "$dir"
+}
+
 function testOmittingFirstCharacterWorks() {
   POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER=true
   POWERLEVEL9K_FOLDER_ICON='folder-icon'


### PR DESCRIPTION
This was partially an experiment on my part; I wanted to see
what would be involved in (safely) replacing some sed calls.

The rational is that forks out to sed are slower than pure ZSH.

It isn't a huge difference on Linux, but each fork can take a while even in
the latest Windows.

...and as I said, it was an experiment.  I'm interested in optimizing some things.