### PR TITLE
Fixed home abbreviation not being exclusive with circular navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ customization is provided via:
 |`POWERLEVEL9K_VCS_GIT_HOOKS`|`(vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname)`|Layout of the segment for git repositories.|
 |`POWERLEVEL9K_VCS_HG_HOOKS`|`(vcs-detect-changes)`|Layout of the segment for Mercurial repositories.|
 |`POWERLEVEL9K_VCS_SVN_HOOKS`|`(vcs-detect-changes svn-detect-changes)`|Layout of the segment for SVN repositories.|
+|`POWERLEVEL9K_VCS_ACTIONFORMAT_FOREGROUND`|`red`|The color of the foreground font during actions (e.g., `REBASE`).|
 
 
 ##### vcs symbols

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -809,7 +809,9 @@ prompt_dir() {
         current_path="${cur_short_path: : -1}"
       ;;
       *)
-        current_path="$(print -P "%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c")"
+        if [[ $current_path != "~" ]]; then
+          current_path="$(print -P "%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c")"
+        fi
       ;;
     esac
   fi


### PR DESCRIPTION
When navigating to a sub-folder of $HOME and then back up to $HOME, the shortened directory incorrectly contains the shorten delimiter (`cd; cd Documents; cd ..;'` results in `.../~` as the directory shown). This only seems to occur if the shorten strategy environment variable is left blank.

To solve this I added a conditional check to apply the default switch statement case only if the current_path is not $HOME (i.e. not equal to "~").

Just in case this may be more specific to my configuration, my PowerLevel9K config is shown below:
```export DEFAULT_USER=conrad
export POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir_writable dir ssh anaconda vcs)
export POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status root_indicator time) 
export POWERLEVEL9K_STATUS_VERBOSE=true
export POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
export POWERLVEL9K_BACKGROUND_JOBS_VERBOSE=true```