### PR TITLE
Fix vi-mode and support hiding segment when in insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,8 @@ you are using the [ZSH Line Editor](http://zsh.sourceforge.net/Doc/Release/Zsh-L
 |`POWERLEVEL9K_VI_INSERT_MODE_STRING`|`"INSERT"`|String to display while in 'Insert' mode.|
 |`POWERLEVEL9K_VI_COMMAND_MODE_STRING`|`"NORMAL"`|String to display while in 'Command' mode.|
 
+To hide the segment entirely when in `INSERT` mode, set `POWERLEVEL9K_VI_INSERT_MODE_STRING=''`
+
 #### Unit Test Ratios
 
 The `symfony2_tests` and `rspec_stats` segments both show a ratio of "real"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1366,6 +1366,7 @@ prompt_vi_mode() {
       "$1_prompt_segment" "$0_NORMAL" "$2" "$DEFAULT_COLOR" "default" "$POWERLEVEL9K_VI_COMMAND_MODE_STRING"
     ;;
     main|viins|*)
+      if [[ -z $POWERLEVEL9K_VI_INSERT_MODE_STRING ]]; then return; fi
       "$1_prompt_segment" "$0_INSERT" "$2" "$DEFAULT_COLOR" "blue" "$POWERLEVEL9K_VI_INSERT_MODE_STRING"
     ;;
   esac

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1522,6 +1522,11 @@ NEWLINE='
   [[ $POWERLEVEL9K_PROMPT_ADD_NEWLINE == true ]] && PROMPT="$NEWLINE$PROMPT"
 }
 
+zle-keymap-select () {
+	zle reset-prompt
+	zle -R
+}
+
 prompt_powerlevel9k_setup() {
   # The value below was set to better support 32-bit CPUs.
   # It's the maximum _signed_ integer value on 32-bit CPUs.
@@ -1590,6 +1595,8 @@ prompt_powerlevel9k_setup() {
   # prepare prompts
   add-zsh-hook precmd powerlevel9k_prepare_prompts
   add-zsh-hook preexec powerlevel9k_preexec
+
+  zle -N zle-keymap-select
 }
 
 prompt_powerlevel9k_teardown() {


### PR DESCRIPTION
I believe [this commit](https://github.com/bhilburn/powerlevel9k/commit/520eed12482b276e630d66b01a3f5852c96b6b1f) stopped the vi_mode plugin from working (also see [this comment](https://github.com/bhilburn/powerlevel9k/issues/319#issuecomment-355870476) from issue #319).

This PR returns one of the parts that was removed in that commit to get vi_mode working again as suggested by the comment linked above.

It also adds a check to see if `POWERLEVEL9K_VI_INSERT_MODE_STRING` is an empty string and if so, it skips showing the segment entirely.

This works both when using vi mode directly and when temporarily entering vi mode from emacs mode with `^X^V`.

This fixes #725 and possibly #319.