### PR TITLE
Add Stash naming support for Bitbucket Server

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -116,6 +116,8 @@ function +vi-vcs-detect-changes() {
       vcs_visual_identifier='VCS_GIT_GITHUB_ICON'
     elif [[ "$remote" =~ "bitbucket" ]] then
       vcs_visual_identifier='VCS_GIT_BITBUCKET_ICON'
+    elif [[ "$remote" =~ "stash" ]] then
+      vcs_visual_identifier='VCS_GIT_BITBUCKET_ICON'
     elif [[ "$remote" =~ "gitlab" ]] then
       vcs_visual_identifier='VCS_GIT_GITLAB_ICON'
     else


### PR DESCRIPTION
Some self-hosted Bitbucket Server instances still use 'stash' in the naming convention for servers and endpoints. Whilst this is a preferential change, it should cause no harm to have Stash or other self-hosted Bitbucket servers use the Bitbucket icon, as opposed to the generic Git icon.