### PR TITLE
Hide one-space indent at right margin

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -222,6 +222,12 @@ right_prompt_segment() {
   [[ -n "$4" ]] && fg="%F{$4}" || fg="%f"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
+
+  if [[ "$CURRENT_RIGHT_BG" != "NONE" ]]; then
+    # This is the closing whitespace for the previous segment
+    echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}%f"
+  fi
+
   if [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]]; then
     if isSameColor "$CURRENT_RIGHT_BG" "$3"; then
       # Middle segment with same color as previous segment
@@ -257,7 +263,7 @@ right_prompt_segment() {
   # Print segment content if there is any
   [[ -n "$5" ]] && echo -n "${5}"
   # Print the visual identifier
-  echo -n "${visual_identifier}${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}%f"
+  echo -n "${visual_identifier}"
 
   CURRENT_RIGHT_BG=$3
   last_right_element_index=$current_index
@@ -1484,6 +1490,9 @@ build_right_prompt() {
 
     index=$((index + 1))
   done
+
+  # Clear to the end of the line
+  echo -n "%E"
 }
 
 powerlevel9k_preexec() {


### PR DESCRIPTION
ZSH displays the right prompt indented one space from the right
margin. This can be tweaked with `ZLE_RPROMPT_INDENT=0`, but that
makes display problems very likely and I don't recommend it. But
all is not lost.

The %E prompt format does continue the current background color
through that last indent space. So it can *look* like our prompt
goes right up to the margin, if:
1) We remove the trailing space from the last segment, and
2) We add %E before clearing the background color