### PR TITLE
Fix `pyenv` segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,19 @@ Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the rbenv segment even if the current Ruby version is the same as the global Ruby version|
 
+##### pyenv
+
+This segment shows the version of Python being used when using `pyenv` to change your current Python stack.
+
+The `PYENV_VERSION` environment variable will be used if specified. Otherwise it figures out the version being used by taking the output of the `pyenv version-name` command.
+
+* If `pyenv` is not in $PATH, nothing will be shown.
+* If the current Python version is the same as the global Python version, nothing will be shown.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the pyenv segment even if the current Python version is the same as the global Python version|
+
 ##### rspec_stats
 
 See [Unit Test Ratios](#unit-test-ratios), below.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1264,7 +1264,7 @@ prompt_ram() {
 # Segment to display rbenv information
 set_default POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW false
 prompt_rbenv() {
-  if ! [ -x "$(command -v rbenv)" ]; then
+  if [ $commands[rbenv] ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
 
@@ -1632,7 +1632,7 @@ prompt_virtualenv() {
 # https://github.com/pyenv/pyenv#choosing-the-python-version
 set_default POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW false
 prompt_pyenv() {
-  if ! [ -x "$(command -v pyenv)" ]; then
+  if [ $commands[pyenv] ]; then
     if [[ -n "$PYENV_VERSION" ]]; then
       "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
     else

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1270,7 +1270,7 @@ prompt_rbenv() {
   elif [ $commands[rbenv] ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
-    if ! [[ $rbenv_version_name == $rbenv_global && "$POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW" = false ]]; then
+    if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
     fi
   fi
@@ -1635,7 +1635,7 @@ prompt_pyenv() {
   elif [ $commands[pyenv] ]; then
     local pyenv_version_name="$(pyenv version-name)"
     local pyenv_global="$(pyenv version-file-read $(pyenv root)/version)"
-    if ! [[ $pyenv_version_name == $pyenv_global && "$POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW" = false ]]; then
+    if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$pyenv_version_name" 'PYTHON_ICON'
     fi
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1262,19 +1262,17 @@ prompt_ram() {
 
 ################################################################
 # Segment to display rbenv information
+# https://github.com/rbenv/rbenv#choosing-the-ruby-version
 set_default POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW false
 prompt_rbenv() {
-  if [ $commands[rbenv] ]; then
+  if [[ -n "$RBENV_VERSION" ]]; then
+    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$RBENV_VERSION" 'RUBY_ICON'
+  elif [ $commands[rbenv] ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
-
-    # Don't show anything if the current Ruby is the same as the global Ruby
-    # unless `POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW` is set.
-    if [[ $rbenv_version_name == $rbenv_global && "$POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW" = false ]]; then
-      return
+    if ! [[ $rbenv_version_name == $rbenv_global && "$POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW" = false ]]; then
+      "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
     fi
-
-    "$1_prompt_segment" "$0" "$2" "red" "$DEFAULT_COLOR" "$rbenv_version_name" 'RUBY_ICON'
   fi
 }
 
@@ -1632,15 +1630,12 @@ prompt_virtualenv() {
 # https://github.com/pyenv/pyenv#choosing-the-python-version
 set_default POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW false
 prompt_pyenv() {
-  if [ $commands[pyenv] ]; then
-    if [[ -n "$PYENV_VERSION" ]]; then
-      "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
-    else
-      local pyenv_version_name="$(pyenv version-name)"
-      local pyenv_global="$(pyenv version-file-read $(pyenv root)/version)"
-      if [[ $pyenv_version_name == $pyenv_global && "$POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW" = false ]]; then
-        return
-      fi
+  if [[ -n "$PYENV_VERSION" ]]; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
+  elif [ $commands[pyenv] ]; then
+    local pyenv_version_name="$(pyenv version-name)"
+    local pyenv_global="$(pyenv version-file-read $(pyenv root)/version)"
+    if ! [[ $pyenv_version_name == $pyenv_global && "$POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW" = false ]]; then
       "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$pyenv_version_name" 'PYTHON_ICON'
     fi
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1260,11 +1260,11 @@ prompt_ram() {
   "$1_prompt_segment" "$0" "$2" "yellow" "$DEFAULT_COLOR" "$(printSizeHumanReadable "$ramfree" $base)" 'RAM_ICON'
 }
 
-
+################################################################
+# Segment to display rbenv information
 set_default POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW false
-# rbenv information
 prompt_rbenv() {
-  if command which rbenv 2>/dev/null >&2; then
+  if ! [ -x "$(command -v rbenv)" ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
 
@@ -1628,11 +1628,21 @@ prompt_virtualenv() {
 }
 
 ################################################################
-# pyenv: current active python version (with restrictions)
+# Segment to display pyenv information
 # https://github.com/pyenv/pyenv#choosing-the-python-version
+set_default POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW false
 prompt_pyenv() {
-  if [[ -n "$PYENV_VERSION" ]]; then
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
+  if ! [ -x "$(command -v pyenv)" ]; then
+    if [[ -n "$PYENV_VERSION" ]]; then
+      "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
+    else
+      local pyenv_version_name="$(pyenv version-name)"
+      local pyenv_global="$(pyenv version-file-read $(pyenv root)/version)"
+      if [[ $pyenv_version_name == $pyenv_global && "$POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW" = false ]]; then
+        return
+      fi
+      "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$pyenv_version_name" 'PYTHON_ICON'
+    fi
   fi
 }
 


### PR DESCRIPTION
Fix #839 #879.

* Get the version being used by taking the output of the `pyenv version-name` command.
* Get the global Python version by reading global  `$(pyenv root)/version` file.
* Add variable `POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW` similar to `rbenv`.