### PR TITLE
[WIP] Staging 0.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - test/segments/go_version.spec
   - test/segments/vcs.spec
   - test/segments/kubecontext.spec
+  - test/segments/laravel_version.spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next
+
+### New Segment: `laravel_version`
+
+Displays the current laravel version.
+
 ## v0.6.4
 
 - `load` segment now has configurable averages.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The segments that are currently available are:
     * `nvm` - Show the version of Node that is currently active, if it differs from the version used by NVM
 * **PHP Segments:**
     * `php_version` - Show the current PHP version.
+    * `laravel_version` - Show the current Laravel version.
     * [`symfony2_tests`](#symfony2_tests) - Show a ratio of test classes vs code classes for Symfony2.
     * `symfony2_version` - Show the current Symfony2 version, if you are in a Symfony2-Project dir.
 * **Python Segments:**

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The segments that are currently available are:
     * [`chruby`](#chruby) - Ruby environment information using `chruby` (if one is active).
     * [`rbenv`](#rbenv) - Ruby environment information using `rbenv` (if one is active).
     * [`rspec_stats`](#rspec_stats) - Show a ratio of test classes vs code classes for RSpec.
+    * `rvm` - Ruby environment information using `$GEM_HOME` and `$MY_RUBY_HOME` (if one is active).
 * **Rust Segments:**
     * `rust_version` - Display the current rust version and [logo](https://www.rust-lang.org/logos/rust-logo-blk.svg).
 * **Swift Segments:**
@@ -213,8 +214,10 @@ You can also change the battery icon automatically depending on the battery
 level. This will override the default battery icon. In order to do this, you
 need to define the `POWERLEVEL9k_BATTERY_STAGES` variable.
 
-| Variable | Default Value | Description |
-| `POWERLEVEL9K_BATTERY_STAGES`|Unset|A string or array, which each index indicates a charge level.|
+
+| Variable                      | Default Value | Description                                                   |
+|-------------------------------|---------------|---------------------------------------------------------------|
+| `POWERLEVEL9K_BATTERY_STAGES` | Unset         | A string or array, which each index indicates a charge level. |
 
 Powerlevel9k will use each index of the string or array as a stage to indicate battery
 charge level, progressing from left to right. You can provide any number of
@@ -254,10 +257,12 @@ As with the battery stages, you can use any number of colors and Powerlevel9k
 will automatically use all of them appropriately.
 
 Some example settings:
-|Brightness|Possible Array|
-|Bright Colors|(red1 orangered1 darkorange orange1 gold1 yellow1 yellow2 greenyellow chartreuse1 chartreuse2 green1)|
-|Normal Colors|(red3 darkorange3 darkgoldenrod gold3 yellow3 chartreuse2 mediumspringgreen green3 green3 green4 darkgreen)|
-|Subdued Colors|(darkred orange4 yellow4 yellow4 chartreuse3 green3 green4 darkgreen)|
+
+| Brightness     | Possible Array                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------|
+| Bright Colors  | `(red1 orangered1 darkorange orange1 gold1 yellow1 yellow2 greenyellow chartreuse1 chartreuse2 green1)`       |
+| Normal Colors  | `(red3 darkorange3 darkgoldenrod gold3 yellow3 chartreuse2 mediumspringgreen green3 green3 green4 darkgreen)` |
+| Subdued Colors | `(darkred orange4 yellow4 yellow4 chartreuse3 green3 green4 darkgreen)`                                       |
 
 ##### command_execution_time
 
@@ -537,6 +542,10 @@ It figures out the version being used by taking the output of the `rbenv version
 Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`POWERLEVEL9K_RBENV_ALWAYS`|'false'|Always show the `rbenv` segment, even if the local version matches the global.|
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the rbenv segment even if the current Ruby version is the same as the global Ruby version|
 
 ##### rspec_stats
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,17 @@ Some example settings:
 | Normal Colors  | `(red3 darkorange3 darkgoldenrod gold3 yellow3 chartreuse2 mediumspringgreen green3 green3 green4 darkgreen)` |
 | Subdued Colors | `(darkred orange4 yellow4 yellow4 chartreuse3 green3 green4 darkgreen)`                                       |
 
+##### chruby
+
+This segment shows the version of Ruby being used when using `chruby` to change your current Ruby stack.
+
+It uses `$RUBY_ENGINE` and `$RUBY_VERSION` as set by `chruby`.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_CHRUBY_SHOW_ENGINE`|true|Show the currently selected Ruby engine (e.g. `ruby`, `jruby`, `rbx`, etc)
+|`POWERLEVEL9K_CHRUBY_SHOW_VERSION`|true|Shows the currently selected engine's version (e.g. `2.5.1`)
+
 ##### command_execution_time
 
 Display the time the previous command took to execute if the time is above

--- a/README.md
+++ b/README.md
@@ -660,6 +660,8 @@ from the [Installation](#Installation) section above.
 | None         |  None               | ![icon_git](https://cloud.githubusercontent.com/assets/1544760/7976092/b5909f80-0a76-11e5-9950-1438b9d72465.gif) | Repository is a git repository
 | None         |  None               | ![icon_mercurial](https://cloud.githubusercontent.com/assets/1544760/7976090/b5908da6-0a76-11e5-8c91-452b6e73f631.gif) | Repository is a Mercurial repository
 
+##### vcs truncation
+
 You can limit the branch name to a certain length by truncating long names.
 Customizations available are:
 
@@ -679,7 +681,7 @@ For example, if you want to truncate `1234-super_super_long_branch_name` to `123
 ```zsh
 POWERLEVEL9K_VCS_SHORTEN_LENGTH=4
 POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=11
-POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
+POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
 POWERLEVEL9K_VCS_SHORTEN_DELIMITER=".."
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The segments that are currently available are:
     * `rust_version` - Display the current rust version and [logo](https://www.rust-lang.org/logos/rust-logo-blk.svg).
 * **Swift Segments:**
     * `swift_version` - Show the version number of the installed Swift.
+* **Java Segments:**
+    * `java_version` - Show the current Java version.
 
 **Cloud Segments:**
 * **AWS Segments:**

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ segment will not be displayed.
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p8k_public_ip'|This is the file your public IP is cached in.|
+|`POWERLEVEL9K_PUBLIC_IP_FILE`|'/tmp/p9k_public_ip'|This is the file your public IP is cached in.|
 |`POWERLEVEL9K_PUBLIC_IP_HOST`|'http://ident.me'|This is the default host to get your public IP.|
 |`POWERLEVEL9K_PUBLIC_IP_TIMEOUT`|300|The amount of time in seconds between refreshing your cached IP.|
 |`POWERLEVEL9K_PUBLIC_IP_METHODS`|(dig curl wget)| These methods in that order are used to refresh your IP.|

--- a/README.md
+++ b/README.md
@@ -646,6 +646,29 @@ from the [Installation](#Installation) section above.
 | None         |  None               | ![icon_git](https://cloud.githubusercontent.com/assets/1544760/7976092/b5909f80-0a76-11e5-9950-1438b9d72465.gif) | Repository is a git repository
 | None         |  None               | ![icon_mercurial](https://cloud.githubusercontent.com/assets/1544760/7976090/b5908da6-0a76-11e5-8c91-452b6e73f631.gif) | Repository is a Mercurial repository
 
+You can limit the branch name to a certain length by truncating long names.
+Customizations available are:
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_VCS_SHORTEN_LENGTH`|None|This field determines how many characters to show.|
+|`POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH`|None|This field determines minimum branch length. Branch name will be truncated if its length greater than this field.|
+|`POWERLEVEL9K_VCS_SHORTEN_STRATEGY`|None|This field determines how branch name should be truncated. See the table below for more information.|
+|`POWERLEVEL9K_SHORTEN_DELIMITER`|`...`|Delimiter to use in truncated strings. This can be any string you choose, including an empty string if you wish to have no delimiter.|
+
+| Strategy Name | Description |
+|---------------|-------------|
+|`truncate_middle`|Truncates the middle part of a branch. E.g. branch name is `1234-super_super_long_branch_name`, then it will truncated to `1234-..._name`, if `POWERLEVEL9K_VCS_SHORTEN_LENGTH=5` is also set (controls the amount of characters to be left).|
+|`truncate_from_right`|Just leaves the beginning of a branch name untouched. E.g. branch name will be truncated like so: `1234-...`. How many characters will be untouched is controlled by `POWERLEVEL9K_VCS_SHORTEN_LENGTH`.|
+
+For example, if you want to truncate `1234-super_super_long_branch_name` to `1234-..` and don't do it with `development`:
+```zsh
+POWERLEVEL9K_VCS_SHORTEN_LENGTH=4
+POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=11
+POWERLEVEL9K_SHORTEN_STRATEGY="truncate_from_right"
+POWERLEVEL9K_VCS_SHORTEN_DELIMITER=".."
+```
+
 ##### vi_mode
 
 This segment shows ZSH's current input mode. Note that this is only useful if

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -111,6 +111,7 @@ case $POWERLEVEL9K_MODE in
       DATE_ICON                      $'\uE184'              # 
       TIME_ICON                      $'\uE12E'              # 
       JAVA_ICON                      $'\U2615'              # ☕︎
+      LARAVEL_ICON                   ''
     )
   ;;
   'awesome-fontconfig')
@@ -206,6 +207,7 @@ case $POWERLEVEL9K_MODE in
       DATE_ICON                      $'\uF073 '             # 
       TIME_ICON                      $'\uF017 '             # 
       JAVA_ICON                      $'\U2615'              # ☕︎
+      LARAVEL_ICON                   ''
     )
   ;;
   'awesome-mapped-fontconfig')
@@ -306,6 +308,7 @@ case $POWERLEVEL9K_MODE in
       DATE_ICON                      $'\uF073 '                                     # 
       TIME_ICON                      $'\uF017 '                                     # 
       JAVA_ICON                      $'\U2615'              # ☕︎
+      LARAVEL_ICON                   ''
     )
   ;;
   'nerdfont-complete'|'nerdfont-fontconfig')
@@ -402,6 +405,7 @@ case $POWERLEVEL9K_MODE in
       DATE_ICON                      $'\uF073 '             # 
       TIME_ICON                      $'\uF017 '             # 
       JAVA_ICON                      $'\U2615'              # ☕︎
+      LARAVEL_ICON                   $'\ue73f '             # 
     )
   ;;
   *)
@@ -497,6 +501,7 @@ case $POWERLEVEL9K_MODE in
       DATE_ICON                      ''
       TIME_ICON                      ''
       JAVA_ICON                      $'\U2615'              # ☕︎
+      LARAVEL_ICON                   ''
     )
   ;;
 esac

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -96,7 +96,7 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            $'\uE20E '             #
       VCS_HG_ICON                    $'\uE1C3 '             # 
       VCS_SVN_ICON                   '(svn) '
-      RUST_ICON                      ''
+      RUST_ICON                      '(rust)'
       PYTHON_ICON                    $'\ue63c'             # 
       SWIFT_ICON                     ''
       GO_ICON                        ''
@@ -478,7 +478,7 @@ case $POWERLEVEL9K_MODE in
       VCS_GIT_GITLAB_ICON            ''
       VCS_HG_ICON                    ''
       VCS_SVN_ICON                   ''
-      RUST_ICON                      ''
+      RUST_ICON                      'Rust'
       PYTHON_ICON                    ''
       SWIFT_ICON                     'Swift'
       GO_ICON                        'Go'

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -71,6 +71,7 @@ case $POWERLEVEL9K_MODE in
       HOME_SUB_ICON                  $'\uE18D'              # 
       FOLDER_ICON                    $'\uE818'              # 
       NETWORK_ICON                   $'\uE1AD'              # 
+      ETC_ICON                       $'\uE818'              # 
       LOAD_ICON                      $'\uE190 '             # 
       SWAP_ICON                      $'\uE87D'              # 
       RAM_ICON                       $'\uE1E2 '             # 
@@ -168,6 +169,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      $'\uF015'              # 
       HOME_SUB_ICON                  $'\uF07C'              # 
       FOLDER_ICON                    $'\uF115'              # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   $'\uF09E'              # 
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF0E4'              # 
@@ -268,6 +270,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      '\u'$CODEPOINT_OF_AWESOME_HOME                 # 
       HOME_SUB_ICON                  '\u'$CODEPOINT_OF_AWESOME_FOLDER_OPEN          # 
       FOLDER_ICON                    '\u'$CODEPOINT_OF_AWESOME_FOLDER_O             # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   '\u'$CODEPOINT_OF_AWESOME_RSS                  # 
       LOAD_ICON                      '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '         # 
       SWAP_ICON                      '\u'$CODEPOINT_OF_AWESOME_DASHBOARD            # 
@@ -362,6 +365,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      $'\uF015'              # 
       HOME_SUB_ICON                  $'\uF07C'              # 
       FOLDER_ICON                    $'\uF115'              # 
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   $'\uF1EB'              # 
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF464'              # 
@@ -456,6 +460,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      ''
       HOME_SUB_ICON                  ''
       FOLDER_ICON                    ''
+      ETC_ICON                       $'\uF013'              # 
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
       SWAP_ICON                      'SWP'

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -109,6 +109,7 @@ case $POWERLEVEL9K_MODE in
       DROPBOX_ICON                   $'\UF16B'              # 
       DATE_ICON                      $'\uE184'              # 
       TIME_ICON                      $'\uE12E'              # 
+      JAVA_ICON                      $'\U2615'              # ☕︎
     )
   ;;
   'awesome-fontconfig')
@@ -202,6 +203,7 @@ case $POWERLEVEL9K_MODE in
       DROPBOX_ICON                   $'\UF16B'              # 
       DATE_ICON                      $'\uF073 '             # 
       TIME_ICON                      $'\uF017 '             # 
+      JAVA_ICON                      $'\U2615'              # ☕︎
     )
   ;;
   'awesome-mapped-fontconfig')
@@ -300,6 +302,7 @@ case $POWERLEVEL9K_MODE in
       DROPBOX_ICON                   '\u'$CODEPOINT_OF_AWESOME_DROPBOX              # 
       DATE_ICON                      $'\uF073 '                                     # 
       TIME_ICON                      $'\uF017 '                                     # 
+      JAVA_ICON                      $'\U2615'              # ☕︎
     )
   ;;
   'nerdfont-complete'|'nerdfont-fontconfig')
@@ -394,6 +397,7 @@ case $POWERLEVEL9K_MODE in
       DROPBOX_ICON                   $'\UF16B'              # 
       DATE_ICON                      $'\uF073 '             # 
       TIME_ICON                      $'\uF017 '             # 
+      JAVA_ICON                      $'\U2615'              # ☕︎
     )
   ;;
   *)
@@ -487,6 +491,7 @@ case $POWERLEVEL9K_MODE in
       DROPBOX_ICON                   'Dropbox'
       DATE_ICON                      ''
       TIME_ICON                      ''
+      JAVA_ICON                      $'\U2615'              # ☕︎
     )
   ;;
 esac

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -71,7 +71,7 @@ case $POWERLEVEL9K_MODE in
       HOME_SUB_ICON                  $'\uE18D'              # 
       FOLDER_ICON                    $'\uE818'              # 
       NETWORK_ICON                   $'\uE1AD'              # 
-      ETC_ICON                       $'\uE818'              # 
+      ETC_ICON                       $'\uE82F'              # 
       LOAD_ICON                      $'\uE190 '             # 
       SWAP_ICON                      $'\uE87D'              # 
       RAM_ICON                       $'\uE1E2 '             # 
@@ -170,7 +170,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      $'\uF015'              # 
       HOME_SUB_ICON                  $'\uF07C'              # 
       FOLDER_ICON                    $'\uF115'              # 
-      ETC_ICON                       $'\uF013'              # 
+      ETC_ICON                       $'\uF013 '             # 
       NETWORK_ICON                   $'\uF09E'              # 
       LOAD_ICON                      $'\uF080 '             # 
       SWAP_ICON                      $'\uF0E4'              # 
@@ -272,7 +272,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      '\u'$CODEPOINT_OF_AWESOME_HOME                 # 
       HOME_SUB_ICON                  '\u'$CODEPOINT_OF_AWESOME_FOLDER_OPEN          # 
       FOLDER_ICON                    '\u'$CODEPOINT_OF_AWESOME_FOLDER_O             # 
-      ETC_ICON                       $'\uF013'              # 
+      ETC_ICON                       '\u'$CODEPOINT_OF_AWESOME_COG' '               # 
       NETWORK_ICON                   '\u'$CODEPOINT_OF_AWESOME_RSS                  # 
       LOAD_ICON                      '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '         # 
       SWAP_ICON                      '\u'$CODEPOINT_OF_AWESOME_DASHBOARD            # 
@@ -464,7 +464,7 @@ case $POWERLEVEL9K_MODE in
       HOME_ICON                      ''
       HOME_SUB_ICON                  ''
       FOLDER_ICON                    ''
-      ETC_ICON                       $'\uF013'              # 
+      ETC_ICON                       $'\u2699'              # ⚙
       NETWORK_ICON                   'IP'
       LOAD_ICON                      'L'
       SWAP_ICON                      'SWP'

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -106,58 +106,58 @@ case $(uname) in
       OS='Linux'
       os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
       case "$os_release_id" in
-        "arch")
+        *arch*)
         OS_ICON=$(print_icon 'LINUX_ARCH_ICON')
         ;;
-        "debian")
+        *debian*)
         OS_ICON=$(print_icon 'LINUX_DEBIAN_ICON')
         ;;
-       "ubuntu")
+       *ubuntu*)
         OS_ICON=$(print_icon 'LINUX_UBUNTU_ICON')
         ;;
-       "elementary")
+       *elementary*)
         OS_ICON=$(print_icon 'LINUX_ELEMENTARY_ICON')
         ;;
-       "fedora")
+       *fedora*)
         OS_ICON=$(print_icon 'LINUX_FEDORA_ICON')
         ;;
-       "coreos")
+       *coreos*)
         OS_ICON=$(print_icon 'LINUX_COREOS_ICON')
         ;;
-       "gentoo")
+       *gentoo*)
         OS_ICON=$(print_icon 'LINUX_GENTOO_ICON')
         ;;
-       "mageia")
+       *mageia*)
         OS_ICON=$(print_icon 'LINUX_MAGEIA_ICON')
         ;;
-       "centos")
+       *centos*)
         OS_ICON=$(print_icon 'LINUX_CENTOS_ICON')
         ;;
-       "opensuse"|"tumbleweed")
+       *opensuse*|*tumbleweed*)
         OS_ICON=$(print_icon 'LINUX_OPENSUSE_ICON')
         ;;
-       "sabayon")
+       *sabayon*)
         OS_ICON=$(print_icon 'LINUX_SABAYON_ICON')
         ;;
-       "slackware")
+       *slackware*)
         OS_ICON=$(print_icon 'LINUX_SLACKWARE_ICON')
         ;;
-       "linuxmint")
+       *linuxmint*)
         OS_ICON=$(print_icon 'LINUX_MINT_ICON')
         ;;
-       "alpine")
+       *alpine*)
         OS_ICON=$(print_icon 'LINUX_ALPINE_ICON')
         ;;
-       "aosc")
+       *aosc*)
         OS_ICON=$(print_icon 'LINUX_AOSC_ICON')
         ;;
-       "nixos")
+       *nixos*)
         OS_ICON=$(print_icon 'LINUX_NIXOS_ICON')
         ;;
-       "devuan")
+       *devuan*)
         OS_ICON=$(print_icon 'LINUX_DEVUAN_ICON')
         ;;
-       "manjaro")
+       *manjaro*)
         OS_ICON=$(print_icon 'LINUX_MANJARO_ICON')
         ;;
         *)

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -51,6 +51,21 @@ function +vi-git-remotebranch() {
     remote=${$(command git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
     branch_name=$(command git symbolic-ref --short HEAD 2>/dev/null)
 
+    if [[ -n "$POWERLEVEL9K_VCS_SHORTEN_LENGTH" ]] && [[ -n "$POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH" ]]; then
+     set_default POWERLEVEL9K_VCS_SHORTEN_DELIMITER $'\U2026'
+
+     if [ ${#hook_com[branch]} -gt $POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH ] && [ ${#hook_com[branch]} -gt $POWERLEVEL9K_VCS_SHORTEN_LENGTH ]; then
+       case "$POWERLEVEL9K_VCS_SHORTEN_STRATEGY" in
+         truncate_middle)
+           hook_com[branch]="$(echo "${branch_name:0:$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")$POWERLEVEL9K_VCS_SHORTEN_DELIMITER$(echo "${branch_name: -$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")"
+         ;;
+         truncate_from_right)
+           hook_com[branch]="$(echo "${branch_name:0:$POWERLEVEL9K_VCS_SHORTEN_LENGTH}")$POWERLEVEL9K_VCS_SHORTEN_DELIMITER"
+         ;;
+       esac
+     fi
+    fi
+
     hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${hook_com[branch]}"
     # Always show the remote
     #if [[ -n ${remote} ]] ; then

--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -16,8 +16,8 @@ function +vi-git-untracked() {
       FLAGS+='--ignore-submodules=dirty'
     fi
 
-    if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
-            -n $(git status ${FLAGS} | \grep -E '^\?\?' 2> /dev/null | tail -n1) ]]; then
+    if [[ $(command git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' && \
+            -n $(command git status ${FLAGS} | \grep -E '^\?\?' 2> /dev/null | tail -n1) ]]; then
         hook_com[unstaged]+=" $(print_icon 'VCS_UNTRACKED_ICON')"
         VCS_WORKDIR_HALF_DIRTY=true
     else
@@ -29,16 +29,16 @@ function +vi-git-aheadbehind() {
     local ahead behind branch_name
     local -a gitstatus
 
-    branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
+    branch_name=$(command git symbolic-ref --short HEAD 2>/dev/null)
 
     # for git prior to 1.7
-    # ahead=$(git rev-list origin/${branch_name}..HEAD | wc -l)
-    ahead=$(git rev-list "${branch_name}"@{upstream}..HEAD 2>/dev/null | wc -l)
+    # ahead=$(command git rev-list origin/${branch_name}..HEAD | wc -l)
+    ahead=$(command git rev-list "${branch_name}"@{upstream}..HEAD 2>/dev/null | wc -l)
     (( ahead )) && gitstatus+=( " $(print_icon 'VCS_OUTGOING_CHANGES_ICON')${ahead// /}" )
 
     # for git prior to 1.7
-    # behind=$(git rev-list HEAD..origin/${branch_name} | wc -l)
-    behind=$(git rev-list HEAD.."${branch_name}"@{upstream} 2>/dev/null | wc -l)
+    # behind=$(command git rev-list HEAD..origin/${branch_name} | wc -l)
+    behind=$(command git rev-list HEAD.."${branch_name}"@{upstream} 2>/dev/null | wc -l)
     (( behind )) && gitstatus+=( " $(print_icon 'VCS_INCOMING_CHANGES_ICON')${behind// /}" )
 
     hook_com[misc]+=${(j::)gitstatus}
@@ -48,8 +48,8 @@ function +vi-git-remotebranch() {
     local remote branch_name
 
     # Are we on a remote-tracking branch?
-    remote=${$(git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
-    branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
+    remote=${$(command git rev-parse --verify HEAD@{upstream} --symbolic-full-name 2>/dev/null)/refs\/(remotes|heads)\/}
+    branch_name=$(command git symbolic-ref --short HEAD 2>/dev/null)
 
     hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${hook_com[branch]}"
     # Always show the remote
@@ -65,18 +65,18 @@ function +vi-git-tagname() {
     if [[ "$POWERLEVEL9K_VCS_HIDE_TAGS" == "false" ]]; then
         # If we are on a tag, append the tagname to the current branch string.
         local tag
-        tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
+        tag=$(command git describe --tags --exact-match HEAD 2>/dev/null)
 
         if [[ -n "${tag}" ]] ; then
             # There is a tag that points to our current commit. Need to determine if we
             # are also on a branch, or are in a DETACHED_HEAD state.
-            if [[ -z $(git symbolic-ref HEAD 2>/dev/null) ]]; then
+            if [[ -z $(command git symbolic-ref HEAD 2>/dev/null) ]]; then
                 # DETACHED_HEAD state. We want to append the tag name to the commit hash
                 # and print it. Unfortunately, `vcs_info` blows away the hash when a tag
                 # exists, so we have to manually retrieve it and clobber the branch
                 # string.
                 local revision
-                revision=$(git rev-list -n 1 --abbrev-commit --abbrev=${POWERLEVEL9K_VCS_INTERNAL_HASH_LENGTH} HEAD)
+                revision=$(command git rev-list -n 1 --abbrev-commit --abbrev=${POWERLEVEL9K_VCS_INTERNAL_HASH_LENGTH} HEAD)
                 hook_com[branch]="$(print_icon 'VCS_BRANCH_ICON')${revision} $(print_icon 'VCS_TAG_ICON')${tag}"
             else
                 # We are on both a tag and a branch; print both by appending the tag name.
@@ -91,8 +91,8 @@ function +vi-git-tagname() {
 function +vi-git-stash() {
   local -a stashes
 
-  if [[ -s $(git rev-parse --git-dir)/refs/stash ]] ; then
-    stashes=$(git stash list 2>/dev/null | wc -l)
+  if [[ -s $(command git rev-parse --git-dir)/refs/stash ]] ; then
+    stashes=$(command git stash list 2>/dev/null | wc -l)
     hook_com[misc]+=" $(print_icon 'VCS_STASH_ICON')${stashes// /}"
   fi
 }
@@ -111,7 +111,7 @@ function +vi-hg-bookmarks() {
 function +vi-vcs-detect-changes() {
   if [[ "${hook_com[vcs]}" == "git" ]]; then
 
-    local remote=$(git ls-remote --get-url 2> /dev/null)
+    local remote=$(command git ls-remote --get-url 2> /dev/null)
     if [[ "$remote" =~ "github" ]] then
       vcs_visual_identifier='VCS_GIT_GITHUB_ICON'
     elif [[ "$remote" =~ "bitbucket" ]] then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -224,6 +224,12 @@ right_prompt_segment() {
   [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="$(foregroundColor)"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
+
+  if [[ "$CURRENT_RIGHT_BG" != "NONE" ]]; then
+    # This is the closing whitespace for the previous segment
+    echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}%f"
+  fi
+
   if [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]]; then
     if isSameColor "$CURRENT_RIGHT_BG" "$3"; then
       # Middle segment with same color as previous segment
@@ -262,7 +268,7 @@ right_prompt_segment() {
   # Print segment content if there is any
   [[ -n "$5" ]] && echo -n "${5}"
   # Print the visual identifier
-  echo -n "${visual_identifier}${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}%f"
+  echo -n "${visual_identifier}"
 
   CURRENT_RIGHT_BG=$3
   last_right_element_index=$current_index
@@ -1757,6 +1763,9 @@ build_right_prompt() {
 
     index=$((index + 1))
   done
+
+  # Clear to the end of the line
+  echo -n "%E"
 }
 
 powerlevel9k_preexec() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1252,11 +1252,24 @@ prompt_rbenv() {
 # Segment to display chruby information
 # see https://github.com/postmodern/chruby/issues/245 for chruby_auto issue with ZSH
 prompt_chruby() {
-  local chruby_env
-  chrb_env="$(chruby 2> /dev/null | grep \* | tr -d '* ')"
+  # Uses $RUBY_VERSION and $RUBY_ENGINE set by chruby
+  set_default POWERLEVEL9K_CHRUBY_SHOW_VERSION true
+  set_default POWERLEVEL9K_CHRUBY_SHOW_ENGINE true
+  local chruby_label=""
+
+  if [[ "$POWERLEVEL9K_CHRUBY_SHOW_ENGINE" == true ]]; then
+    chruby_label+="$RUBY_ENGINE "
+  fi
+  if [[ "$POWERLEVEL9K_CHRUBY_SHOW_VERSION" == true ]]; then
+    chruby_label+="$RUBY_VERSION"
+  fi
+
+  # Truncate trailing spaces
+  chruby_label="${chruby_label%"${chruby_label##*[![:space:]]}"}"
+
   # Don't show anything if the chruby did not change the default ruby
-  if [[ "${chrb_env:-system}" != "system" ]]; then
-    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "${chrb_env}" 'RUBY_ICON'
+  if [[ "$RUBY_ENGINE" != "" ]]; then
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "${chruby_label}" 'RUBY_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1307,7 +1307,8 @@ prompt_root_indicator() {
 ################################################################
 # Segment to display Rust version number
 prompt_rust_version() {
-  local rust_version=$(command rustc --version 2>/dev/null)
+  local rust_version
+  rust_version=$(command rustc --version 2>/dev/null)
   # Remove "rustc " (including the whitespace) from the beginning
   # of the version string and remove everything after the next
   # whitespace. This way we'll end up with only the version.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -915,10 +915,13 @@ prompt_dir() {
     "HOME"            "HOME_ICON"
     "HOME_SUBFOLDER"  "HOME_SUB_ICON"
     "NOT_WRITABLE"    "LOCK_ICON"
+    "ETC"             "ETC_ICON"
   )
   local state_path="$(print -P '%~')"
   local current_state="DEFAULT"
-  if [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == true && ! -w "$PWD" ]]; then
+  if [[ $state_path == '/etc'* ]]; then
+    current_state='ETC'
+  elif [[ "${POWERLEVEL9K_DIR_SHOW_WRITABLE}" == true && ! -w "$PWD" ]]; then
     current_state="NOT_WRITABLE"
   elif [[ $state_path == '~' ]]; then
     current_state="HOME"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1662,7 +1662,16 @@ prompt_dropbox() {
 
     "$1_prompt_segment" "$0" "$2" "white" "blue" "$dropbox_status" "DROPBOX_ICON"
   fi
+}
 
+# print Java version number
+prompt_java_version() {
+  local java_version
+  java_version=$(java -fullversion 2>&1 | cut -d '"' -f 2)
+
+  if [[ -n "$java_version" ]]; then
+    "$1_prompt_segment" "$0" "$2" "red" "white" "$java_version" "JAVA_ICON"
+  fi
 }
 
 ################################################################

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -156,12 +156,14 @@ left_prompt_segment() {
   if [[ -n $6 ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
+      # Add an whitespace if we print more than just the visual identifier.
+      # To avoid cutting off the visual identifier in some terminal emulators (e.g., Konsole, st),
+      # we need to color both the visual identifier and the whitespace.
+      [[ -n "$5" ]] && visual_identifier="$visual_identifier "
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable $4
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-      # Add an whitespace if we print more than just the visual identifier
-      [[ -n "$5" ]] && visual_identifier="$visual_identifier "
     fi
   fi
 
@@ -241,12 +243,14 @@ right_prompt_segment() {
   if [[ -n "$6" ]]; then
     visual_identifier="$(print_icon $6)"
     if [[ -n "$visual_identifier" ]]; then
+      # Add an whitespace if we print more than just the visual identifier.
+      # To avoid cutting off the visual identifier in some terminal emulators (e.g., Konsole, st),
+      # we need to color both the visual identifier and the whitespace.
+      [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable $4
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
-      # Add an whitespace if we print more than just the visual identifier
-      [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
     fi
   fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -487,16 +487,20 @@ prompt_battery() {
       [[ "${(t)POWERLEVEL9K_BATTERY_STAGES}" =~ "array" ]] && POWERLEVEL9K_BATTERY_ICON="$POWERLEVEL9K_BATTERY_STAGES[$offset]" || POWERLEVEL9K_BATTERY_ICON=${POWERLEVEL9K_BATTERY_STAGES:$offset:1}
     fi
   fi
-
-  # override the default color if we are using a color level array
-  if [[ -n "$POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND" ]] && [[ "${(t)POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND}" =~ "array" ]]; then
-    local segment=$(( 100.0 / (${#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND} - 1 ) ))
-    local offset=$(( ($bat_percent / $segment) + 1 ))
-    "$1_prompt_segment" "$0_${current_state}" "$2" "${POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND[$offset]}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
-  else
-    # Draw the prompt_segment
-    "$1_prompt_segment" "$0_${current_state}" "$2" "${DEFAULT_COLOR}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
+  # return if POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD is set and the battery percentage is greater or equal
+  if [[ -v "POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD" && "${bat_percent}" -ge $POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD ]]; then
+    return
   fi
+
+    # override the default color if we are using a color level array
+    if [[ -n "$POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND" ]] && [[ "${(t)POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND}" =~ "array" ]]; then
+      local segment=$(( 100.0 / (${#POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND} - 1 ) ))
+      local offset=$(( ($bat_percent / $segment) + 1 ))
+      "$1_prompt_segment" "$0_${current_state}" "$2" "${POWERLEVEL9K_BATTERY_LEVEL_BACKGROUND[$offset]}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
+    else
+      # Draw the prompt_segment
+      "$1_prompt_segment" "$0_${current_state}" "$2" "${DEFAULT_COLOR}" "${battery_states[$current_state]}" "${message}" "BATTERY_ICON"
+    fi
 }
 
 ################################################################
@@ -637,14 +641,14 @@ prompt_user() {
         "FOREGROUND_COLOR"    "yellow"
         "VISUAL_IDENTIFIER"   "ROOT_ICON"
       )
-    elif sudo -n true 2>/dev/null; then 
-      user_state=( 
-        "STATE"               "SUDO" 
-        "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}" 
-        "BACKGROUND_COLOR"    "${DEFAULT_COLOR}" 
-        "FOREGROUND_COLOR"    "yellow" 
-        "VISUAL_IDENTIFIER"   "SUDO_ICON" 
-      ) 
+    elif sudo -n true 2>/dev/null; then
+      user_state=(
+        "STATE"               "SUDO"
+        "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}"
+        "BACKGROUND_COLOR"    "${DEFAULT_COLOR}"
+        "FOREGROUND_COLOR"    "yellow"
+        "VISUAL_IDENTIFIER"   "SUDO_ICON"
+      )
     else
       user_state=(
         "STATE"               "DEFAULT"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1273,9 +1273,9 @@ prompt_root_indicator() {
 prompt_rust_version() {
   local rust_version
   rust_version=$(rustc --version 2>&1 | grep -oe "^rustc\s*[^ ]*" | grep -o '[0-9.a-z\\\-]*$')
-
+  
   if [[ -n "$rust_version" ]]; then
-    "$1_prompt_segment" "$0" "$2" "darkorange" "$DEFAULT_COLOR" "Rust $rust_version" 'RUST_ICON'
+    "$1_prompt_segment" "$0" "$2" "darkorange" "$DEFAULT_COLOR" "$rust_version" 'RUST_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1110,6 +1110,18 @@ prompt_vpn_ip() {
 }
 
 ################################################################
+# Segment to display laravel version
+prompt_laravel_version() {
+  local laravel_version="$(php artisan --version 2>/dev/null)"
+  if [[ -n "${laravel_version}" ]]; then
+    # Remove unrelevant infos
+    laravel_version="${laravel_version//Laravel Framework version /}"
+
+    "$1_prompt_segment" "$0" "$2" "maroon" "white" "${laravel_version}" 'LARAVEL_ICON'
+  fi
+}
+
+################################################################
 # Segment to display load
 set_default POWERLEVEL9K_LOAD_WHICH 5
 prompt_load() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1779,7 +1779,7 @@ $(print_icon 'MULTILINE_LAST_PROMPT_PREFIX')'
   fi
 
   if [[ "$POWERLEVEL9K_DISABLE_RPROMPT" != true ]]; then
-    RPROMPT='$RPROMPT_PREFIX%f%b%k$(build_right_prompt)%{$reset_color%}$RPROMPT_SUFFIX'
+    RPROMPT="${RPROMPT_PREFIX}"'%f%b%k$(build_right_prompt)%{$reset_color%}'"${RPROMPT_SUFFIX}"
   fi
 
 local NEWLINE='

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1262,12 +1262,13 @@ prompt_rbenv() {
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
 
-
     # Don't show anything if the current Ruby is the same as the global Ruby
     # unless `POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW` is set.
     if [[ $rbenv_version_name == $rbenv_global && "$POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW" = false ]]; then
       return
     fi
+
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1271,16 +1271,18 @@ prompt_root_indicator() {
 ################################################################
 # Segment to display Rust version number
 prompt_rust_version() {
-  local rust_version
-  rust_version=$(rustc --version 2>&1 | grep -oe "^rustc\s*[^ ]*" | grep -o '[0-9.a-z\\\-]*$')
-  
+  local rust_version=$(command rustc --version 2>/dev/null)
+  # Remove "rustc " (including the whitespace) from the beginning
+  # of the version string and remove everything after the next
+  # whitespace. This way we'll end up with only the version.
+  rust_version=${${rust_version/rustc /}%% *}
+
   if [[ -n "$rust_version" ]]; then
     "$1_prompt_segment" "$0" "$2" "darkorange" "$DEFAULT_COLOR" "$rust_version" 'RUST_ICON'
   fi
 }
 
-################################################################
-# Segment to display RSpec test ratio
+# RSpec test ratio
 prompt_rspec_stats() {
   if [[ (-d app && -d spec) ]]; then
     local code_amount tests_amount

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1713,7 +1713,12 @@ prompt_dropbox() {
 # print Java version number
 prompt_java_version() {
   local java_version
-  java_version=$(java -fullversion 2>/dev/null | cut -d '"' -f 2)
+  # Stupid: Java prints its version on STDERR.
+  # The first version ouput will print nothing, we just
+  # use it to transport whether the command was successful.
+  # If yes, we parse the version string (and need to
+  # redirect the stderr to stdout to make the pipe work).
+  java_version=$(java -version 2>/dev/null && java -fullversion 2>&1 | cut -d '"' -f 2)
 
   if [[ -n "$java_version" ]]; then
     "$1_prompt_segment" "$0" "$2" "red" "white" "$java_version" "JAVA_ICON"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1707,7 +1707,7 @@ prompt_dropbox() {
 # print Java version number
 prompt_java_version() {
   local java_version
-  java_version=$(java -fullversion 2>&1 | cut -d '"' -f 2)
+  java_version=$(java -fullversion 2>/dev/null | cut -d '"' -f 2)
 
   if [[ -n "$java_version" ]]; then
     "$1_prompt_segment" "$0" "$2" "red" "white" "$java_version" "JAVA_ICON"

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -65,7 +65,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{blue} %F{green%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{green%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -86,7 +86,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{yellow} %F{green%}icon-here%f %F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{yellow} %F{green%}icon-here %f%F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -106,7 +106,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{blue} %F{black%}icon-here%f %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_FOLDER_ICON

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -114,4 +114,23 @@ function testOverwritingIconsWork() {
   # rm -fr ~/$testFolder
 }
 
+function testNewlineOnRpromptCanBeDisabled() {
+  POWERLEVEL9K_PROMPT_ON_NEWLINE=true
+  POWERLEVEL9K_RPROMPT_ON_NEWLINE=false
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_CUSTOM_RWORLD='echo rworld'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
+
+  powerlevel9k_prepare_prompts
+  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[47m [30mworld [49m[37m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[37m[39m[47m[30m rworld [39m[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
+
+  unset POWERLEVEL9K_PROMPT_ON_NEWLINE
+  unset POWERLEVEL9K_RPROMPT_ON_NEWLINE
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unset POWERLEVEL9K_CUSTOM_RWORLD
+}
+
 source shunit2/source/2.1/src/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -123,7 +123,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 
   powerlevel9k_prepare_prompts
-  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[47m [30mworld [49m[37m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[37m[39m[47m[30m rworld [39m[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
+  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[47m [30mworld [49m[37m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[37m[39m[47m[30m rworld[K[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
 
   unset POWERLEVEL9K_PROMPT_ON_NEWLINE
   unset POWERLEVEL9K_RPROMPT_ON_NEWLINE

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -28,7 +28,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}2.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}2.03 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -40,7 +40,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}0.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}0.03 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -53,7 +53,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=4
   _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}0.0001 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}0.0001 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -66,7 +66,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=0
   _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}23 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}23 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -77,7 +77,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}03:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}03:00 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -87,7 +87,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{red} %F{yellow1%}Dur%f %F{yellow1}02:00:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}02:00:00 %k%F{red}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -329,7 +329,7 @@ function testHomeFolderDetectionWorks() {
   POWERLEVEL9K_HOME_ICON='home-icon'
 
   cd ~
-  assertEquals "%K{blue} %F{black%}home-icon%f %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}home-icon %f%F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_HOME_ICON
@@ -341,7 +341,7 @@ function testHomeSubfolderDetectionWorks() {
   FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}sub-icon%f %F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}sub-icon %f%F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -355,7 +355,7 @@ function testOtherFolderDetectionWorks() {
   FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -407,7 +407,7 @@ function testOmittingFirstCharacterWorks() {
   POWERLEVEL9K_FOLDER_ICON='folder-icon'
   cd /tmp
 
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_FOLDER_ICON
@@ -421,7 +421,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black%}folder-icon%f %F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -46,6 +46,27 @@ function testTruncateFoldersWorks() {
   unset POWERLEVEL9K_SHORTEN_STRATEGY
 }
 
+function testTruncateFolderWithHomeDirWorks() {
+  POWERLEVEL9K_SHORTEN_DIR_LENGTH=1
+  CURRENT_DIR=$(pwd)
+
+  cd ~
+  FOLDER="powerlevel9k-test-${RANDOM}"
+  mkdir -p $FOLDER
+  cd $FOLDER
+  # Switch back to home folder as this causes the problem.
+  cd ..
+
+  assertEquals "%K{blue} %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+
+  rmdir $FOLDER
+  cd ${CURRENT_DIR}
+
+  unset CURRENT_DIR
+  unset FOLDER
+  unset POWERLEVEL9K_SHORTEN_DIR_LENGTH
+}
+
 function testTruncateMiddleWorks() {
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_middle'

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -40,7 +40,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{green} %F{grey93%}%f %F{grey93}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{green} %F{grey93%} %f%F{grey93}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_GO_ICON
   unset PWD

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -69,7 +69,7 @@ function testKubeContext() {
   alias kubectl=mockKubectl
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -78,7 +78,7 @@ function testKubeContextOtherNamespace() {
   alias kubectl=mockKubectlOtherNamespace
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈%f %F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function mockLaravelVersion() {
+  case "$1" in
+    "artisan")
+      echo "Laravel Framework version 5.4.23"
+      ;;
+    default)
+  esac
+}
+
+function mockNoLaravelVersion() {
+  # This should output some error
+  >&2 echo "Artisan not available"
+  return 1
+}
+
+function testLaravelVersionSegment() {
+  alias php=mockLaravelVersion
+  POWERLEVEL9K_LARAVEL_ICON='x'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
+
+  assertEquals "%K{001} %F{white%}x%f %F{white}5.4.23 %k%F{maroon}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_LARAVEL_ICON
+  unalias php
+}
+
+function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
+  alias php=mockNoLaravelVersion
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LARAVEL_ICON='x'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_LARAVEL_ICON
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias php
+}
+
+function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
+  alias php=noPhp
+  POWERLEVEL9K_CUSTOM_WORLD='echo world'
+  POWERLEVEL9K_LARAVEL_ICON='x'
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+
+  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_LARAVEL_ICON
+  unset POWERLEVEL9K_CUSTOM_WORLD
+  unalias php
+}
+
+source shunit2/source/2.1/src/shunit2

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -31,7 +31,7 @@ function testLaravelVersionSegment() {
   POWERLEVEL9K_LARAVEL_ICON='x'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
 
-  assertEquals "%K{001} %F{white%}x%f %F{white}5.4.23 %k%F{maroon}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{white%}x %f%F{white}5.4.23 %k%F{maroon}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_LARAVEL_ICON

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -19,7 +19,8 @@ function testRust() {
   alias rustc=mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{black}Rust 0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{black%}Rust%f %F{black}0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
+
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias rustc

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -32,7 +32,7 @@ function testRust() {
   mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{black%}Rust%f %F{black}0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{black%}Rust %f%F{black}0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
 }

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -5,29 +5,39 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
+TEST_BASE_FOLDER=/tmp/powerlevel9k-test
+RUST_TEST_FOLDER="${TEST_BASE_FOLDER}/rust-test"
+
 function setUp() {
+  OLDPATH="${PATH}"
+  mkdir -p "${RUST_TEST_FOLDER}"
+  PATH="${RUST_TEST_FOLDER}:${PATH}"
+
   export TERM="xterm-256color"
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }
 
+function tearDown() {
+  PATH="${OLDPATH}"
+  rm -fr "${TEST_BASE_FOLDER}"
+}
+
 function mockRust() {
-  echo 'rustc  0.4.1a-alpha'
+  echo "#!/bin/sh\n\necho 'rustc 0.4.1a-alpha'" > "${RUST_TEST_FOLDER}/rustc"
+  chmod +x "${RUST_TEST_FOLDER}/rustc"
 }
 
 function testRust() {
-  alias rustc=mockRust
+  mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
   assertEquals "%K{208} %F{black%}Rust%f %F{black}0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
 
-
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unalias rustc
 }
 
 function testRustPrintsNothingIfRustIsNotAvailable() {
-  alias rustc=noRust
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
 
@@ -35,7 +45,6 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
-  unalias rustc
 }
 
 source shunit2/source/2.1/src/shunit2

--- a/test/segments/vcs.spec
+++ b/test/segments/vcs.spec
@@ -78,4 +78,84 @@ function testColorOverridingForUntrackedStateWorks() {
   unset POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND
 }
 
+function testBranchNameTruncatingShortenLength() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=6
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
+function testBranchNameTruncatingMinLength() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=6
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=7
+
+  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
+function testBranchNameTruncatingShortenStrategy() {
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=3
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git init 1>/dev/null
+  touch testfile
+
+  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+
+  POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_middle"
+
+  assertEquals "%K{green} %F{black} mas…ter ? %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_SHORTEN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH
+  unset POWERLEVEL9K_VCS_SHORTEN_STRATEGY
+}
+
 source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
This is a staging branch to be merged in `next`. 

It includes the following changes (in order of merge):
- `master`. For easier merging later on, `master` was merged in first. There were two conflicts, one being a conflict in the `README.md` (#781 vs #684) and another one in the `powerlevel9k.zsh-theme` (#795 vs #610). The latter one being the more impacting one, as I had to drop one completely (both implemented the same thing). I went with #795, even this one is more recent. The reason for that is that this commit is the one on `master`, and I don't want to deprecate a variable just for naming reasons (or the naming must improve vastly, which didn't here).
- #797. Conflicts: `functions/vcs.zsh`: Two commits avoided wrapper behaviour. #685
    in grep, #797 in git.
- #798
- #783 Conflicts: `functions/icons.zsh` and `powerlevel9k.zsh-theme`: On `master` the Java Segment was added, on `next` the Dropbox Segment.
- #641 Conflicts: `test/segments/rust_version.spec` and `powerlevel9k.zsh-theme`: On `master` the "Rust" was refactored as Visual Identifier; On `next` the color names changed.
- #826 Conflicts: `test/segments/rust_version.spec` and `powerlevel9k.zsh-theme`: On `master` the Rust version is now parsed differently; On `next` the color names changed.
- #816 
- #830 
- #838 
- #847 
- #844 
- #854 Conflicts: `test/segments/command_execution_time.spec` and `test/segments/go_version.spec`: All conflicts come from renaming color names on `next` (#703) and adding a whitespace to the Visual Identifier (#854) on `master`.
- #818 Conflicts: `functions/icons.zsh`: Java Segment (#783) was added on `master` with icons.
- #871 

Not yet merged (This is on purpose and will be done in #863 ):
- #771