### PR TITLE
Fixed Vi mode indicator issue

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1192,11 +1192,11 @@ set_default POWERLEVEL9K_VI_INSERT_MODE_STRING "INSERT"
 set_default POWERLEVEL9K_VI_COMMAND_MODE_STRING "NORMAL"
 prompt_vi_mode() {
   case ${KEYMAP} in
-    main|viins)
-      "$1_prompt_segment" "$0_INSERT" "$2" "$DEFAULT_COLOR" "blue" "$POWERLEVEL9K_VI_INSERT_MODE_STRING"
-    ;;
     vicmd)
       "$1_prompt_segment" "$0_NORMAL" "$2" "$DEFAULT_COLOR" "default" "$POWERLEVEL9K_VI_COMMAND_MODE_STRING"
+    ;;
+    main|viins|*)
+      "$1_prompt_segment" "$0_INSERT" "$2" "$DEFAULT_COLOR" "blue" "$POWERLEVEL9K_VI_INSERT_MODE_STRING"
     ;;
   esac
 }


### PR DESCRIPTION
**Changes**
* Fixed an issue that Vi mode won't appear before the user changes the mode. (This change shows INSERT when failed to get current Vi mode)
* ~Added nice-exit-code plugin. This can be activated with the flag `POWERLEVEL9K_STATUS_NICE_EXIT_CODE` and shows a signal name of the last status code.~