### PR TITLE
[next] -- fix for colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ Some example settings:
 |Normal Colors|(red3 darkorange3 darkgoldenrod gold3 yellow3 chartreuse2 mediumspringgreen green3 green3 green4 darkgreen)|
 |Subdued Colors|(darkred orange4 yellow4 yellow4 chartreuse3 green3 green4 darkgreen)|
 
+###### test your terminal colors
+Some terminals, like iTerm2, allow you to customize some of the colors via the interface.  This is handy for themes and allowing the colors to change via the GUI.
+Use this command to check how all the colors are rendering in your terminal. This is handy for choosing colors and wheter or not you want to use the static color code, or the dynamic named color.
+
+```zsh
+# execute these in your shell to get a look at all 256 colors
+
+getColorCode background
+getColorCode foreground
+```
+
 ##### command_execution_time
 
 Display the time the previous command took to execute if the time is above

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -6,6 +6,22 @@
 # https://github.com/bhilburn/powerlevel9k
 ################################################################
 
+function termColors() {
+  local term_colors
+
+  if which tput &>/dev/null; then
+	term_colors=$(tput colors)
+  else
+	term_colors=$(echotc Co)
+  fi
+  if (( ! $? && ${term_colors:-0} < 256 )); then
+    print -P "%F{red}WARNING!%f Your terminal appears to support fewer than 256 colors!"
+    print -P "If your terminal supports 256 colors, please export the appropriate environment variable"
+    print -P "_before_ loading this theme in your \~\/.zshrc. In most terminal emulators, putting"
+    print -P "%F{blue}export TERM=\"xterm-256color\"%f at the top of your \~\/.zshrc is sufficient."
+  fi
+}
+
 # get the proper color code if it does not exist as a name.
 function getColor() {
   # no need to check numerical values

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -6,6 +6,46 @@
 # https://github.com/bhilburn/powerlevel9k
 ################################################################
 
+# get the proper color code if it does not exist as a name.
+function getColor() {
+  # no need to check numerical values
+  if [[ "$1" = <-> ]]; then
+    if [[ "$1" = <8-15> ]]; then
+      1=$(($1 - 8))
+    fi
+  else
+    # named color added to parameter expansion print -P to test if the name exists in terminal
+    named="%K{$1}"
+    # https://misc.flogisoft.com/bash/tip_colors_and_formatting
+    default="$'\033'\[49m"
+    # http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html
+    quoted=$(printf "%q" $(print -P "$named"))
+    if [[ $quoted = "$'\033'\[49m" && $1 != "black" ]]; then
+        # color not found, so try to get the code
+        1=$(getColorCode $1)
+    fi
+    echo -n "$1"
+  fi
+}
+
+# empty paramenter resets (stops) background color
+function backgroundColor() {
+  if [[ -z $1 ]]; then
+    echo -n "%k"
+  else
+    echo -n "%K{$(getColor $1)}"
+  fi
+}
+
+# empty paramenter resets (stops) foreground color
+function foregroundColor() {
+  if [[ -z $1 ]]; then
+    echo -n "%f"
+  else
+    echo -n "%F{$(getColor $1)}"
+  fi
+}
+
 # Get numerical color codes. That way we translate ANSI codes
 # into ZSH-Style color codes.
 function getColorCode() {
@@ -15,280 +55,292 @@ function getColorCode() {
     # and "background" colors. We don't need to do that,
     # as ZSH uses a 256 color space anyway.
     if [[ "$1" = <8-15> ]]; then
-      echo $(($1 - 8))
+      echo -n $(($1 - 8))
     else
-      echo "$1"
+      echo -n "$1"
     fi
   else
     typeset -A codes
-    codes=(
     # https://jonasjacek.github.io/colors/
     # use color names by default to allow dark/light themes to adjust colors based on names
-        'black'             '000'
-        'maroon'            '001'
-        'green'             '002'
-        'olive'             '003'
-        'navy'              '004'
-        'purple'            '005'
-        'teal'              '006'
-        'silver'            '007'
-        'grey'              '008'
-        'red'               '009'
-        'lime'              '010'
-        'yellow'            '011'
-        'blue'              '012'
-        'fuchsia'           '013'
-        'aqua'              '014'
-        'white'             '015'
-        'grey0'             '016'
-        'navyblue'          '017'
-        'darkblue'          '018'
-        'blue3'             '019'
-        'blue3'             '020'
-        'blue1'             '021'
-        'darkgreen'         '022'
-        'deepskyblue4'      '023'
-        'deepskyblue4'      '024'
-        'deepskyblue4'      '025'
-        'dodgerblue3'       '026'
-        'dodgerblue2'       '027'
-        'green4'            '028'
-        'springgreen4'      '029'
-        'turquoise4'        '030'
-        'deepskyblue3'      '031'
-        'deepskyblue3'      '032'
-        'dodgerblue1'       '033'
-        'green3'            '034'
-        'springgreen3'      '035'
-        'darkcyan'          '036'
-        'lightseagreen'     '037'
-        'deepskyblue2'      '038'
-        'deepskyblue1'      '039'
-        'green3'            '040'
-        'springgreen3'      '041'
-        'springgreen2'      '042'
-        'cyan3'             '043'
-        'darkturquoise'     '044'
-        'turquoise2'        '045'
-        'green1'            '046'
-        'springgreen2'      '047'
-        'springgreen1'      '048'
-        'mediumspringgreen' '049'
-        'cyan2'             '050'
-        'cyan1'             '051'
-        'darkred'           '052'
-        'deeppink4'         '053'
-        'purple4'           '054'
-        'purple4'           '055'
-        'purple3'           '056'
-        'blueviolet'        '057'
-        'orange4'           '058'
-        'grey37'            '059'
-        'mediumpurple4'     '060'
-        'slateblue3'        '061'
-        'slateblue3'        '062'
-        'royalblue1'        '063'
-        'chartreuse4'       '064'
-        'darkseagreen4'     '065'
-        'paleturquoise4'    '066'
-        'steelblue'         '067'
-        'steelblue3'        '068'
-        'cornflowerblue'    '069'
-        'chartreuse3'       '070'
-        'darkseagreen4'     '071'
-        'cadetblue'         '072'
-        'cadetblue'         '073'
-        'skyblue3'          '074'
-        'steelblue1'        '075'
-        'chartreuse3'       '076'
-        'palegreen3'        '077'
-        'seagreen3'         '078'
-        'aquamarine3'       '079'
-        'mediumturquoise'   '080'
-        'steelblue1'        '081'
-        'chartreuse2'       '082'
-        'seagreen2'         '083'
-        'seagreen1'         '084'
-        'seagreen1'         '085'
-        'aquamarine1'       '086'
-        'darkslategray2'    '087'
-        'darkred'           '088'
-        'deeppink4'         '089'
-        'darkmagenta'       '090'
-        'darkmagenta'       '091'
-        'darkviolet'        '092'
-        'purple'            '093'
-        'orange4'           '094'
-        'lightpink4'        '095'
-        'plum4'             '096'
-        'mediumpurple3'     '097'
-        'mediumpurple3'     '098'
-        'slateblue1'        '099'
-        'yellow4'           '100'
-        'wheat4'            '101'
-        'grey53'            '102'
-        'lightslategrey'    '103'
-        'mediumpurple'      '104'
-        'lightslateblue'    '105'
-        'yellow4'           '106'
-        'darkolivegreen3'   '107'
-        'darkseagreen'      '108'
-        'lightskyblue3'     '109'
-        'lightskyblue3'     '110'
-        'skyblue2'          '111'
-        'chartreuse2'       '112'
-        'darkolivegreen3'   '113'
-        'palegreen3'        '114'
-        'darkseagreen3'     '115'
-        'darkslategray3'    '116'
-        'skyblue1'          '117'
-        'chartreuse1'       '118'
-        'lightgreen'        '119'
-        'lightgreen'        '120'
-        'palegreen1'        '121'
-        'aquamarine1'       '122'
-        'darkslategray1'    '123'
-        'red3'              '124'
-        'deeppink4'         '125'
-        'mediumvioletred'   '126'
-        'magenta3'          '127'
-        'darkviolet'        '128'
-        'purple'            '129'
-        'darkorange3'       '130'
-        'indianred'         '131'
-        'hotpink3'          '132'
-        'mediumorchid3'     '133'
-        'mediumorchid'      '134'
-        'mediumpurple2'     '135'
-        'darkgoldenrod'     '136'
-        'lightsalmon3'      '137'
-        'rosybrown'         '138'
-        'grey63'            '139'
-        'mediumpurple2'     '140'
-        'mediumpurple1'     '141'
-        'gold3'             '142'
-        'darkkhaki'         '143'
-        'navajowhite3'      '144'
-        'grey69'            '145'
-        'lightsteelblue3'   '146'
-        'lightsteelblue'    '147'
-        'yellow3'           '148'
-        'darkolivegreen3'   '149'
-        'darkseagreen3'     '150'
-        'darkseagreen2'     '151'
-        'lightcyan3'        '152'
-        'lightskyblue1'     '153'
-        'greenyellow'       '154'
-        'darkolivegreen2'   '155'
-        'palegreen1'        '156'
-        'darkseagreen2'     '157'
-        'darkseagreen1'     '158'
-        'paleturquoise1'    '159'
-        'red3'              '160'
-        'deeppink3'         '161'
-        'deeppink3'         '162'
-        'magenta3'          '163'
-        'magenta3'          '164'
-        'magenta2'          '165'
-        'darkorange3'       '166'
-        'indianred'         '167'
-        'hotpink3'          '168'
-        'hotpink2'          '169'
-        'orchid'            '170'
-        'mediumorchid1'     '171'
-        'orange3'           '172'
-        'lightsalmon3'      '173'
-        'lightpink3'        '174'
-        'pink3'             '175'
-        'plum3'             '176'
-        'violet'            '177'
-        'gold3'             '178'
-        'lightgoldenrod3'   '179'
-        'tan'               '180'
-        'mistyrose3'        '181'
-        'thistle3'          '182'
-        'plum2'             '183'
-        'yellow3'           '184'
-        'khaki3'            '185'
-        'lightgoldenrod2'   '186'
-        'lightyellow3'      '187'
-        'grey84'            '188'
-        'lightsteelblue1'   '189'
-        'yellow2'           '190'
-        'darkolivegreen1'   '191'
-        'darkolivegreen1'   '192'
-        'darkseagreen1'     '193'
-        'honeydew2'         '194'
-        'lightcyan1'        '195'
-        'red1'              '196'
-        'deeppink2'         '197'
-        'deeppink1'         '198'
-        'deeppink1'         '199'
-        'magenta2'          '200'
-        'magenta1'          '201'
-        'orangered1'        '202'
-        'indianred1'        '203'
-        'indianred1'        '204'
-        'hotpink'           '205'
-        'hotpink'           '206'
-        'mediumorchid1'     '207'
-        'darkorange'        '208'
-        'salmon1'           '209'
-        'lightcoral'        '210'
-        'palevioletred1'    '211'
-        'orchid2'           '212'
-        'orchid1'           '213'
-        'orange1'           '214'
-        'sandybrown'        '215'
-        'lightsalmon1'      '216'
-        'lightpink1'        '217'
-        'pink1'             '218'
-        'plum1'             '219'
-        'gold1'             '220'
-        'lightgoldenrod2'   '221'
-        'lightgoldenrod2'   '222'
-        'navajowhite1'      '223'
-        'mistyrose1'        '224'
-        'thistle1'          '225'
-        'yellow1'           '226'
-        'lightgoldenrod1'   '227'
-        'khaki1'            '228'
-        'wheat1'            '229'
-        'cornsilk1'         '230'
-        'grey100'           '231'
-        'grey3'             '232'
-        'grey7'             '233'
-        'grey11'            '234'
-        'grey15'            '235'
-        'grey19'            '236'
-        'grey23'            '237'
-        'grey27'            '238'
-        'grey30'            '239'
-        'grey35'            '240'
-        'grey39'            '241'
-        'grey42'            '242'
-        'grey46'            '243'
-        'grey50'            '244'
-        'grey54'            '245'
-        'grey58'            '246'
-        'grey62'            '247'
-        'grey66'            '248'
-        'grey70'            '249'
-        'grey74'            '250'
-        'grey78'            '251'
-        'grey82'            '252'
-        'grey85'            '253'
-        'grey89'            '254'
-        'grey93'            '255'
-    )
+    codes[black]=000
+    codes[maroon]=001
+    codes[green]=002
+    codes[olive]=003
+    codes[navy]=004
+    codes[purple]=005
+    codes[teal]=006
+    codes[silver]=007
+    codes[grey]=008
+    codes[red]=009
+    codes[lime]=010
+    codes[yellow]=011
+    codes[blue]=012
+    codes[fuchsia]=013
+    codes[aqua]=014
+    codes[white]=015
+    codes[grey0]=016
+    codes[navyblue]=017
+    codes[darkblue]=018
+    codes[blue3]=019
+    codes[blue3]=020
+    codes[blue1]=021
+    codes[darkgreen]=022
+    codes[deepskyblue4]=023
+    codes[deepskyblue4]=024
+    codes[deepskyblue4]=025
+    codes[dodgerblue3]=026
+    codes[dodgerblue2]=027
+    codes[green4]=028
+    codes[springgreen4]=029
+    codes[turquoise4]=030
+    codes[deepskyblue3]=031
+    codes[deepskyblue3]=032
+    codes[dodgerblue1]=033
+    codes[green3]=034
+    codes[springgreen3]=035
+    codes[darkcyan]=036
+    codes[lightseagreen]=037
+    codes[deepskyblue2]=038
+    codes[deepskyblue1]=039
+    codes[green3]=040
+    codes[springgreen3]=041
+    codes[springgreen2]=042
+    codes[cyan3]=043
+    codes[darkturquoise]=044
+    codes[turquoise2]=045
+    codes[green1]=046
+    codes[springgreen2]=047
+    codes[springgreen1]=048
+    codes[mediumspringgreen]=049
+    codes[cyan2]=050
+    codes[cyan1]=051
+    codes[darkred]=052
+    codes[deeppink4]=053
+    codes[purple4]=054
+    codes[purple4]=055
+    codes[purple3]=056
+    codes[blueviolet]=057
+    codes[orange4]=058
+    codes[grey37]=059
+    codes[mediumpurple4]=060
+    codes[slateblue3]=061
+    codes[slateblue3]=062
+    codes[royalblue1]=063
+    codes[chartreuse4]=064
+    codes[darkseagreen4]=065
+    codes[paleturquoise4]=066
+    codes[steelblue]=067
+    codes[steelblue3]=068
+    codes[cornflowerblue]=069
+    codes[chartreuse3]=070
+    codes[darkseagreen4]=071
+    codes[cadetblue]=072
+    codes[cadetblue]=073
+    codes[skyblue3]=074
+    codes[steelblue1]=075
+    codes[chartreuse3]=076
+    codes[palegreen3]=077
+    codes[seagreen3]=078
+    codes[aquamarine3]=079
+    codes[mediumturquoise]=080
+    codes[steelblue1]=081
+    codes[chartreuse2]=082
+    codes[seagreen2]=083
+    codes[seagreen1]=084
+    codes[seagreen1]=085
+    codes[aquamarine1]=086
+    codes[darkslategray2]=087
+    codes[darkred]=088
+    codes[deeppink4]=089
+    codes[darkmagenta]=090
+    codes[darkmagenta]=091
+    codes[darkviolet]=092
+    codes[purple]=093
+    codes[orange4]=094
+    codes[lightpink4]=095
+    codes[plum4]=096
+    codes[mediumpurple3]=097
+    codes[mediumpurple3]=098
+    codes[slateblue1]=099
+    codes[yellow4]=100
+    codes[wheat4]=101
+    codes[grey53]=102
+    codes[lightslategrey]=103
+    codes[mediumpurple]=104
+    codes[lightslateblue]=105
+    codes[yellow4]=106
+    codes[darkolivegreen3]=107
+    codes[darkseagreen]=108
+    codes[lightskyblue3]=109
+    codes[lightskyblue3]=110
+    codes[skyblue2]=111
+    codes[chartreuse2]=112
+    codes[darkolivegreen3]=113
+    codes[palegreen3]=114
+    codes[darkseagreen3]=115
+    codes[darkslategray3]=116
+    codes[skyblue1]=117
+    codes[chartreuse1]=118
+    codes[lightgreen]=119
+    codes[lightgreen]=120
+    codes[palegreen1]=121
+    codes[aquamarine1]=122
+    codes[darkslategray1]=123
+    codes[red3]=124
+    codes[deeppink4]=125
+    codes[mediumvioletred]=126
+    codes[magenta3]=127
+    codes[darkviolet]=128
+    codes[purple]=129
+    codes[darkorange3]=130
+    codes[indianred]=131
+    codes[hotpink3]=132
+    codes[mediumorchid3]=133
+    codes[mediumorchid]=134
+    codes[mediumpurple2]=135
+    codes[darkgoldenrod]=136
+    codes[lightsalmon3]=137
+    codes[rosybrown]=138
+    codes[grey63]=139
+    codes[mediumpurple2]=140
+    codes[mediumpurple1]=141
+    codes[gold3]=142
+    codes[darkkhaki]=143
+    codes[navajowhite3]=144
+    codes[grey69]=145
+    codes[lightsteelblue3]=146
+    codes[lightsteelblue]=147
+    codes[yellow3]=148
+    codes[darkolivegreen3]=149
+    codes[darkseagreen3]=150
+    codes[darkseagreen2]=151
+    codes[lightcyan3]=152
+    codes[lightskyblue1]=153
+    codes[greenyellow]=154
+    codes[darkolivegreen2]=155
+    codes[palegreen1]=156
+    codes[darkseagreen2]=157
+    codes[darkseagreen1]=158
+    codes[paleturquoise1]=159
+    codes[red3]=160
+    codes[deeppink3]=161
+    codes[deeppink3]=162
+    codes[magenta3]=163
+    codes[magenta3]=164
+    codes[magenta2]=165
+    codes[darkorange3]=166
+    codes[indianred]=167
+    codes[hotpink3]=168
+    codes[hotpink2]=169
+    codes[orchid]=170
+    codes[mediumorchid1]=171
+    codes[orange3]=172
+    codes[lightsalmon3]=173
+    codes[lightpink3]=174
+    codes[pink3]=175
+    codes[plum3]=176
+    codes[violet]=177
+    codes[gold3]=178
+    codes[lightgoldenrod3]=179
+    codes[tan]=180
+    codes[mistyrose3]=181
+    codes[thistle3]=182
+    codes[plum2]=183
+    codes[yellow3]=184
+    codes[khaki3]=185
+    codes[lightgoldenrod2]=186
+    codes[lightyellow3]=187
+    codes[grey84]=188
+    codes[lightsteelblue1]=189
+    codes[yellow2]=190
+    codes[darkolivegreen1]=191
+    codes[darkolivegreen1]=192
+    codes[darkseagreen1]=193
+    codes[honeydew2]=194
+    codes[lightcyan1]=195
+    codes[red1]=196
+    codes[deeppink2]=197
+    codes[deeppink1]=198
+    codes[deeppink1]=199
+    codes[magenta2]=200
+    codes[magenta1]=201
+    codes[orangered1]=202
+    codes[indianred1]=203
+    codes[indianred1]=204
+    codes[hotpink]=205
+    codes[hotpink]=206
+    codes[mediumorchid1]=207
+    codes[darkorange]=208
+    codes[salmon1]=209
+    codes[lightcoral]=210
+    codes[palevioletred1]=211
+    codes[orchid2]=212
+    codes[orchid1]=213
+    codes[orange1]=214
+    codes[sandybrown]=215
+    codes[lightsalmon1]=216
+    codes[lightpink1]=217
+    codes[pink1]=218
+    codes[plum1]=219
+    codes[gold1]=220
+    codes[lightgoldenrod2]=221
+    codes[lightgoldenrod2]=222
+    codes[navajowhite1]=223
+    codes[mistyrose1]=224
+    codes[thistle1]=225
+    codes[yellow1]=226
+    codes[lightgoldenrod1]=227
+    codes[khaki1]=228
+    codes[wheat1]=229
+    codes[cornsilk1]=230
+    codes[grey100]=231
+    codes[grey3]=232
+    codes[grey7]=233
+    codes[grey11]=234
+    codes[grey15]=235
+    codes[grey19]=236
+    codes[grey23]=237
+    codes[grey27]=238
+    codes[grey30]=239
+    codes[grey35]=240
+    codes[grey39]=241
+    codes[grey42]=242
+    codes[grey46]=243
+    codes[grey50]=244
+    codes[grey54]=245
+    codes[grey58]=246
+    codes[grey62]=247
+    codes[grey66]=248
+    codes[grey70]=249
+    codes[grey74]=250
+    codes[grey78]=251
+    codes[grey82]=252
+    codes[grey85]=253
+    codes[grey89]=254
+    codes[grey93]=255
 
-    # Strip eventual "bg-" prefixes
-    1=${1#bg-}
-    # Strip eventual "fg-" prefixes
-    1=${1#fg-}
-    # Strip eventual "br" prefixes ("bright" colors)
-    1=${1#br}
-    echo $codes[$1]
+    # for testing purposes in terminal
+    if [[ "$1" == "foreground"  ]]; then
+        # call via `getColorCode foreground`
+        for i in "${(k@)codes}"; do
+            print -P "$(foregroundColor $i)$(getColor $i) - $i$(foregroundColor)"
+        done
+    elif [[ "$1" == "background"  ]]; then
+        # call via `getColorCode background`
+        for i in "${(k@)codes}"; do
+            print -P "$(backgroundColor $i)$(getColor $i) - $i$(backgroundColor)"
+        done
+    else
+        #[[ -n "$1" ]] bg="%K{$1}" || bg="%k"
+        # Strip eventual "bg-" prefixes
+        1=${1#bg-}
+        # Strip eventual "fg-" prefixes
+        1=${1#fg-}
+        # Strip eventual "br" prefixes ("bright" colors)
+        1=${1#br}
+        echo -n $codes[$1]
+    fi
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -127,8 +127,8 @@ left_prompt_segment() {
   [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n "$3" ]] && bg="%K{$3}" || bg="%k"
-  [[ -n "$4" ]] && fg="%F{$4}" || fg="%f"
+  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="$(backgroundColor)"
+  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="$(foregroundColor)"
 
   if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$3" "$CURRENT_BG"; then
     echo -n "$bg%F{$CURRENT_BG}"
@@ -218,8 +218,8 @@ right_prompt_segment() {
   [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n "$3" ]] && bg="%K{$3}" || bg="%k"
-  [[ -n "$4" ]] && fg="%F{$4}" || fg="%f"
+  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="$(backgroundColor)"
+  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="$(foregroundColor)"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
   if [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1572,14 +1572,7 @@ prompt_powerlevel9k_setup() {
   setopt noprompt{bang,cr,percent,sp,subst} "prompt${^prompt_opts[@]}"
 
   # Display a warning if the terminal does not support 256 colors
-  local term_colors
-  term_colors=$(echotc Co 2>/dev/null)
-  if (( ! $? && ${term_colors:-0} < 256 )); then
-    print -P "%F{red}WARNING!%f Your terminal appears to support fewer than 256 colors!"
-    print -P "If your terminal supports 256 colors, please export the appropriate environment variable"
-    print -P "_before_ loading this theme in your \~\/.zshrc. In most terminal emulators, putting"
-    print -P "%F{blue}export TERM=\"xterm-256color\"%f at the top of your \~\/.zshrc is sufficient."
-  fi
+  termColors
 
   # If the terminal `LANG` is set to `C`, this theme will not work at all.
   local term_lang

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -142,8 +142,8 @@ left_prompt_segment() {
     # subsegment (or the default color). This should have
     # enough contrast.
     local complement
-    [[ -n "$4" ]] && complement="$4" || complement=$DEFAULT_COLOR
-    echo -n "$bg%F{$complement}"
+    [[ -n "$4" ]] && complement="$fg" || complement="$(foregroundColor $DEFAULT_COLOR)"
+    echo -n "${bg}${complement}"
     if [[ $joined == false ]]; then
       echo -n "$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
     fi
@@ -229,10 +229,11 @@ right_prompt_segment() {
       # subsegment (or the default color). This should have
       # enough contrast.
       local complement
-      [[ -n "$4" ]] && complement="$4" || complement=$DEFAULT_COLOR
-      echo -n "%F{$complement}$(print_icon 'RIGHT_SUBSEGMENT_SEPARATOR')%f"
+      [[ -n "$4" ]] && complement="$fg" || complement="$(foregroundColor $DEFAULT_COLOR)"
+      echo -n "$complement$(print_icon 'RIGHT_SUBSEGMENT_SEPARATOR')%f"
     else
-      echo -n "%F{$3}$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f"
+      # Use the new BG color for the foreground with separator
+      echo -n "$(foregroundColor $3)$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f"
     fi
   fi
 

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -19,7 +19,7 @@ function testRust() {
   alias rustc=mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{darkorange} %F{black}Rust 0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{black}Rust 0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias rustc


### PR DESCRIPTION
terminals do not always render named colors
when using parameter expansion.

- check if named color renders (dynamic)
- if not use the colorCode
- getColorCode executable with (foreground|background) to show example in terminal
- only 2 places render colors, so it is an easy fix.

https://github.com/bhilburn/powerlevel9k/issues/702