### PR TITLE
Fix newline issues in the anaconda segment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - test/segments/go_version.spec
   - test/segments/vcs.spec
   - test/segments/kubecontext.spec
+  - test/segments/anaconda.spec

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -281,7 +281,7 @@ prompt_anaconda() {
   # Caret notation: ^J is Newline (LF), ^M is Carriage Return (CR),
   # ^G is Bell (BEL), ^I is horizontal tab (TAB)
   # see https://en.wikipedia.org/wiki/ASCII#ASCII_control_characters
-  local SANITIZATION_CHARACTER_GROUP="[\^J\^M\^G\^I]"
+  local SANITIZATION_CHARACTER_GROUP="[\^J\^M\^G\^I"$'\n\r\a\t'"]"
   local _path="${CONDA_ENV_PATH//${~SANITIZATION_CHARACTER_GROUP}/}${CONDA_PREFIX//${~SANITIZATION_CHARACTER_GROUP}}/"
 
   if ! [ -z "$_path" ]; then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -278,7 +278,7 @@ CURRENT_BG='NONE'
 prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
-  local _path=$CONDA_ENV_PATH$CONDA_PREFIX
+  local _path="${CONDA_ENV_PATH//\\n/}${CONDA_PREFIX//\\n/}"
   if ! [ -z "$_path" ]; then
     # config - can be overwritten in users' zshrc file.
     set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -282,13 +282,14 @@ prompt_anaconda() {
   # ^G is Bell (BEL), ^I is horizontal tab (TAB)
   # see https://en.wikipedia.org/wiki/ASCII#ASCII_control_characters
   local SANITIZATION_CHARACTER_GROUP="[\^J\^M\^G\^I"$'\n\r\a\t'"]"
-  local _path="${CONDA_ENV_PATH//${~SANITIZATION_CHARACTER_GROUP}/}${CONDA_PREFIX//${~SANITIZATION_CHARACTER_GROUP}}/"
+  local _CONDA_ENV="$(basename ${CONDA_ENV_PATH}${CONDA_PREFIX})"
+  _CONDA_ENV="${_CONDA_ENV//${~SANITIZATION_CHARACTER_GROUP}/}"
 
-  if ! [ -z "$_path" ]; then
+  if ! [ -z "${_CONDA_ENV}" ]; then
     # config - can be overwritten in users' zshrc file.
     set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("
     set_default POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER ")"
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$POWERLEVEL9K_ANACONDA_LEFT_DELIMITER$(basename $_path)$POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER" 'PYTHON_ICON'
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "${POWERLEVEL9K_ANACONDA_LEFT_DELIMITER}${_CONDA_ENV}${POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER}" 'PYTHON_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -278,7 +278,12 @@ CURRENT_BG='NONE'
 prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
-  local _path="${CONDA_ENV_PATH//\\n/}${CONDA_PREFIX//\\n/}"
+  # Caret notation: ^J is Newline (LF), ^M is Carriage Return (CR),
+  # ^G is Bell (BEL), ^I is horizontal tab (TAB)
+  # see https://en.wikipedia.org/wiki/ASCII#ASCII_control_characters
+  local SANITIZATION_CHARACTER_GROUP="[\^J\^M\^G\^I]"
+  local _path="${CONDA_ENV_PATH//${~SANITIZATION_CHARACTER_GROUP}/}${CONDA_PREFIX//${~SANITIZATION_CHARACTER_GROUP}}/"
+
   if ! [ -z "$_path" ]; then
     # config - can be overwritten in users' zshrc file.
     set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -21,12 +21,51 @@ function testConda() {
   unset CONDA_PREFIX
 }
 
-function testCondaSegmentWithWindowsPath() {
+function testCondaSegmentWithNewlineInPath() {
   local CONDA_ENV_PATH="C:\app\anaconda3\lib\site-packages\newton\conda\cli"
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
 
-  # Careful! This string contains special characters! Look with hexdump or similar.
-  assertEquals "%K{blue} %F{black}(C:ppnaconda3\lib\site-packagesewton %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black}(C:appanaconda3libsite-packagesnewtoncondacli) %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_ENV_PATH
+}
+
+function testCondaSegmentWithCarriageReturnInPath() {
+  local CONDA_ENV_PATH="C:\app\anaconda3\lib\site-packages\redmond\conda\cli"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  assertEquals "%K{blue} %F{black}(C:appanaconda3libsite-packagesredmondcondacli) %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_ENV_PATH
+}
+
+function testCondaSegmentWithNewlineAndCarriageReturnInPath() {
+  local CONDA_ENV_PATH="C:\app\anaconda3\lib\site-packages\newton\redmond\conda\cli"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  assertEquals "%K{blue} %F{black}(C:appanaconda3libsite-packagesnewtonredmondcondacli) %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_ENV_PATH
+}
+
+function testCondaSegmentWithCarriageReturnAndNewlineInPath() {
+  local CONDA_ENV_PATH="C:\app\anaconda3\lib\site-packages\redmond\newton\conda\cli"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  assertEquals "%K{blue} %F{black}(C:appanaconda3libsite-packagesredmondnewtoncondacli) %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_ENV_PATH
+}
+
+function testCondaSegmentWithCarriageReturnNewlineBellAndTabInPath() {
+  local CONDA_ENV_PATH="C:\app\anaconda3\lib\t\a\n\site-packages\redmond\newton\conda\cli"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  assertEquals "%K{blue} %F{black}(C:appanaconda3libtansite-packagesredmondnewtoncondacli) %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset CONDA_ENV_PATH

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -1,0 +1,35 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function testConda() {
+  local CONDA_PREFIX="conda"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  assertEquals "%K{blue} %F{black}(conda) %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_PREFIX
+}
+
+function testCondaSegmentWithWindowsPath() {
+  local CONDA_ENV_PATH="C:\app\anaconda3\lib\site-packages\newton\conda\cli"
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+
+  # Careful! This string contains special characters! Look with hexdump or similar.
+  assertEquals "%K{blue} %F{black}(C:ppnaconda3\lib\site-packagesewton %k%F{blue}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset CONDA_ENV_PATH
+}
+
+source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
This is a PR for #747 

It might be that the directory after `proxy` starts with an "n". This could lead to a newline as the string gets evaled..

@sbmueller Could you check if this branch works for you?
It is not a super good solution, because it just strips the newlines, but if the path contains backslashes it will still be broken eventually.. It might be a better idea to replace backslashes with slashes. What do you think @sbmueller ?