### PR TITLE
Windows battery support

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -86,7 +86,7 @@ case $(uname) in
       OS='OSX'
       OS_ICON=$(print_icon 'APPLE_ICON')
       ;;
-    CYGWIN_NT-*)
+    CYGWIN_NT-* | MINGW32_NT-* | MINGW64_NT*)
       OS='Windows'
       OS_ICON=$(print_icon 'WINDOWS_ICON')
       ;;


### PR DESCRIPTION
Initial support for battery widget on Windows OS.

It uses [WMIC](https://docs.microsoft.com/ru-ru/windows/desktop/WmiSdk/wmi-start-page) output which looks pretty reliable to parse with stuff like grep and sed.

I admit there's still some work to do, like supporting systems without batteries and respecting `$POWERLEVEL9K_BATTERY_LOW_THRESHOLD` variable.

But it's a good starting point, and I would be glad to hear feedback from MINGW / MSYS2 users.