### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,3 +12,6 @@ questions:
   - Which font do you use (for font related issues)?
   - Which powerlevel9k mode do you use (`echo $POWERLEVEL9K_MODE`)?
   - For font issues: Could you post the output of `debug/font-issues.zsh`?
+
+Please also have a look at the [troubleshooting guide](https://github.com/bhilburn/powerlevel9k/wiki/Troubleshooting)
+which solves the most common problems.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,35 @@
-Problems with powerlevel9k come with a lot of possible causes.
-The problem you have may arise from the used ZSH version to the
-configured font or even depend on the terminal emulator you are
-using.
+Thanks for opening an issue! For a project that deals with as many different things as P9k, debugging problems can be difficult. Please follow the guide, below, to create a bug report that will help us help you!
 
-So, please help us a bit and describe your problem as detailed as
-possible. Here is a little questionnaire to help us ask the right
-questions:
-  - What does `zsh --version` give you?
-  - Do you use a ZSH framework?
+### Before Opening a Bug
+P9k is lovingly maintained by volunteers, and we are happy to help you! You can help us by first making sure your issue hasn't already been solved before opening a new one. Please check the [Troubleshooting Guide](https://github.com/bhilburn/powerlevel9k/wiki/Troubleshooting) first. Many issues are actually local configuration problems, which may have previously been solved by another user - be sure to also [search the existing issues](https://github.com/bhilburn/powerlevel9k/issues?utf8=%E2%9C%93&q=is%3Aissue) before opening a new one.
+
+Once you've done these things, you can delete this section and proceed `=)`
+
+-----
+
+#### Describe Your Issue
+What is happening?
+
+Most issues are best explained with a screenshot. Please share one if you can!
+
+#### Have you tried to debug or fix it?
+
+
+Have you tinkered with your settings, and what happened when you did? Did you find a bit of code that you think might be the culprit? Let us know what you've done so far!
+
+#### Environment Information
+This information will help us understand your configuration. 
+
+  - What version of ZSH are you using? You can use `zsh --version` to see this.
+  - Do you use a ZSH framework (e.g., Oh-My-ZSH, Antigen)?
+  - How did you install P9k (cloning the repo, by tarball, a package from your OS, etc.,)?
+  - What version of P9k are you using?
   - Which terminal emulator do you use?
-  - Which font do you use (for font related issues)?
-  - Which powerlevel9k mode do you use (`echo $POWERLEVEL9K_MODE`)?
-  - For font issues: Could you post the output of `debug/font-issues.zsh`?
 
-Please also have a look at the [troubleshooting guide](https://github.com/bhilburn/powerlevel9k/wiki/Troubleshooting)
-which solves the most common problems.
+#### Issues with Fonts & Icons
+You may delete this section if your issue is not font / icon related.
+
+  - Which font do you use?
+  - Which [font configuration mode](https://github.com/bhilburn/powerlevel9k/wiki/About-Fonts) are you using? You can check this with (`echo $POWERLEVEL9K_MODE`).
+  - Please share the contents of `$P9k/debug/font-issues.zsh`.
+  - If this is an icon problem, does the output of `$ get_icon_names` look correct?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+Problems with powerlevel9k come with a lot of possible causes.
+The problem you have may arise from the used ZSH version to the
+configured font or even depend on the terminal emulator you are
+using.
+
+So, please help us a bit and describe your problem as detailed as
+possible. Here is a little questionnaire to help us ask the right
+questions:
+  - What does `zsh --version` give you?
+  - Do you use a ZSH framework?
+  - Which terminal emulator do you use?
+  - Which font do you use (for font related issues)?
+  - Which powerlevel9k mode do you use (`echo $POWERLEVEL9K_MODE`)?
+  - For font issues: Could you post the output of `debug/font-issues.zsh`?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Hey! Thanks for you contribution. To help you with that pull request,
+we have here some useful informations for you.
+
+Did you know:
+  - Our development happens on `next` branch. So should yours. Please
+    ensure your base is `next`. More information [here](https://github.com/bhilburn/powerlevel9k/wiki/Developer's-Guide).
+  - We have a lot of unit tests (in `test` dir). It would be awesome,
+    if you would add one for your feature.
+  - For manual tests there are Vagrant files and Docker files prepared.
+    Just have a look at the [test readme](https://github.com/bhilburn/powerlevel9k/blob/next/TESTS.md)
+  - Our [wiki](https://github.com/bhilburn/powerlevel9k/wiki) is quite
+    packed with loads of information about how to configure this theme.
+    If your feature has some flexpoint, the configuration help should
+    probably go there or in the README.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,32 @@
-Hey! Thanks for you contribution. To help you with that pull request,
-we have here some useful informations for you.
+Thank you so much for opening a PR for P9k! Many of our best features and segments have come from the community, and we are excited to see your contribution.
 
-Did you know:
-  - Our development happens on `next` branch. So should yours. Please
-    ensure your base is `next`. More information [here](https://github.com/bhilburn/powerlevel9k/wiki/Developer's-Guide).
-  - We have a lot of unit tests (in `test` dir). It would be awesome,
-    if you would add one for your feature.
-  - For manual tests there are Vagrant files and Docker files prepared.
-    Just have a look at the [test readme](https://github.com/bhilburn/powerlevel9k/blob/next/TESTS.md)
-  - Our [wiki](https://github.com/bhilburn/powerlevel9k/wiki) is quite
-    packed with loads of information about how to configure this theme.
-    If your feature has some flexpoint, the configuration help should
-    probably go there or in the README.
+To help you make the best PR, here are some guidelines:
+
+  - The `master` branch is our *stable* branch, and the `next` branch is our development branch. If you are submitting a bug fix, please file your PR against `master`. If it is a new feature, enhancement, segment, or something similar, please submit it against `next`. For more information, please see our [Developer's Guide](https://github.com/bhilburn/powerlevel9k/wiki/Developer's-Guide).
+  - We maintain unit tests for segments and features in the `test` directory. Please add unit tests for anything new you have developed! If you aren't sure how to do this, go ahead and file your PR and ask for help!
+  - For running manual tests in different environments, we have Vagrant and Docker configurations. Please see the [Test README](https://github.com/bhilburn/powerlevel9k/blob/next/TESTS.md) and make sure your new feature is working as expected!
+  - If your PR requires user configuration, please make sure that it includes an update to the README describing this.
+  - P9k maintains a lot of useful information in our [Wiki](https://github.com/bhilburn/powerlevel9k/wiki). Depending on the content of your PR, we might ask you to update the Wiki (or provide text for us to use) to document your work. Most PRs don't require this.
+  - Please make your commit messages useful! Here is a [great short guide on useful commit messages](https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503).
+
+Once you have submitted your PR, P9k core contributors will review the code and work with you to get it merged. During this process, we might request changes to your code and discuss different ways of doing things. This is all part of the open source process, and our goal is to help you create the best contribution possible for P9k `=)`.
+
+Please follow this template for creating your PR:
+
+#### Title
+Please make the title of your PR descriptive! If appropriate, please prefix the title with one of these tags:
+
+ - [Bugfix]
+ - [New Segment]
+ - [Docs]
+ - [Enhancement]
+ 
+#### Description
+Please describe the contribution your PR makes! Screenshots are especially helpful, here, if it's a new segment.
+
+If your PR is addressing an issue, please reference the Issue number here.
+
+#### Questions
+Is there something in your PR you're not sure about or need help with? Is there a particular piece of code you would like feedback on? Let us know here!
+
+


### PR DESCRIPTION
This adds Templates for new Issues and Pull Requests to help people. The Templates are mostly a backport from #344 .

We could even go a step further and add [multiple templates](https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/)..

This could be safely included in the next release (0.6.5).