### PR TITLE
fix wrong current_path under certain circumstances

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -809,7 +809,7 @@ prompt_dir() {
         current_path="${cur_short_path: : -1}"
       ;;
       *)
-        current_path="$(print -P "%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c")"
+        current_path="$(print "%$((POWERLEVEL9K_SHORTEN_DIR_LENGTH+1))(c:$POWERLEVEL9K_SHORTEN_DELIMITER/:)%${POWERLEVEL9K_SHORTEN_DIR_LENGTH}c")"
       ;;
     esac
   fi


### PR DESCRIPTION
Under certain circumstances like a mounted directory the variable literal of ```current_path``` is printed instead of the actualy pwd content.

-P in this case is wrongly used, what it dies: ```print the arguments to the input of the coprocess.``` which results in printing ```~current_path```.

This fixes #731