### PR TITLE
Implemented functionality from dir_writable to dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ You can also customize the leading tilde character when you are in `$HOME` using
 # Double quotes are important here!
 POWERLEVEL9K_HOME_FOLDER_ABBREVIATION="%F{red} $(print_icon 'HOME_ICON') %F{black}"
 ```
-If you want to see, when you do not have write permissions on the current folder, you can set `POWERLEVEL9K_DIR_SHOW_WRITABLE=true`.
-This will set the `dir` segment to a `NOT_WRITABLE` state when current folder is not writable, allowing you to customize the `dir` segment [colors](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization).
+You can also configure the `dir` segment to show when you are in a directory without write permissions, using the variable below.
 
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_DIR_SHOW_WRITABLE`|`false`|If set to `true` and you are in a directory that you do not have write permissions for, this segment will display a lock icon and enter the `NOT_WRITABLE` state (which can be customized per [our usual process](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization). Note that this functionality is also available in a separate segment, `dir_writable`.|
 
 ##### disk_usage
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ You can also customize the leading tilde character when you are in `$HOME` using
 # Double quotes are important here!
 POWERLEVEL9K_HOME_FOLDER_ABBREVIATION="%F{red} $(print_icon 'HOME_ICON') %F{black}"
 ```
+If you want to see, when you do not have write permissions on the current folder, you can set `POWERLEVEL9K_DIR_SHOW_WRITABLE=true`.
+This will set the `dir` segment to a `NOT_WRITABLE` state when current folder is not writable, allowing you to customize the `dir` segment [colors](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization).
 
 
 ##### disk_usage

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -689,6 +689,7 @@ prompt_command_execution_time() {
 # Dir: current working directory
 set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
 set_default POWERLEVEL9K_HOME_FOLDER_ABBREVIATION "~"
+set_default POWERLEVEL9K_DIR_SHOW_WRITABLE false
 prompt_dir() {
   local current_path="$(print -P "%~")"
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" || "$POWERLEVEL9K_SHORTEN_STRATEGY" == "truncate_with_folder_marker" ]]; then
@@ -805,7 +806,7 @@ prompt_dir() {
     "NOT_WRITABLE"    "LOCK_ICON"
   )
   local current_state="DEFAULT"
-  if [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == "true" && ! -w "$PWD" ]]; then
+  if [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == true && ! -w "$PWD" ]]; then
     current_state="NOT_WRITABLE"
   elif [[ $(print -P "%~") == '~' ]]; then
     current_state="HOME"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -802,9 +802,12 @@ prompt_dir() {
     "DEFAULT"         "FOLDER_ICON"
     "HOME"            "HOME_ICON"
     "HOME_SUBFOLDER"  "HOME_SUB_ICON"
+    "NOT_WRITABLE"    "LOCK_ICON"
   )
   local current_state="DEFAULT"
-  if [[ $(print -P "%~") == '~' ]]; then
+  if [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == "true" && ! -w "$PWD" ]]; then
+    current_state="NOT_WRITABLE"
+  elif [[ $(print -P "%~") == '~' ]]; then
     current_state="HOME"
   elif [[ $(print -P "%~") == '~'* ]]; then
     current_state="HOME_SUBFOLDER"


### PR DESCRIPTION
When variable POWERLEVEL9K_DIR_SHOW_WRITABLE is set to true, dir prompt
will have new state NOT_WRITABLE.

This state will be set when user doesn't have permission to write in
current working directory as in prompt dir_writable.

When mode that allows icons is set, LOCK_ICON is used.

Closes #588.