### PR TITLE
Add vcs branch name truncating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,29 @@ from the [Installation](#Installation) section above.
 | None         |  None               | ![icon_git](https://cloud.githubusercontent.com/assets/1544760/7976092/b5909f80-0a76-11e5-9950-1438b9d72465.gif) | Repository is a git repository
 | None         |  None               | ![icon_mercurial](https://cloud.githubusercontent.com/assets/1544760/7976090/b5908da6-0a76-11e5-8c91-452b6e73f631.gif) | Repository is a Mercurial repository
 
+You can limit the branch name to a certain length by truncating long names.
+Customizations available are:
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_VCS_SHORTEN_LENGTH`|None|This field determines how many characters to show.|
+|`POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH`|None|This field determines minimum branch length. Branch name will be truncated if its length greater than this field.|
+|`POWERLEVEL9K_VCS_SHORTEN_STRATEGY`|None|This field determines how branch name should be truncated. See the table below for more information.|
+|`POWERLEVEL9K_SHORTEN_DELIMITER`|`...`|Delimiter to use in truncated strings. This can be any string you choose, including an empty string if you wish to have no delimiter.|
+
+| Strategy Name | Description |
+|---------------|-------------|
+|`truncate_middle`|Truncates the middle part of a branch. E.g. branch name is `1234-super_super_long_branch_name`, then it will truncated to `1234-..._name`, if `POWERLEVEL9K_VCS_SHORTEN_LENGTH=5` is also set (controls the amount of characters to be left).|
+|`truncate_from_right`|Just leaves the beginning of a branch name untouched. E.g. branch name will be truncated like so: `1234-...`. How many characters will be untouched is controlled by `POWERLEVEL9K_VCS_SHORTEN_LENGTH`.|
+
+For example, if you want to truncate `1234-super_super_long_branch_name` to `1234-..` and don't do it with `development`:
+```zsh
+POWERLEVEL9K_VCS_SHORTEN_LENGTH=4
+POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=11
+POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
+POWERLEVEL9K_VCS_SHORTEN_DELIMITER=".."
+```
+
 ##### vi_mode
 
 This segment shows ZSH's current input mode. Note that this is only useful if

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -51,6 +51,21 @@ function +vi-git-remotebranch() {
     remote=${$(git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
     branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
 
+    if [[ -n "$POWERLEVEL9K_VCS_SHORTEN_LENGTH" ]] && [[ -n "$POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH" ]]; then
+     set_default POWERLEVEL9K_VCS_SHORTEN_DELIMITER $'\U2026'
+
+     if [ ${#hook_com[branch]} -gt $POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH ] && [ ${#hook_com[branch]} -gt $POWERLEVEL9K_VCS_SHORTEN_LENGTH ]; then
+       case "$POWERLEVEL9K_VCS_SHORTEN_STRATEGY" in
+         truncate_middle)
+           hook_com[branch]="$(echo "${branch_name:0:$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")$POWERLEVEL9K_VCS_SHORTEN_DELIMITER$(echo "${branch_name: -$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")"
+         ;;
+         truncate_from_right)
+           hook_com[branch]="$(echo "${branch_name:0:$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")$POWERLEVEL9K_VCS_SHORTEN_DELIMITER"
+         ;;
+       esac
+     fi
+    fi
+
     hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${hook_com[branch]}"
     # Always show the remote
     #if [[ -n ${remote} ]] ; then

--- a/test/segments/vcs.spec
+++ b/test/segments/vcs.spec
@@ -78,4 +78,84 @@ function testColorOverridingForUntrackedStateWorks() {
   unset POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND
 }
 
+function testBranchNameTruncatingShortenLength() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=6
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
+function testBranchNameTruncatingMinLength() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=6
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=7
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
+function testBranchNameTruncatingShortenStrategy() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_middle"
+
+  assertEquals "%K{green} %F{black} mas…ter ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
 source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
These changes allow truncating of vcs branch name.

Before:
![image](https://user-images.githubusercontent.com/11468173/38685814-76df371a-3e7b-11e8-968d-9f7db6de3558.png)

After:
![image](https://user-images.githubusercontent.com/11468173/38686023-03f3c508-3e7c-11e8-8122-37d286b109fc.png)


@bhilburn, please take a look.