### PR TITLE
Feature/status cross ok option set

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,8 +505,8 @@ This segment shows the return code of the last command.
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|`POWERLEVEL9K_STATUS_VERBOSE`|`true`|Set to false if you wish to not show the error code when the last command returned an error and optionally hide this segment when the last command completed successfully by setting `POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE` to false.|
-|`POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE`|`false`|Set to true if you wish to show this segment when the last command completed successfully in non-verbose mode.|
+|`POWERLEVEL9K_STATUS_CROSS`|`false`|Set to true if you wish not to show the error code when the last command returned an error and optionally hide this segment when the last command completed successfully by setting `POWERLEVEL9K_STATUS_OK` to false.|
+|`POWERLEVEL9K_STATUS_OK`|`true`|Set to true if you wish to show this segment when the last command completed successfully, false to hide it.|
 |`POWERLEVEL9K_STATUS_SHOW_PIPESTATUS`|`true`|Set to true if you wish to show the exit status for all piped commands.|
 
 ##### ram

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1087,9 +1087,13 @@ prompt_ssh() {
   fi
 }
 
-# Status: return code if verbose, otherwise just an icon if an error occurred
+# old options, retro compatibility
 set_default POWERLEVEL9K_STATUS_VERBOSE true
 set_default POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE false
+# Status: When an error occur, return the error code, or a cross icon if option is set
+# Display an ok icon when no error occur, or hide the segment if option is set to false
+set_default POWERLEVEL9K_STATUS_CROSS false
+set_default POWERLEVEL9K_STATUS_OK true
 set_default POWERLEVEL9K_STATUS_SHOW_PIPESTATUS true
 prompt_status() {
   local ec_text
@@ -1112,12 +1116,12 @@ prompt_status() {
   fi
 
   if (( ec_sum > 0 )); then
-    if [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
+    if [[ "$POWERLEVEL9K_STATUS_CROSS" == false && "$POWERLEVEL9K_STATUS_VERBOSE" == true ]]; then
       "$1_prompt_segment" "$0_ERROR" "$2" "red" "226" "$ec_text" 'CARRIAGE_RETURN_ICON'
     else
       "$1_prompt_segment" "$0_ERROR" "$2" "$DEFAULT_COLOR" "red" "" 'FAIL_ICON'
     fi
-  elif [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true || "$POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
+  elif [[ "$POWERLEVEL9K_STATUS_OK" == true ]] && [[ "$POWERLEVEL9K_STATUS_VERBOSE" == true || "$POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
     "$1_prompt_segment" "$0_OK" "$2" "$DEFAULT_COLOR" "green" "" 'OK_ICON'
   fi
 }


### PR DESCRIPTION
The purpose of this PR is to be able to have the error code but no icon when there is no error.
We strictly win one more possibility : 

|        | ERROR CODE           | CROSS ICON  |
| ------------- |:-------------:|:-----:|
| OK ICON      | present | present |
| HIDDEN SEGMENT     | **new** |   present |

I've made the new option set such as his default values doesn't affect old option set, no matter what the old option set values are. To do so, I've used logical operator properties : 
`true && condition` == `condition` where `true` is the default value of the new option set and `condition` is the old option set value.

So, to use the new option set, the old option set must be at his default values and to use the old option set, the new option set must be at his default values.