### PR TITLE
Fix test-in-docker

### DIFF
--- a/docker/base-5.3.1/Dockerfile
+++ b/docker/base-5.3.1/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:stretch
+
+# We switched here to debian, as there seems no ZSH 5.3 in ubuntu.
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.3.1-4+b2 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+# Locale generation is different in debian. We need to enable en_US
+# locale and then regenerate locales.
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.4.2/Dockerfile
+++ b/docker/base-5.4.2/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.4.2-3ubuntu3 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.5.1/Dockerfile
+++ b/docker/base-5.5.1/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.10
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.5.1-1ubuntu1 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/prezto/install.zsh
+++ b/docker/prezto/install.zsh
@@ -9,7 +9,7 @@ for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
   ln -nsf "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
 done
 
-ln -s "${HOME}/p9k/powerlevel9k.zsh-theme" \
+ln -sf "${HOME}/p9k/powerlevel9k.zsh-theme" \
   "${HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
 
 echo "zstyle ':prezto:module:prompt' theme 'powerlevel9k'" \

--- a/test-in-docker
+++ b/test-in-docker
@@ -40,8 +40,8 @@ err()
 resolve_framework() {
   local f=$1 found
   found=${frameworks[(In:-1:)$f*]}
-  if (( found <= $#frameworks )); then
-    echo "${frameworks[$found]}"
+  if (( found <= ${#frameworks} )); then
+    echo "${1}"
   fi
 }
 
@@ -162,7 +162,7 @@ while (( $# > 0 )); do
       if [[ -z "$use_framework" ]]; then
         local f="$(resolve_framework "$1")"
         if [[ -n "$f" ]]; then
-          use_framework=$f
+          use_framework="${f}"
         else
           err "No such framework '${1}'"
         fi


### PR DESCRIPTION
This fixes the `test-in-docker` script and adds more recent ZSH versions (5.3.1 from Debian; rest is from Ubuntu).

//cc @docwhat 