### PR TITLE
Rbenv prompt option always displays #777

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,10 @@ It figures out the version being used by taking the output of the `rbenv version
 * If `rbenv` is not in $PATH, nothing will be shown.
 * If the current Ruby version is the same as the global Ruby version, nothing will be shown.
 
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the rbenv segment even if the current Ruby version is the same as the global Ruby version|
+
 ##### rspec_stats
 
 See [Unit Test Ratios](#unit-test-ratios), below.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1065,14 +1065,15 @@ prompt_ram() {
   "$1_prompt_segment" "$0" "$2" "yellow" "$DEFAULT_COLOR" "$(printSizeHumanReadable "$ramfree" $base)" 'RAM_ICON'
 }
 
+set_default POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW false
 # rbenv information
 prompt_rbenv() {
-  if which rbenv 2>/dev/null >&2; then
+  if command which rbenv 2>/dev/null >&2; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
 
     # Don't show anything if the current Ruby is the same as the global Ruby.
-    if [[ $rbenv_version_name == $rbenv_global ]]; then
+    if [[ $rbenv_version_name == $rbenv_global && "$POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW" = false ]]; then
       return
     fi
 
@@ -1418,7 +1419,7 @@ prompt_kubecontext() {
     if [[ -z "$k8s_namespace" ]]; then
       k8s_namespace="default"
     fi
-  
+
     local k8s_final_text=""
 
     if [[ "$k8s_context" == "k8s_namespace" ]]; then
@@ -1427,8 +1428,8 @@ prompt_kubecontext() {
     else
       k8s_final_text="$k8s_context/$k8s_namespace"
     fi
-  
-    
+
+
     "$1_prompt_segment" "$0" "$2" "magenta" "white" "$k8s_final_text" "KUBERNETES_ICON"
   fi
 }


### PR DESCRIPTION
- Add environment variable POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW to set the rbenv prompt segment to show if the local Ruby version is the same as the global Ruby version.
- This also includes a small bugfix where $(which rbenv) would return the actual function, so $(command which rbenv) returns the result of calling the function.
- Update Readme with description for setting POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW