### PR TITLE
#632: Indicate `Rust` or `(rust)` for rust_version segment only if ic…

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -77,7 +77,7 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            $'\uE20E '             #
       VCS_HG_ICON                    $'\uE1C3 '             # 
       VCS_SVN_ICON                   '(svn) '
-      RUST_ICON                      ''
+      RUST_ICON                      '(rust)'
       PYTHON_ICON                    $'\ue63c'             # 
       SWIFT_ICON                     ''
       GO_ICON                        ''
@@ -290,7 +290,7 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            ''
       VCS_HG_ICON                    ''
       VCS_SVN_ICON                   ''
-      RUST_ICON                      ''
+      RUST_ICON                      'Rust'
       PYTHON_ICON                    ''
       SWIFT_ICON                     'Swift'
       GO_ICON                        'Go'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1095,9 +1095,9 @@ prompt_root_indicator() {
 prompt_rust_version() {
   local rust_version
   rust_version=$(rustc --version 2>&1 | grep -oe "^rustc\s*[^ ]*" | grep -o '[0-9.a-z\\\-]*$')
-
+  
   if [[ -n "$rust_version" ]]; then
-    "$1_prompt_segment" "$0" "$2" "208" "$DEFAULT_COLOR" "Rust $rust_version" 'RUST_ICON'
+    "$1_prompt_segment" "$0" "$2" "208" "$DEFAULT_COLOR" "$rust_version" 'RUST_ICON'
   fi
 }
 # RSpec test ratio

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -19,7 +19,7 @@ function testRust() {
   alias rustc=mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{black}Rust 0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{black%}Rust%f %F{black}0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias rustc


### PR DESCRIPTION
…on is unavailable

Hi @bhilburn, please let me know what you think. 