### PR TITLE
Dir - New Strategy - truncate_from_left

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -298,12 +298,12 @@ function truncatePath() {
     local paths=$1
     paths=(${(s:/:)${paths//"~\/"/}})
     # declare locals for the directory being tested and its length
-    local test_dir test_dir_length
+    local test_dir test_dir_length threshhold last_pos
     # do the needed truncation
     case $4 in
       right)
         # include the delimiter length in the threshhold
-        local threshhold=$(( $2 + ${#3} ))
+        threshhold=$(( $2 + ${#3} ))
         # loop through the paths
         for (( i=1; i<${#paths}; i++ )); do
           # get the current directory value
@@ -322,9 +322,9 @@ function truncatePath() {
       ;;
       middle)
         # we need double the length for start and end truncation + delimiter length
-        local threshhold=$(( $2 * 2 ))
+        threshhold=$(( $2 * 2 ))
         # create a variable for the start of the end truncation
-        local last_pos
+        last_pos
         # loop through the paths
         for (( i=1; i<${#paths}; i++ )); do
           # get the current directory value
@@ -336,6 +336,26 @@ function truncatePath() {
             # use the first $2 characters, the delimiter and the last $2 characters
             last_pos=$(( $test_dir_length - $2 ))
             trunc_path+="${test_dir:0:$2}$3${test_dir:$last_pos:$test_dir_length}/"
+          else
+            # use the full path
+            trunc_path+="${test_dir}/"
+          fi
+        done
+      ;;
+      left)
+        # include the delimiter length in the threshhold
+        threshhold=$(( $2 + ${#3} ))
+        # loop through the paths
+        for (( i=1; i<${#paths}; i++ )); do
+          # get the current directory value
+          test_dir=$paths[$i]
+          test_dir_length=${#test_dir}
+          # only truncate if the resulting truncation will be shorter than
+          # the truncation + delimiter length and at least 3 characters
+          if (( $test_dir_length > $threshhold )) && (( $test_dir_length > 3 )); then
+            # use the delimiter and the first $2 characters
+            last_pos=$(( $test_dir_length - $2 ))
+            trunc_path+="$3${test_dir:$last_pos:$test_dir_length}/"
           else
             # use the full path
             trunc_path+="${test_dir}/"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -637,14 +637,14 @@ prompt_user() {
         "FOREGROUND_COLOR"    "yellow"
         "VISUAL_IDENTIFIER"   "ROOT_ICON"
       )
-    elif sudo -n true 2>/dev/null; then 
-      user_state=( 
-        "STATE"               "SUDO" 
-        "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}" 
-        "BACKGROUND_COLOR"    "${DEFAULT_COLOR}" 
-        "FOREGROUND_COLOR"    "yellow" 
-        "VISUAL_IDENTIFIER"   "SUDO_ICON" 
-      ) 
+    elif sudo -n true 2>/dev/null; then
+      user_state=(
+        "STATE"               "SUDO"
+        "CONTENT"             "${POWERLEVEL9K_USER_TEMPLATE}"
+        "BACKGROUND_COLOR"    "${DEFAULT_COLOR}"
+        "FOREGROUND_COLOR"    "yellow"
+        "VISUAL_IDENTIFIER"   "SUDO_ICON"
+      )
     else
       user_state=(
         "STATE"               "DEFAULT"
@@ -766,6 +766,10 @@ prompt_dir() {
       truncate_from_right)
         # truncate characters from the right of the path
         current_path=$(truncatePath "$current_path" $POWERLEVEL9K_SHORTEN_DIR_LENGTH $POWERLEVEL9K_SHORTEN_DELIMITER)
+      ;;
+      truncate_from_left)
+        # truncate characters from the left of the path
+        current_path=$(truncatePath "$current_path" $P9K_SHORTEN_DIR_LENGTH $P9K_SHORTEN_DELIMITER "left")
       ;;
       truncate_absolute)
         # truncate all characters except the last POWERLEVEL9K_SHORTEN_DIR_LENGTH characters


### PR DESCRIPTION
New strategy for the dir segment - truncate_from_left

This adds the ability to shorten a directory from the left. It leaves just the end of a folder name untouched. E.g. your folders will be truncated like so: "/..9k/..st/segments". How many characters will be untouched is controlled by P9K_SHORTEN_DIR_LENGTH.

NOTE: Created in response to #885 