### PR TITLE
Fix prompt_kubecontext:local:1: not valid in this context: Version:

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1408,7 +1408,7 @@ prompt_dir_writable() {
 
 # Kubernetes Current Context
 prompt_kubecontext() {
-  local kubectl_version=$(kubectl version --client 2>/dev/null)
+  local kubectl_version="$(kubectl version --client 2>/dev/null)"
 
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kubernetes config context's namespaece


### PR DESCRIPTION
Same issue as here and same fix:

https://github.com/bhilburn/powerlevel9k/commit/bddbdd62e841d6e008e95fe2f0909d5b32e623a8