### PR TITLE
Fix RPROMPT_ON_NEWLINE when PROMPT_ON_NEWLINE is set to false

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1500,26 +1500,25 @@ powerlevel9k_prepare_prompts() {
   # Reset start time
   _P9K_TIMER_START=0x7FFFFFFF
 
+  if [[ "$POWERLEVEL9K_RPROMPT_ON_NEWLINE" != true ]]; then
+    # The right prompt should be on the same line as the first line of the left
+    # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
+    # the RPROMPT, we advise it, to go one line up. At the end of RPROMPT, we
+    # advise it to go one line down. See:
+    # http://superuser.com/questions/357107/zsh-right-justify-in-ps1
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
+    RPROMPT_PREFIX='%{'$'\e[1A''%}' # one line up
+    RPROMPT_SUFFIX='%{'$'\e[1B''%}' # one line down
+  else
+    RPROMPT_PREFIX=''
+    RPROMPT_SUFFIX=''
+  fi
+
   if [[ "$POWERLEVEL9K_PROMPT_ON_NEWLINE" == true ]]; then
     PROMPT='$(print_icon 'MULTILINE_FIRST_PROMPT_PREFIX')%f%b%k$(build_left_prompt)
 $(print_icon 'MULTILINE_LAST_PROMPT_PREFIX')'
-    if [[ "$POWERLEVEL9K_RPROMPT_ON_NEWLINE" != true ]]; then
-      # The right prompt should be on the same line as the first line of the left
-      # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
-      # the RPROMPT, we advise it, to go one line up. At the end of RPROMPT, we
-      # advise it to go one line down. See:
-      # http://superuser.com/questions/357107/zsh-right-justify-in-ps1
-      local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
-      RPROMPT_PREFIX='%{'$'\e[1A''%}' # one line up
-      RPROMPT_SUFFIX='%{'$'\e[1B''%}' # one line down
-    else
-      RPROMPT_PREFIX=''
-      RPROMPT_SUFFIX=''
-    fi
   else
     PROMPT='%f%b%k$(build_left_prompt)'
-    RPROMPT_PREFIX=''
-    RPROMPT_SUFFIX=''
   fi
 
   if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then


### PR DESCRIPTION
By having the `RPROMPT_ON_NEWLINE` if-block only inside the `PROMPT_ON_NEWLINE == true` if-block, `RPROMPT_ON_NEWLINE` is ignored in the case where `(RPROMPT_ON_NEWLINE == false) && (PROMPT_ON_NEWLINE == false)` and there is a `newline` segment in the left prompt. This causes the right prompt to always be drawn in the second line.

This patch fixes the issue #840