### PR TITLE
Fix Linux distribution detection

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -106,58 +106,58 @@ case $(uname) in
       OS='Linux'
       os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
       case "$os_release_id" in
-        "arch")
+        *arch*)
         OS_ICON=$(print_icon 'LINUX_ARCH_ICON')
         ;;
-        "debian")
+        *debian*)
         OS_ICON=$(print_icon 'LINUX_DEBIAN_ICON')
         ;;
-       "ubuntu")
+       *ubuntu*)
         OS_ICON=$(print_icon 'LINUX_UBUNTU_ICON')
         ;;
-       "elementary")
+       *elementary*)
         OS_ICON=$(print_icon 'LINUX_ELEMENTARY_ICON')
         ;;
-       "fedora")
+       *fedora*)
         OS_ICON=$(print_icon 'LINUX_FEDORA_ICON')
         ;;
-       "coreos")
+       *coreos*)
         OS_ICON=$(print_icon 'LINUX_COREOS_ICON')
         ;;
-       "gentoo")
+       *gentoo*)
         OS_ICON=$(print_icon 'LINUX_GENTOO_ICON')
         ;;
-       "mageia")
+       *mageia*)
         OS_ICON=$(print_icon 'LINUX_MAGEIA_ICON')
         ;;
-       "centos")
+       *centos*)
         OS_ICON=$(print_icon 'LINUX_CENTOS_ICON')
         ;;
-       "opensuse"|"tumbleweed")
+       *opensuse*|*tumbleweed*)
         OS_ICON=$(print_icon 'LINUX_OPENSUSE_ICON')
         ;;
-       "sabayon")
+       *sabayon*)
         OS_ICON=$(print_icon 'LINUX_SABAYON_ICON')
         ;;
-       "slackware")
+       *slackware*)
         OS_ICON=$(print_icon 'LINUX_SLACKWARE_ICON')
         ;;
-       "linuxmint")
+       *linuxmint*)
         OS_ICON=$(print_icon 'LINUX_MINT_ICON')
         ;;
-       "alpine")
+       *alpine*)
         OS_ICON=$(print_icon 'LINUX_ALPINE_ICON')
         ;;
-       "aosc")
+       *aosc*)
         OS_ICON=$(print_icon 'LINUX_AOSC_ICON')
         ;;
-       "nixos")
+       *nixos*)
         OS_ICON=$(print_icon 'LINUX_NIXOS_ICON')
         ;;
-       "devuan")
+       *devuan*)
         OS_ICON=$(print_icon 'LINUX_DEVUAN_ICON')
         ;;
-       "manjaro")
+       *manjaro*)
         OS_ICON=$(print_icon 'LINUX_MANJARO_ICON')
         ;;
         *)


### PR DESCRIPTION
The diff is pretty self explanatory. I changed the switch-case so that it will actually pick up the keywords. Tested to be successful on OpenSUSE Tumbleweed.

Hoping for this feature to be pushed to master soon :smile: 