### PR TITLE
Replace PUBLIC_IP_ICON with VPN_ICON if VPN is up

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -564,7 +564,8 @@ prompt_public_ip() {
         break
       done
     fi
-    $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" "$icon"  fi
+    $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" "$icon"
+  fi
 }
 
 # Context: user@hostname (who am I and where am I)

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -555,8 +555,16 @@ prompt_public_ip() {
 
   # Draw the prompt segment
   if [[ -n $public_ip ]]; then
-    $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" 'PUBLIC_IP_ICON'
-  fi
+    icon='PUBLIC_IP_ICON'
+    # Check VPN is on if VPN interface is set
+    if [[ -n $POWERLEVEL9K_PUBLIC_IP_VPN_INTERFACE ]]; then
+      for vpn_iface in $(/sbin/ifconfig | grep -e ^"$POWERLEVEL9K_PUBLIC_IP_VPN_INTERFACE" | cut -d":" -f1)
+      do
+        icon='VPN_ICON'
+        break
+      done
+    fi
+    $1_prompt_segment "$0" "$2" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED" "${public_ip}" "$icon"  fi
 }
 
 # Context: user@hostname (who am I and where am I)


### PR DESCRIPTION
Replace PUBLIC_IP_ICON with VPN_ICON if $POWERLEVEL9K_PUBLIC_IP_VPN_INTERFACE is set and up. It allows to check quicker if the VPN is up or if the public IP is already a registered ip.