### PR TITLE
Add absolute truncation option to dir segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Customizations available are:
 | Strategy Name | Description |
 |---------------|-------------|
 |Default|Truncate whole directories from left. How many is defined by `POWERLEVEL9K_SHORTEN_DIR_LENGTH`|
-|`truncate_absolute_chars`|Truncates an absolute number of characters from the left such that the number of characters that your path displays (including `POWERLEVEL9K_SHORTEN_DELIMITER`) is no more than `POWERLEVEL9K_SHORTEN_DIR_LENGTH`.|
+|`truncate_absolute_chars`|Truncates an absolute number of characters from the left such that the number of characters that your path displays (with or without `POWERLEVEL9K_SHORTEN_DELIMITER`) is no more than `POWERLEVEL9K_SHORTEN_DIR_LENGTH` + the length of `POWERLEVEL9K_SHORTEN_DELIMITER` |
 |`truncate_middle`|Truncates the middle part of a folder. E.g. you are in a folder named `~/MySuperProjects/AwesomeFiles/BoringOffice`, then it will truncated to `~/MyS..cts/Awe..les/BoringOffice`, if `POWERLEVEL9K_SHORTEN_DIR_LENGTH=3` is also set (controls the amount of characters to be left).|
 |`truncate_from_right`|Just leaves the beginning of a folder name untouched. E.g. your folders will be truncated like so: "/ro../Pr../office". How many characters will be untouched is controlled by `POWERLEVEL9K_SHORTEN_DIR_LENGTH`.|
 |`truncate_with_package_name`|Search for a `package.json` or `composer.json` and prints the `name` field to abbreviate the directory path. The precedence and/or files could be set by `POWERLEVEL9K_DIR_PACKAGE_FILES=(package.json composer.json)`. If you have [jq](https://stedolan.github.io/jq/) installed, it will dramatically improve the speed of this strategy.|

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -730,10 +730,8 @@ prompt_dir() {
     case "$POWERLEVEL9K_SHORTEN_STRATEGY" in
       truncate_absolute_chars)
         if [ ${#current_path} -gt $(( $POWERLEVEL9K_SHORTEN_DIR_LENGTH + ${#POWERLEVEL9K_SHORTEN_DELIMITER} )) ]; then
-          current_path=$(echo $current_path | rev | cut -c 1-$POWERLEVEL9K_SHORTEN_DIR_LENGTH | rev | cat <(echo -n $POWERLEVEL9K_SHORTEN_DELIMITER) -)
+          current_path=$POWERLEVEL9K_SHORTEN_DELIMITER${current_path:(-POWERLEVEL9K_SHORTEN_DIR_LENGTH)}
         fi
-        # Alternative implementation
-        #current_path="%$POWERLEVEL9K_SHORTEN_DIR_LENGTH<$POWERLEVEL9K_SHORTEN_DELIMITER<%~%<<"
       ;;
       truncate_middle)
         current_path=$(echo "$current_path" | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\2\//g")

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -728,6 +728,13 @@ prompt_dir() {
     set_default POWERLEVEL9K_SHORTEN_DELIMITER $'\U2026'
 
     case "$POWERLEVEL9K_SHORTEN_STRATEGY" in
+      truncate_absolute_chars)
+        if [ ${#current_path} -gt $(( $POWERLEVEL9K_SHORTEN_DIR_LENGTH + ${#POWERLEVEL9K_SHORTEN_DELIMITER} )) ]; then
+          current_path=$(echo $current_path | rev | cut -c 1-$POWERLEVEL9K_SHORTEN_DIR_LENGTH | rev | cat <(echo -n $POWERLEVEL9K_SHORTEN_DELIMITER) -)
+        fi
+        # Alternative implementation
+        #current_path="%$POWERLEVEL9K_SHORTEN_DIR_LENGTH<$POWERLEVEL9K_SHORTEN_DELIMITER<%~%<<"
+      ;;
       truncate_middle)
         current_path=$(echo "$current_path" | sed $SED_EXTENDED_REGEX_PARAMETER "s/([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})[^/]+([^/]{$POWERLEVEL9K_SHORTEN_DIR_LENGTH})\//\1$POWERLEVEL9K_SHORTEN_DELIMITER\2\//g")
       ;;


### PR DESCRIPTION
There were a few ways to do this - I have no idea about which ways yield the best performance (tbh I'm not very familiar with bash scripting, but I just assume the less pipes the better).
I've also included an alternative implementation which seems to work - but for some reason, the implementation of every other truncation option doesn't use stuff like `%~` and surely there must be a reason, which is why I've commented it out.

I'm sure I could work on this a bit more to give it more customizability - I've just implemented it so that I can get my prompt to appear how I want. As a sidenote, I definitely think that the dir configuration options could be refactored and made more powerful and easier to use.