### PR TITLE
Added sudo state to prompt_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ main theme distribution so that everyone can use it!
 
 The `context` segment (user@host string) is conditional. By default, it will
 only print if you are not your 'normal' user (including if you are root), or if
-you are SSH'd to a remote host.
+you are SSH'd to a remote host. `SUDO` and `REMOTE_SUDO` states are also available to show whether the current user or remote user has superuser privileges.
 
 To use this feature, make sure the `context` segment is enabled in your prompt
 elements (it is by default), and define a `DEFAULT_USER` in your `~/.zshrc`.
@@ -580,6 +580,7 @@ You can also override the icons by setting:
 ```
 POWERLEVEL9K_USER_ICON="\uF415" # 
 POWERLEVEL9K_ROOT_ICON="#"
+POWERLEVEL9K_SUDO_ICON=$'\uF09C' # 
 ```
 
 | Variable | Default Value | Description |

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -258,6 +258,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
       CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
       ROOT_ICON                      $'\uE614 '             # 
+      SUDO_ICON                      $'\uE0A2'              # 
       RUBY_ICON                      $'\uF219 '             # 
       AWS_ICON                       $'\uF270'              # 
       AWS_EB_ICON                    $'\UF1BD  '            # 
@@ -332,6 +333,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
       CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
       ROOT_ICON                      $'\u26A1'              # ⚡
+      SUDO_ICON                      $'\uE0A2'              # 
       RUBY_ICON                      ''
       AWS_ICON                       'AWS:'
       AWS_EB_ICON                    $'\U1F331 '            # 🌱

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -27,6 +27,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
       CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
       ROOT_ICON                      $'\uE801'              # 
+      SUDO_ICON                      $'\uF09C'              # 
       RUBY_ICON                      $'\uE847 '             # 
       AWS_ICON                       $'\uE895'              # 
       AWS_EB_ICON                    $'\U1F331 '            # 🌱
@@ -105,6 +106,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
       CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
       ROOT_ICON                      $'\uF201'              # 
+      SUDO_ICON                      $'\uF09C'              # 
       RUBY_ICON                      $'\uF219 '             # 
       AWS_ICON                       $'\uF270'              # 
       AWS_EB_ICON                    $'\U1F331 '            # 🌱
@@ -188,6 +190,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'                                      # 
       CARRIAGE_RETURN_ICON           $'\u21B5'                                      # ↵
       ROOT_ICON                      '\u'$CODEPOINT_OF_OCTICONS_ZAP                 # 
+      SUDO_ICON                      '\u'$CODEPOINT_OF_AWESOME_UNLOCK               # 
       RUBY_ICON                      '\u'$CODEPOINT_OF_OCTICONS_RUBY' '             # 
       AWS_ICON                       '\u'$CODEPOINT_OF_AWESOME_SERVER               # 
       AWS_EB_ICON                    $'\U1F331 '                                    # 🌱
@@ -258,7 +261,7 @@ case $POWERLEVEL9K_MODE in
       RIGHT_SUBSEGMENT_SEPARATOR     $'\uE0B3'              # 
       CARRIAGE_RETURN_ICON           $'\u21B5'              # ↵
       ROOT_ICON                      $'\uE614 '             # 
-      SUDO_ICON                      $'\uE0A2'              # 
+      SUDO_ICON                      $'\uF09C'              # 
       RUBY_ICON                      $'\uF219 '             # 
       AWS_ICON                       $'\uF270'              # 
       AWS_EB_ICON                    $'\UF1BD  '            # 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -610,7 +610,7 @@ prompt_context() {
   elif [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
     current_state="REMOTE"
   elif sudo -n true 2>/dev/null; then
-    current_statue="SUDO"
+    current_state="SUDO"
   fi
 
   "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${context_states[$current_state]}" "${content}"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -609,7 +609,7 @@ prompt_context() {
     current_state="ROOT"
   elif [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
     current_state="REMOTE"
-  elif sudo -n uptime >/dev/null 2>&1; then
+  elif sudo -n true 2>/dev/null; then
     current_statue="SUDO"
   fi
 
@@ -632,7 +632,7 @@ prompt_user() {
         "FOREGROUND_COLOR"    "yellow"
         "VISUAL_IDENTIFIER"   "ROOT_ICON"
       )
-    elif sudo -n uptime >/dev/null 2>&1; then 
+    elif sudo -n true 2>/dev/null; then 
       user_state=( 
         "STATE"               "SUDO" 
         "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}" 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -589,10 +589,11 @@ prompt_context() {
   local current_state="DEFAULT"
   typeset -AH context_states
   context_states=(
-    "ROOT"      "yellow"
-    "SUDO"      "yellow"
-    "DEFAULT"   "yellow"
-    "REMOTE"    "yellow"
+    "ROOT"        "yellow"
+    "SUDO"        "yellow"
+    "DEFAULT"     "yellow"
+    "REMOTE"      "yellow"
+    "REMOTE_SUDO" "yellow"
   )
 
   local content=""
@@ -608,7 +609,11 @@ prompt_context() {
   if [[ $(print -P "%#") == '#' ]]; then
     current_state="ROOT"
   elif [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
-    current_state="REMOTE"
+    if sudo -n true 2>/dev/null; then
+      current_state="REMOTE_SUDO"
+    else
+      current_state="REMOTE"
+    fi
   elif sudo -n true 2>/dev/null; then
     current_state="SUDO"
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -638,7 +638,7 @@ prompt_user() {
         "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}" 
         "BACKGROUND_COLOR"    "${DEFAULT_COLOR}" 
         "FOREGROUND_COLOR"    "yellow" 
-        "VISUAL_IDENTIFIER"   "ROOT_ICON" 
+        "VISUAL_IDENTIFIER"   "SUDO_ICON" 
       ) 
     else
       user_state=(

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -590,6 +590,7 @@ prompt_context() {
   typeset -AH context_states
   context_states=(
     "ROOT"      "yellow"
+    "SUDO"      "yellow"
     "DEFAULT"   "yellow"
     "REMOTE"    "yellow"
   )
@@ -608,6 +609,8 @@ prompt_context() {
     current_state="ROOT"
   elif [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
     current_state="REMOTE"
+  elif sudo -n uptime >/dev/null 2>&1; then
+    current_statue="SUDO"
   fi
 
   "$1_prompt_segment" "${0}_${current_state}" "$2" "$DEFAULT_COLOR" "${context_states[$current_state]}" "${content}"
@@ -629,6 +632,14 @@ prompt_user() {
         "FOREGROUND_COLOR"    "yellow"
         "VISUAL_IDENTIFIER"   "ROOT_ICON"
       )
+    elif sudo -n uptime >/dev/null 2>&1; then 
+      user_state=( 
+        "STATE"               "SUDO" 
+        "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}" 
+        "BACKGROUND_COLOR"    "${DEFAULT_COLOR}" 
+        "FOREGROUND_COLOR"    "yellow" 
+        "VISUAL_IDENTIFIER"   "ROOT_ICON" 
+      ) 
     else
       user_state=(
         "STATE"               "DEFAULT"


### PR DESCRIPTION
Before I discovered zsh, I was using oh-my-bash. What I missed from that was that if I still had elevated privileges that I could see that. This adds the state of `SUDO` to `user_prompt` which gives this capability.