### PR TITLE
Add support for both AWS_PROFILE and AWS_DEFAULT_PROFILE

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -287,7 +287,7 @@ prompt_anaconda() {
 
 # AWS Profile
 prompt_aws() {
-  local aws_profile="$AWS_DEFAULT_PROFILE"
+  local aws_profile="${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}"
 
   if [[ -n "$aws_profile" ]]; then
     "$1_prompt_segment" "$0" "$2" red white "$aws_profile" 'AWS_ICON'


### PR DESCRIPTION
`AWS_PROFILE` env var has been respected by AWS client as well as `AWS_DEFAULT_PROFILE`. See here: http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html

This small change adds `AWS_PROFILE` in coalesce with `AWS_DEFAULT_PROFILE`