### PR TITLE
[bugfix] Zsh < 5.3: Replace [[-v with ((${+

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -498,7 +498,7 @@ prompt_battery() {
     fi
   fi
   # return if POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD is set and the battery percentage is greater or equal
-  if [[ -v "POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD" && "${bat_percent}" -ge $POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD ]]; then
+  if defined POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD && [[ "${bat_percent}" -ge $POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD ]]; then
     return
   fi
 


### PR DESCRIPTION
For zsh 5.1 compatibility.

From https://github.com/bhilburn/powerlevel9k/pull/830/files#diff-ea5a405f0331722fc10a832209ffe20bL490 it only worked in 5.3+.

I'm not sure if this is better or if the `defined` util function should be preferred?