### PR TITLE
Fix reference for Python icon.

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -76,7 +76,7 @@ case $POWERLEVEL9K_MODE in
       VCS_HG_ICON                    $'\uE1C3 '             # 
       VCS_SVN_ICON                   '(svn) '
       RUST_ICON                      ''
-      PYTHON_ICON                    $'\U1F40D'             # 🐍
+      PYTHON_ICON                    $'\ue63c'             # 
       SWIFT_ICON                     ''
       GO_ICON                        ''
       PUBLIC_IP_ICON                 ''
@@ -143,7 +143,7 @@ case $POWERLEVEL9K_MODE in
       VCS_HG_ICON                    $'\uF0C3 '             # 
       VCS_SVN_ICON                   '(svn) '
       RUST_ICON                      $'\uE6A8'              #  
-      PYTHON_ICON                    $'\U1F40D'             # 🐍
+      PYTHON_ICON                    $'\ue63c'             # 
       SWIFT_ICON                     ''
       GO_ICON                        ''
       PUBLIC_IP_ICON                 ''


### PR DESCRIPTION
While using awesome-terminal-fonts it is recommended to use `\ue63c` to
reference python icon instead of `\U1F40D` (that wasn't even working).
Ref:
https://github.com/gabrielelana/awesome-terminal-fonts/issues/38#issuecomment-302939451