### PR TITLE
Add back the prompt_sp option for zsh >= 5.4.1

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1341,11 +1341,11 @@ prompt_powerlevel9k_setup() {
   # returns. We need prompt_subst so we can safely run commands in the prompt
   # without them being double expanded and we need prompt_percent to expand the
   # common percent escape sequences.
-  prompt_opts=(subst percent cr)
+  prompt_opts=(cr percent sp subst)
 
   # Borrowed from promptinit, sets the prompt options in case the theme was
   # not initialized via promptinit.
-  setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+  setopt noprompt{bang,cr,percent,sp,subst} "prompt${^prompt_opts[@]}"
 
   # Display a warning if the terminal does not support 256 colors
   local term_colors


### PR DESCRIPTION
In 5.4.1, this option was reset between prompts, so to retain the
previous default behavior, this should be added back.

This was the change which caused it to be reset: https://github.com/zsh-users/zsh/commit/43e55a9bcd2c90124a751f2597d2f33cb6e3c042#diff-bb10d67e7a8561b66a53a805f3c77a40R233

This is the documentation on the option itself: http://zsh.sourceforge.net/Doc/Release/Options.html#Prompting

Note that this makes it a little harder to unset this option (as it needs to be done after setting the prompt) but that seems fine, as all the other prompt options are already this way.