### PR TITLE
add ability to force rbenv being shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ It figures out the version being used by taking the output of the `rbenv version
 * If `rbenv` is not in $PATH, nothing will be shown.
 * If the current Ruby version is the same as the global Ruby version, nothing will be shown.
 
+Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_RBENV_ALWAYS`|'false'|Always show rbenv version, even if global|
+
 ##### rspec_stats
 
 See [Unit Test Ratios](#unit-test-ratios), below.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -939,11 +939,14 @@ prompt_rbenv() {
     local rbenv_global="$(rbenv global)"
 
     # Don't show anything if the current Ruby is the same as the global Ruby.
-    if [[ $rbenv_version_name == $rbenv_global ]]; then
+    # Unless POWERLEVEL_RBENV_ALWAYS is set.
+    if [[ $POWERLEVEL9K_RBENV_ALWAYS == "true" ]];then
+      "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
+    elif [[ $rbenv_version_name != $rbenv_global ]]; then
+      "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
+    else
       return
     fi
-
-    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
   fi
 }
 


### PR DESCRIPTION
I set a global rbenv, but do always want the prompt segment to be shown, so this adds a simple `POWERLEVEL9K_RBENV_ALWAYS` to force the segment even if its the global version. 

