### PR TITLE
FIx status segment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
   - test/segments/vcs.spec
   - test/segments/kubecontext.spec
   - test/segments/laravel_version.spec
+  - test/segments/status.spec

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1779,10 +1779,16 @@ powerlevel9k_preexec() {
 
 set_default POWERLEVEL9K_PROMPT_ADD_NEWLINE false
 powerlevel9k_prepare_prompts() {
-  local RETVAL RPROMPT_PREFIX RPROMPT_SUFFIX
+  # Return values. These need to be global, because
+  # they are used in prompt_status. Also, we need
+  # to get the return value of the last command at
+  # very first in this function. Do not move the
+  # lines down, otherwise the last command is not
+  # what you expected it to be.
   RETVAL=$?
   RETVALS=( "$pipestatus[@]" )
 
+  local RPROMPT_SUFFIX RPROMPT_PREFIX
   _P9K_COMMAND_DURATION=$((EPOCHREALTIME - _P9K_TIMER_START))
 
   # Reset start time

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -1,0 +1,85 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+
+  ### Test specific
+  # Resets if someone has set these in his/hers env
+  unset POWERLEVEL9K_STATUS_VERBOSE
+  unset POWERLEVEL9K_STATUS_OK_IN_NON_VERBOSE
+}
+
+function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
+    local POWERLEVEL9K_CUSTOM_WORLD='echo world'
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status custom_world)
+    local POWERLEVEL9K_STATUS_VERBOSE=false
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
+
+    assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+}
+
+function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
+    local POWERLEVEL9K_STATUS_VERBOSE=true
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
+    local POWERLEVEL9K_STATUS_HIDE_SIGNAME=true
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+
+    assertEquals "%K{black} %F{green%}✔%f %k%F{black}%f " "$(build_left_prompt)"
+}
+
+function testStatusInGeneralErrorCase() {
+    local RETVAL=1
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+    local POWERLEVEL9K_STATUS_VERBOSE=true
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
+
+    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}1 %k%F{red}%f " "$(build_left_prompt)"
+}
+
+function testPipestatusInErrorCase() {
+    local -a RETVALS
+    RETVALS=(0 0 1 0)
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+    local POWERLEVEL9K_STATUS_VERBOSE=true
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=true
+
+    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}0|0|1|0 %k%F{red}%f " "$(build_left_prompt)"
+}
+
+function testStatusCrossWinsOverVerbose() {
+    local RETVAL=1
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
+    local POWERLEVEL9K_STATUS_VERBOSE=true
+    local POWERLEVEL9K_STATUS_CROSS=true
+
+    assertEquals "%K{black} %F{red%}✘%f %k%F{black}%f " "$(build_left_prompt)"
+}
+
+function testStatusShowsSignalNameInErrorCase() {
+    local RETVAL=132
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+    local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
+    local POWERLEVEL9K_STATUS_VERBOSE=true
+    local POWERLEVEL9K_STATUS_HIDE_SIGNAME=false
+
+    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}SIGILL(4) %k%F{red}%f " "$(build_left_prompt)"
+}
+
+function testStatusSegmentIntegrated() {
+    local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
+    local POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=()
+
+    false; powerlevel9k_prepare_prompts
+
+    assertEquals "%f%b%k%K{black} %F{red%}✘%f %k%F{black}%f " "${(e)PROMPT}"
+}
+
+source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
This fixes #903 . The problem here was that I made some variables local, but `RETVAL` must be global. In `powerlevel9k_prepare_prompts` (precmd hook) we save the return value of the last executed command. This must be done at the very top of that function, otherwise we get the return value of another command. E.g.:
```
local xxx
RETVAL=$?
```
will always have a RETVAL of 0, because it gets the return value of `local xxx`.