### PR TITLE
Merge in commits from master

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at bhilburn@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -80,6 +80,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      ''
       PYTHON_ICON                    $'\U1F40D'             # 🐍
       SWIFT_ICON                     ''
+      GO_ICON                        ''
       PUBLIC_IP_ICON                 ''
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\UE89C'              # 
@@ -150,6 +151,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      $'\uE6A8'              # 
       PYTHON_ICON                    $'\U1F40D'             # 🐍
       SWIFT_ICON                     ''
+      GO_ICON                        ''
       PUBLIC_IP_ICON                 ''
       LOCK_ICON                      $'\UE138'              # 
       EXECUTION_TIME_ICON            $'\uF253'
@@ -220,6 +222,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      $'\uE7A8 '             # 
       PYTHON_ICON                    $'\UE73C '             # 
       SWIFT_ICON                     $'\uE755'              # 
+      GO_ICON                        $'\uE626'              # 
       PUBLIC_IP_ICON                 $'\UF0AC'              # 
       LOCK_ICON                      $'\UF023'              # 
       EXECUTION_TIME_ICON            $'\uF252'              # 
@@ -290,6 +293,7 @@ case $POWERLEVEL9K_MODE in
       RUST_ICON                      ''
       PYTHON_ICON                    ''
       SWIFT_ICON                     'Swift'
+      GO_ICON                        'Go'
       PUBLIC_IP_ICON                 ''
       LOCK_ICON                      $'\UE0A2'
       EXECUTION_TIME_ICON            'Dur'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -829,7 +829,7 @@ prompt_go_version() {
   go_path=$(go env GOPATH 2>/dev/null)
 
   if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
-    "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version"
+    "$1_prompt_segment" "$0" "$2" "green" "255" "$go_version" "GO_ICON"
   fi
 }
 
@@ -1074,7 +1074,7 @@ prompt_rvm() {
   local gemset=$(echo $GEM_HOME | awk -F'@' '{print $2}')
   [ "$gemset" != "" ] && gemset="@$gemset"
 
-  local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
+  local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $NF}')
 
   if [[ -n "$version$gemset" ]]; then
     "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$version$gemset" 'RUBY_ICON'

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -35,12 +35,14 @@ function mockGoEmptyGopath() {
 
 function testGo() {
   alias go=mockGo
+  POWERLEVEL9K_GO_ICON=""
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(go_version)
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{green} %F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{green} %F{255%}%f %F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
 
+  unset POWERLEVEL9K_GO_ICON
   unset PWD
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias go


### PR DESCRIPTION
List of commits:

- 82f319d
    > Adding Code of Conduct
    >
    > Slightly modified version of Contributors Covenant.
- 65c7706
    > Fixed RVM segment for usernames with dashes
    >
    > Having a username with a dash, such as mine, `d-side`, currently results in
    > RVM segment displaying the wrong thing, e. g. `side/.rvm/rubies/ruby`. This
    > fixes the issue.
- f81ecc1
    > set GO_ICON manually in test
- a6887eb
    > update test
- 99c9ba9
    > add Gopher icon to go_version segment