### PR TITLE
Fix incomplete vpn segment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ specify the correct network interface by setting:
 |----------|---------------|-------------|
 |`POWERLEVEL9K_IP_INTERFACE`|None|The NIC for which you wish to display the IP address. Example: `eth0`.|
 
-##### vpn
+##### vpn_ip
 
 This segment tries to extract the VPN related IP addresses from nmcli, based on the NIC type:
 


### PR DESCRIPTION
The segment function is called *prompt_vpn_ip()* thus the segment needs to be called "vpn_ip".