### PR TITLE
ISS-650 Fix PYTHONPATH appearing in prompt

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -691,7 +691,7 @@ set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
 set_default POWERLEVEL9K_HOME_FOLDER_ABBREVIATION "~"
 set_default POWERLEVEL9K_DIR_SHOW_WRITABLE false
 prompt_dir() {
-  local current_path="$(print -P "%~")"
+  local current_path=$(pwd | sed -e "s,^$HOME,~,")
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" || "$POWERLEVEL9K_SHORTEN_STRATEGY" == "truncate_with_folder_marker" ]]; then
     set_default POWERLEVEL9K_SHORTEN_DELIMITER $'\U2026'
 


### PR DESCRIPTION
- Modify prompt_dir function to set current_path based on pwd and
replace $HOME with ~