### PR TITLE
test-in-docker: fix with newer ZSH versions

### DIFF
--- a/docker/base-5.0.3/Dockerfile
+++ b/docker/base-5.0.3/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh \
+  zsh=5.0.2-3ubuntu6.2 \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.1.1/Dockerfile
+++ b/docker/base-5.1.1/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh \
+  zsh=5.1.1-1ubuntu2.2 \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.2/Dockerfile
+++ b/docker/base-5.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 RUN \
   apt-get update && \

--- a/docker/base-5.2/Dockerfile
+++ b/docker/base-5.2/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh \
+  zsh=5.2-5ubuntu1.2 \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.3.1/Dockerfile
+++ b/docker/base-5.3.1/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:stretch
+
+# We switched here to debian, as there seems no ZSH 5.3 in ubuntu.
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.3.1-4+b2 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+# Locale generation is different in debian. We need to enable en_US
+# locale and then regenerate locales.
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.4.2/Dockerfile
+++ b/docker/base-5.4.2/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.4.2-3ubuntu3 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/base-5.5.1/Dockerfile
+++ b/docker/base-5.5.1/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.10
+
+RUN \
+  apt-get update && \
+  echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  git \
+  zsh=5.5.1-1ubuntu1 \
+  mercurial \
+  subversion \
+  golang \
+  jq \
+  nodejs \
+  ruby \
+  python \
+  python-virtualenv \
+  sudo \
+  locales
+
+RUN adduser --shell /bin/zsh --gecos 'fred' --disabled-password fred
+RUN locale-gen "en_US.UTF-8"
+
+COPY docker/fred-sudoers /etc/sudoers.d/fred
+
+USER fred
+WORKDIR /home/fred
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm-256color
+ENV DEFAULT_USER=fred
+ENV POWERLEVEL9K_ALWAYS_SHOW_CONTEXT=true
+
+RUN touch .zshrc
+
+CMD ["/bin/zsh", "-l"]

--- a/docker/prezto/install.zsh
+++ b/docker/prezto/install.zsh
@@ -9,7 +9,7 @@ for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
   ln -nsf "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
 done
 
-ln -s "${HOME}/p9k/powerlevel9k.zsh-theme" \
+ln -snf "${HOME}/p9k/powerlevel9k.zsh-theme" \
   "${HOME}/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup"
 
 echo "zstyle ':prezto:module:prompt' theme 'powerlevel9k'" \

--- a/docker/zshing/Dockerfile
+++ b/docker/zshing/Dockerfile
@@ -1,0 +1,7 @@
+ARG base
+FROM p9k:${base}
+
+COPY docker/zshing/install.zsh /tmp/
+RUN zsh /tmp/install.zsh
+
+COPY ./ p9k/

--- a/docker/zshing/install.zsh
+++ b/docker/zshing/install.zsh
@@ -1,0 +1,16 @@
+#!zsh
+
+# install zshing https://github.com/zakariaGatter/zshing
+git clone https://github.com/zakariaGatter/zshing.git ~/.zshing/zshing
+
+# Link P9K in zshing directory
+ln -nsf ~/p9k ~/.zshing/powerlevel9k
+
+{
+  echo
+  echo 'ZSHING_PLUGINS=(
+     "bhilburn/powerlevel9k"
+ )'
+  echo
+  echo "source ~/.zshing/zshing/zshing.zsh"
+} >> ~/.zshrc

--- a/test-in-docker
+++ b/test-in-docker
@@ -6,6 +6,7 @@ set -eu
 default_version='4.3.11'
 
 setopt extended_glob glob_subst numeric_glob_sort
+setopt warn_create_global warn_nested_var 2> /dev/null
 cd "${${(%):-%x}:A:h}"
 
 # TODO: Crazy Logic to munge TERM to something supported in Ubuntu 14.04

--- a/test-in-docker
+++ b/test-in-docker
@@ -21,7 +21,10 @@ versions=( docker/base-*/Dockerfile(N.on:h:t:s/base-//) )
 # List of frameworks
 typeset -a frameworks
 frameworks=( docker/*/Dockerfile(N.on:h:t) )
-frameworks=${(@)frameworks:#base-*}
+for i in {$#frameworks..1}; do
+  # Remove all base entries
+  [[ "${frameworks[$i]}" = base-* ]] && frameworks[$i]=()
+done
 
 # Known Issues
 typeset -A known_issues

--- a/test-in-docker
+++ b/test-in-docker
@@ -25,7 +25,7 @@ typeset -aU frameworks
 frameworks=( docker/*/Dockerfile(N.on:h:t) )
 for i in {$#frameworks..1}; do
   # Remove all base entries
-  [[ "${frameworks[$i]}" = base-* ]] && frameworks[$i]=()
+  [[ "${frameworks[$i]}" == base-* ]] && frameworks[$i]=()
 done
 typeset -r frameworks
 

--- a/test-in-docker
+++ b/test-in-docker
@@ -72,6 +72,14 @@ check_for_known_issues() {
   fi
 }
 
+cmd() {
+  if (( dry_run )); then
+    echo "${(@q)*}" 1>&2
+  else
+    "${(@)*}"
+  fi
+}
+
 build_and_run() {
   local version="$1"
   local framework="$2"
@@ -82,14 +90,14 @@ build_and_run() {
   print -P "%F{green}Preparing containers...%f"
 
   echo -n "p9k:base-${version}: "
-  docker build \
+  cmd docker build \
     --quiet \
     --tag "p9k:base-${version}" \
     --file "docker/base-${version}/Dockerfile" \
     .
 
   echo -n "p9k:${version}-${framework}: "
-  docker build \
+  cmd docker build \
     --quiet \
     --build-arg="base=base-${version}" \
     --tag "p9k:${version}-${framework}" \
@@ -97,7 +105,7 @@ build_and_run() {
     .
 
   print -P "%F{green}Starting ${name} container...%f"
-  exec docker run \
+  cmd docker run \
     --rm \
     --interactive \
     --tty \
@@ -112,9 +120,10 @@ show_help() {
   echo
   echo "Loads up a docker image with powershell9k configured in <framework>"
   echo
-  echo "  --frameworks  Lists all available frameworks, newline separated."
-  echo "  --versions    Lists all available ZSH versions, newline separated."
-  echo "  --zsh VER     Uses ZSH with version VER."
+  echo "  -f --frameworks  Lists all available frameworks, newline separated."
+  echo "  -v --versions    Lists all available ZSH versions, newline separated."
+  echo "  -z --zsh VER     Uses ZSH with version VER."
+  echo "  -n --dry-run     Just prints the docker commands that would be run."
   echo "  --help        You're soaking in it."
   echo
   echo "ZSH versions:"
@@ -137,6 +146,7 @@ fi
 # Parse flags and such.
 use_version=$default_version
 use_framework=
+dry_run=0
 while (( $# > 0 )); do
   case "$1" in
     -f | --frameworks )
@@ -156,6 +166,7 @@ while (( $# > 0 )); do
         err "No such ZSH version '${1}'"
       fi
       ;;
+    -n | --dry-run ) dry_run=1 ;;
     -h | --help )
       show_help
       exit
@@ -181,7 +192,7 @@ while (( $# > 0 )); do
   shift
 done
 
-typeset -r use_version use_framework
+typeset -r use_version use_framework dry_run
 
 build_and_run "$use_version" "$use_framework"
 

--- a/test-in-docker
+++ b/test-in-docker
@@ -16,16 +16,18 @@ term=screen-256color
 # ...see Modifiers in zshexpn(1) for details.
 
 # List of ZSH versions
-typeset -a versions
+typeset -aU versions
 versions=( docker/base-*/Dockerfile(N.on:h:t:s/base-//) )
+typeset -r versions
 
 # List of frameworks
-typeset -a frameworks
+typeset -aU frameworks
 frameworks=( docker/*/Dockerfile(N.on:h:t) )
 for i in {$#frameworks..1}; do
   # Remove all base entries
   [[ "${frameworks[$i]}" = base-* ]] && frameworks[$i]=()
 done
+typeset -r frameworks
 
 # Known Issues
 typeset -A known_issues
@@ -34,6 +36,7 @@ known_issues["4.3.11-zim"]="BROKEN: Zim wants ZSH 5.2 or newer."
 known_issues["5.0.3-zim"]="DEPRECATED: Zim wants ZSH 5.2 or newer."
 known_issues["5.1.1-zim"]="DEPRECATED: Zim wants ZSH 5.2 or newer."
 known_issues["4.3.11-zulu"]="Zulu doesn't work; it needs a newer version of git."
+typeset -r known_issues
 
 err()
 {
@@ -177,6 +180,8 @@ while (( $# > 0 )); do
   esac
   shift
 done
+
+typeset -r use_version use_framework
 
 build_and_run "$use_version" "$use_framework"
 

--- a/test-in-docker
+++ b/test-in-docker
@@ -2,8 +2,9 @@
 
 set -eu
 
-# The default ZSH to use.
-default_version='4.3.11'
+# The default ZSH to use; it can just be the first few characters.
+# This should be the oldest version we support.
+default_version='4.'
 
 setopt extended_glob glob_subst numeric_glob_sort
 setopt warn_create_global warn_nested_var 2> /dev/null
@@ -144,8 +145,8 @@ if (( $# == 0 )); then
 fi
 
 # Parse flags and such.
-use_version=$default_version
-use_framework=
+asked_for_version=$default_version
+asked_for_framework=
 dry_run=0
 while (( $# > 0 )); do
   case "$1" in
@@ -159,12 +160,7 @@ while (( $# > 0 )); do
       ;;
     -z | --zsh )
       shift
-      local v="$(resolve_version "$1")"
-      if [[ -n "$v" ]]; then
-        use_version=$v
-      else
-        err "No such ZSH version '${1}'"
-      fi
+      asked_for_version=$1
       ;;
     -n | --dry-run ) dry_run=1 ;;
     -h | --help )
@@ -177,22 +173,27 @@ while (( $# > 0 )); do
       exit 1
       ;;
     * )
-      if [[ -z "$use_framework" ]]; then
-        local f="$(resolve_framework "$1")"
-        if [[ -n "$f" ]]; then
-          use_framework=$f
-        else
-          err "No such framework '${1}'"
-        fi
+      if [[ -z "$asked_for_framework" ]]; then
+        asked_for_framework=$1
       else
-        err "You can only specify one framework at a time; you already specified '${use_framework}'"
+        err "You can only specify one framework at a time; you already specified '${asked_for_framework}'"
       fi
       ;;
   esac
   shift
 done
 
-typeset -r use_version use_framework dry_run
+typeset -r asked_for_version asked_for_framework
+
+typeset -r use_version="$(resolve_version "${asked_for_version}")"
+if [[ -z "$use_version" ]]; then
+  err "No such ZSH version '${asked_for_version}'"
+fi
+
+typeset -r use_framework="$(resolve_framework "${asked_for_framework}")"
+if [[ -z "$use_framework" ]]; then
+  err "No such framework '${asked_for_framework}'"
+fi
 
 build_and_run "$use_version" "$use_framework"
 


### PR DESCRIPTION
The way I was filtering out entries in the frameworks array stopped working in newer versions of ZSH; it would convert the array into a string (you could see it with `typeset -p frameworks`)

So I rewrote it.

I don't see anything in the release notes for ZSH that would explain this and I didn't find any option that would restore this behavior.

I also added a bunch of debugging and warning stuff to catch problems in the future.

And there is a `--dry-run` flag now.

Related: #882 (cc: @dritter)