### PR TITLE
[Bugfix] Fix error in laravel_version when artisan is not present

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1118,7 +1118,7 @@ prompt_vpn_ip() {
 ################################################################
 # Segment to display laravel version
 prompt_laravel_version() {
-  local laravel_version="$(php artisan --version 2> /dev/null"
+  local laravel_version="$(php artisan --version 2> /dev/null)"
   if [[ -n "${laravel_version}" && "${laravel_version}" =~ "Laravel Framework" ]]; then
     # Strip out everything but the version
     laravel_version="${laravel_version//Laravel Framework /}"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1118,8 +1118,8 @@ prompt_vpn_ip() {
 ################################################################
 # Segment to display laravel version
 prompt_laravel_version() {
-  local laravel_version="$(php artisan --version 2>&1 | grep -oe '^Laravel Framework [0-9.]*')"
-  if [[ -n "${laravel_version}" ]]; then
+  local laravel_version="$(php artisan --version 2> /dev/null"
+  if [[ -n "${laravel_version}" && "${laravel_version}" =~ "Laravel Framework" ]]; then
     # Strip out everything but the version
     laravel_version="${laravel_version//Laravel Framework /}"
     "$1_prompt_segment" "$0" "$2" "maroon" "white" "${laravel_version}" 'LARAVEL_ICON'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1118,11 +1118,10 @@ prompt_vpn_ip() {
 ################################################################
 # Segment to display laravel version
 prompt_laravel_version() {
-  local laravel_version="$(php artisan --version 2>/dev/null)"
+  local laravel_version="$(php artisan --version 2>&1 | grep -oe '^Laravel Framework [0-9.]*')"
   if [[ -n "${laravel_version}" ]]; then
-    # Remove unrelevant infos
-    laravel_version="${laravel_version//Laravel Framework version /}"
-
+    # Strip out everything but the version
+    laravel_version="${laravel_version//Laravel Framework /}"
     "$1_prompt_segment" "$0" "$2" "maroon" "white" "${laravel_version}" 'LARAVEL_ICON'
   fi
 }

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -14,16 +14,17 @@ function setUp() {
 function mockLaravelVersion() {
   case "$1" in
     "artisan")
-      echo "Laravel Framework version 5.4.23"
+      # artisan --version follows the format Laravel Framework <version>
+      echo "Laravel Framework 5.4.23"
       ;;
     default)
   esac
 }
 
 function mockNoLaravelVersion() {
-  # This should output some error
-  >&2 echo "Artisan not available"
-  return 1
+  # When php can't find a file it will output a message
+  echo "Could not open input file: artisan"
+  return 0
 }
 
 function testLaravelVersionSegment() {


### PR DESCRIPTION
If PHP could not find the artisan file when building the prompt, it would output `Could not open input file: artisan` to stdout. Where only stderr was being redirected to /dev/null, this output would get placed into `laravel_version` variable and displayed on the prompt.

Also the output of `php artisan --version` follows the format `Laravel Framework <version number>`, so I adjusted pulling just the version number out accordingly.

The reference PR and conversation about this error can be found here: https://github.com/bhilburn/powerlevel9k/pull/818

On a side note, this is hands down my favorite zsh theme!

