### PR TITLE
Added Dropbox segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The segments that are currently available are:
     * `aws_eb_env` - The current Elastic Beanstalk Environment.
 * `docker_machine` - The current Docker Machine.
 * `kubecontext` - The current context of your `kubectl` configuration.
+* `dropbox` - Indicates Dropbox directory and syncing status using `dropbox-cli`
 
 **Other:**
 * [`custom_command`](#custom_command) - Create a custom segment to display the

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -87,6 +87,7 @@ case $POWERLEVEL9K_MODE in
       SSH_ICON                       '(ssh)'
       VPN_ICON                       '(vpn)'
       KUBERNETES_ICON                $'\U2388'              # ⎈
+      DROPBOX_ICON                   $'\UF16B'              # 
     )
   ;;
   'awesome-fontconfig')
@@ -158,6 +159,7 @@ case $POWERLEVEL9K_MODE in
       SSH_ICON                       '(ssh)'
       VPN_ICON                       $'\uF023'
       KUBERNETES_ICON                $'\U2388'              # ⎈
+      DROPBOX_ICON                   $'\UF16B'              # 
     )
   ;;
   'awesome-mapped-fontconfig')
@@ -303,6 +305,7 @@ case $POWERLEVEL9K_MODE in
       SSH_ICON                       $'\uF489'              # 
       VPN_ICON                       '(vpn)'
       KUBERNETES_ICON                $'\U2388'              # ⎈
+      DROPBOX_ICON                   $'\UF16B'              # 
     )
   ;;
   *)
@@ -374,6 +377,7 @@ case $POWERLEVEL9K_MODE in
       SSH_ICON                       '(ssh)'
       VPN_ICON                       '(vpn)'
       KUBERNETES_ICON                $'\U2388'              # ⎈
+      DROPBOX_ICON                   $'\UF16B'              # 
     )
   ;;
 esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1423,6 +1423,23 @@ prompt_kubecontext() {
   fi
 }
 
+# Dropbox status
+prompt_dropbox() {
+  # The first column is just the directory, so cut it
+  local dropbox_status="$(dropbox-cli filestatus . | cut -d\  -f2-)"
+
+  # Only show if the folder is tracked
+  if [[ "$dropbox_status" != 'unwatched' ]]; then
+    # If "up to date", only show the icon
+    if [[ "$dropbox_status" =~ 'up to date' ]]; then
+      dropbox_status=""
+    fi
+
+    "$1_prompt_segment" "$0" "$2" "white" "blue" "$dropbox_status" "DROPBOX_ICON"
+  fi
+
+}
+
 
 ################################################################
 # Prompt processing and drawing


### PR DESCRIPTION
Adds a simple dropbox segment that shows the dropbox symbol when in a dropbox directory. Also shows the status when syncing. Requires dropbox-cli to be installed.

I wrote it because I sometimes start editing in a directory without realising I'm in a dropbox folder. So while for me it is quite usefull, I don't know if others will need it. 