### PR TITLE
add cog symbol to dir segment if folder is /etc*

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -71,6 +71,7 @@ case $POWERLEVEL9K_MODE in
       HOME_SUB_ICON                  $'\uE18D'              # 
       FOLDER_ICON                    $'\uE818'              # 
       NETWORK_ICON                   $'\uE1AD'              # 
+      ETC_ICON                       $'\uE818'              # 
       LOAD_ICON                      $'\uE190 '             # 
       SWAP_ICON                      $'\uE87D'              # 
       RAM_ICON                       $'\uE1E2 '             # 
@@ -167,6 +168,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      $'\uF015'              # 
       HOME_SUB_ICON                  $'\uF07C'              # 
       FOLDER_ICON                    $'\uF115'              # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   $'\uF09E'              # 
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF0E4'              # 
@@ -266,6 +268,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      '\u'$CODEPOINT_OF_AWESOME_HOME                 # 
       HOME_SUB_ICON                  '\u'$CODEPOINT_OF_AWESOME_FOLDER_OPEN          # 
       FOLDER_ICON                    '\u'$CODEPOINT_OF_AWESOME_FOLDER_O             # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   '\u'$CODEPOINT_OF_AWESOME_RSS                  # 
       LOAD_ICON                      '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '         # 
       SWAP_ICON                      '\u'$CODEPOINT_OF_AWESOME_DASHBOARD            # 
@@ -359,6 +362,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      $'\uF015'              # 
       HOME_SUB_ICON                  $'\uF07C'              # 
       FOLDER_ICON                    $'\uF115'              # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   $'\uF1EB'              # 
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF464'              # 
@@ -452,6 +456,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      ''
       HOME_SUB_ICON                  ''
       FOLDER_ICON                    ''
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
       SWAP_ICON                      'SWP'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -909,10 +909,13 @@ prompt_dir() {
     "HOME"            "HOME_ICON"
     "HOME_SUBFOLDER"  "HOME_SUB_ICON"
     "NOT_WRITABLE"    "LOCK_ICON"
+    "ETC"             "ETC_ICON"
   )
   local state_path="$(print -P '%~')"
   local current_state="DEFAULT"
-  if [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == true && ! -w "$PWD" ]]; then
+  if [[ $state_path == '/etc'* ]]; then
+    current_state='ETC'
+  elif [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == true && ! -w "$PWD" ]]; then
     current_state="NOT_WRITABLE"
   elif [[ $state_path == '~' ]]; then
     current_state="HOME"


### PR DESCRIPTION
This PR adds a new setting for the `dir` segment to style `/etc` and subfolders independently

It also adds a default Icon to use `\uF013` (only if you are using font-awesome or nerd-fonts config)


Options to change colors and icon:
```
POWERLEVEL9K_ETC_ICON='\uf0ad'
POWERLEVEL9K_DIR_ETC_BACKGROUND='57'
POWERLEVEL9K_DIR_ETC_FOREGROUND='white'
```

Example Screenshot:
![bildschirmfoto 2018-05-17 um 12 54 51](https://user-images.githubusercontent.com/22161944/40173471-42d6916c-59d2-11e8-991a-a1f549bae028.png)
