### PR TITLE
Fix icons cut off in some terminal emulators

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -156,7 +156,9 @@ left_prompt_segment() {
   if [[ -n $6 ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
-      # Add an whitespace if we print more than just the visual identifier
+      # Add an whitespace if we print more than just the visual identifier.
+      # To avoid cutting off the visual identifier in some terminal emulators (e.g., Konsole, st),
+      # we need to color both the visual identifier and the whitespace.
       [[ -n "$5" ]] && visual_identifier="$visual_identifier "
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
@@ -240,7 +242,9 @@ right_prompt_segment() {
   if [[ -n "$6" ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
-      # Add an whitespace if we print more than just the visual identifier
+      # Add an whitespace if we print more than just the visual identifier.
+      # To avoid cutting off the visual identifier in some terminal emulators (e.g., Konsole, st),
+      # we need to color both the visual identifier and the whitespace.
       [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -156,12 +156,12 @@ left_prompt_segment() {
   if [[ -n $6 ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
+      # Add an whitespace if we print more than just the visual identifier
+      [[ -n "$5" ]] && visual_identifier="$visual_identifier "
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable $4
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-      # Add an whitespace if we print more than just the visual identifier
-      [[ -n "$5" ]] && visual_identifier="$visual_identifier "
     fi
   fi
 
@@ -240,12 +240,12 @@ right_prompt_segment() {
   if [[ -n "$6" ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
+      # Add an whitespace if we print more than just the visual identifier
+      [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable $4
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-      # Add an whitespace if we print more than just the visual identifier
-      [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
     fi
   fi
 

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -65,7 +65,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{blue} %F{green%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{green%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -86,7 +86,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{yellow} %F{green%}icon-here%f %F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{yellow} %F{green%}icon-here %f%F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -106,7 +106,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{blue} %F{black%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_FOLDER_ICON

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -28,7 +28,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}2.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}2.03 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -40,7 +40,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}0.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}0.03 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -53,7 +53,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=4
   _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}0.0001 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}0.0001 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -66,7 +66,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=0
   _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}23 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}23 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -77,7 +77,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}03:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}03:00 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -87,7 +87,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{red} %F{226%}Dur%f %F{226}02:00:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{226%}Dur %f%F{226}02:00:00 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -265,7 +265,7 @@ function testHomeFolderDetectionWorks() {
   POWERLEVEL9K_HOME_ICON='home-icon'
 
   cd ~
-  assertEquals "%K{blue} %F{black%}home-icon%f %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}home-icon %f%F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_HOME_ICON
@@ -277,7 +277,7 @@ function testHomeSubfolderDetectionWorks() {
   FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}sub-icon%f %F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}sub-icon %f%F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -291,7 +291,7 @@ function testOtherFolderDetectionWorks() {
   FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -343,7 +343,7 @@ function testOmittingFirstCharacterWorks() {
   POWERLEVEL9K_FOLDER_ICON='folder-icon'
   cd /tmp
 
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_FOLDER_ICON
@@ -357,7 +357,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -40,7 +40,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{green} %F{255%}%f %F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{green} %F{255%} %f%F{255}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_GO_ICON
   unset PWD

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -51,7 +51,7 @@ function testKubeContext() {
   alias kubectl=mockKubectl
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -60,7 +60,7 @@ function testKubeContextOtherNamespace() {
   alias kubectl=mockKubectlOtherNamespace
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl


### PR DESCRIPTION
For terminal emulators such as [suckless](https://st.suckless.org/), the most common scenario of icons being cut off is the virtual identifier before the segment content, even though there is a space between the icon and the text. The reason is that we add color only to the icon but not to the space next to it. To fix it, just add color to both the icon and its neighboring space. It allows the terminal emulator to render the icon correctly without introducing any visual side effects.

Here is a screenshot showing the cut-off before (the first line) and after (the second line) applying the patch:
![powerlevel9k-fix-icons-cut-off](https://user-images.githubusercontent.com/88049/40850943-ee3c920a-6593-11e8-8a32-460b922c1410.png)

This is superior to existing workarounds mentioned in #231 #453 #794 since we do not need to waste an extra space.