### PR TITLE
kubecontext: fix context, namespace comparison

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1429,7 +1429,7 @@ prompt_kubecontext() {
 
     local k8s_final_text=""
 
-    if [[ "$k8s_context" == "k8s_namespace" ]]; then
+    if [[ "$k8s_context" == "$k8s_namespace" ]]; then
       # No reason to print out the same identificator twice
       k8s_final_text="$k8s_context"
     else


### PR DESCRIPTION
Maybe the original author happened to name their context `k8s_namespace` 🤔 