### PR TITLE
Make variables local

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -35,11 +35,11 @@ function getColor() {
     fi
   else
     # named color added to parameter expansion print -P to test if the name exists in terminal
-    named="%K{$1}"
+    local named="%K{$1}"
     # https://misc.flogisoft.com/bash/tip_colors_and_formatting
-    default="$'\033'\[49m"
+    local default="$'\033'\[49m"
     # http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html
-    quoted=$(printf "%q" $(print -P "$named"))
+    local quoted=$(printf "%q" $(print -P "$named"))
     if [[ $quoted = "$'\033'\[49m" && $1 != "black" ]]; then
         # color not found, so try to get the code
         1=$(getColorCode $1)

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -39,6 +39,7 @@ printSizeHumanReadable() {
 
   # if the base is not Bytes
   if [[ -n $2 ]]; then
+    local idx
     for idx in "${extension[@]}"; do
       if [[ "$2" == "$idx" ]]; then
         break

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -921,7 +921,7 @@ prompt_dir() {
   fi
 
   # declare variables used for bold and state colors
-  local bld dir_state_foreground dir_state_user_foreground
+  local bld_on bld_off dir_state_foreground dir_state_user_foreground
   # test if user wants the last directory printed in bold
   if [[ "${(L)POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD}" == "true" ]]; then
     bld_on="%B"
@@ -1685,6 +1685,7 @@ build_left_prompt() {
 # Right prompt
 build_right_prompt() {
   local index=1
+  local element
   for element in "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
     # Remove joined information in direct calls
     element=${element%_joined}
@@ -1707,6 +1708,7 @@ powerlevel9k_preexec() {
 
 set_default POWERLEVEL9K_PROMPT_ADD_NEWLINE false
 powerlevel9k_prepare_prompts() {
+  local RETVAL RPROMPT_PREFIX RPROMPT_SUFFIX
   RETVAL=$?
   RETVALS=( "$pipestatus[@]" )
 
@@ -1741,7 +1743,7 @@ $(print_icon 'MULTILINE_LAST_PROMPT_PREFIX')'
     RPROMPT='$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX'
   fi
 
-NEWLINE='
+local NEWLINE='
 '
 
   if [[ $POWERLEVEL9K_PROMPT_ADD_NEWLINE == true ]]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -278,7 +278,7 @@ CURRENT_BG='NONE'
 prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
-  _path=$CONDA_ENV_PATH$CONDA_PREFIX
+  local _path=$CONDA_ENV_PATH$CONDA_PREFIX
   if ! [ -z "$_path" ]; then
     # config - can be overwritten in users' zshrc file.
     set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("


### PR DESCRIPTION
This is a rather small change. I recently stumbled upon the option `setopt WARN_CREATE_GLOBAL` that 🙄 warns about creating global variables. With this PR I made all unnecessary global variables local.