### PR TITLE
add `POWERLEVEL9K_VIRTUALENV_SHOW_VERSION` option to virtualenv segment

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1570,6 +1570,10 @@ prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n "$virtualenv_path" && "$VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
     "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$(basename "$virtualenv_path")" 'PYTHON_ICON'
+
+    if [[ -v "POWERLEVEL9K_VIRTUALENV_SHOW_VERSION" && "$POWERLEVEL9K_VIRTUALENV_SHOW_VERSION" == true ]]; then
+      "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$(python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}.{2}".format(*version))')"
+    fi
   fi
 }
 


### PR DESCRIPTION
As discussed in #808 
This PR adds a new option to the `virtualenv` segment.

If you add `POWERLEVEL9K_VIRTUALENV_SHOW_VERSION=true` to your `.zshrc` p9k will add your python version to your venv segment

It looks like this:
Using Python2
![Imgur](https://i.imgur.com/fEutMGs.png)
Using Python3
![Imgur](https://i.imgur.com/cPALjq7.png)

Thanks @hiimdoublej for suggesting this!