### PR TITLE
Edited virtualenv prompt to show python version

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1385,10 +1385,11 @@ prompt_vi_mode() {
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n "$virtualenv_path" && "$VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$(basename "$virtualenv_path")" 'PYTHON_ICON'
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR"  "$(basename $virtualenv_path):$(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed   's/.$//')" 'PYTHON_ICON'
+  elif which pyenv &> /dev/null; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR"  "$(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed 's/.$//')" 'PYTHON_ICON'
   fi
-}
-
+  }
 # pyenv: current active python version (with restrictions)
 # https://github.com/pyenv/pyenv#choosing-the-python-version
 prompt_pyenv() {


### PR DESCRIPTION
Edited the prompt for virtualenv to always show current python version
If inside a virtualenv, it would show <virtualenv_name>:<python_version>
ex: django:3.6.0
if not inside any virtualenv, it would show <python_version>
ex: 3.6.0

Since I just recently adopted python3 from python2, I'm switch python versions often to maintain older projects. I would sometimes forget which version I'm at, but the pyenv prompt would only display versions set by `pyenv shell <version>`. I would have to type `python -V` to check for myself.
So I integrated persistent python version displaying along with the `virtualenv` prompt to make `virtualenv` prompt display python version as well ! I thought this could help some others, hence this pull request. 