### PR TITLE
Fix iTerm2 integration with PowerLevel9k

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1623,6 +1623,9 @@ $(print_icon 'MULTILINE_LAST_PROMPT_PREFIX')'
 NEWLINE='
 '
   [[ $POWERLEVEL9K_PROMPT_ADD_NEWLINE == true ]] && PROMPT="$NEWLINE$PROMPT"
+
+  # Allow iTerm integration to work
+  [[ $ITERM_SHELL_INTEGRATION_INSTALLED == "Yes" ]] && PROMPT="%{$(iterm2_prompt_mark)%}$PROMPT"
 }
 
 set_default POWERLEVEL9K_IGNORE_TERM_COLORS false


### PR DESCRIPTION
This fix allows the user to see the "little blue triangle" that is created when iTerm2 shell integration is enabled.