### PR TITLE
[Bugfix] Fix for "truncate_to_unique" strategy

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -756,9 +756,8 @@ getUniqueHomeFolder() {
     local -a matching
     local -a paths
     local cur_path='/'
-    # the first time we run the script, the working directory *should* be the home folder
-    [[ -z $HOME ]] && paths=${PWD} || paths=$HOME
-    paths=(${(s:/:)paths})
+    # all users have the $HOME variable set automatically... see http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
+    paths=(${(s:/:)HOME})
     for directory in ${paths[@]}; do
       test_dir=''
       for (( i=0; i < ${#directory}; i++ )); do


### PR DESCRIPTION
Bugfix for issue #907 

The issue is that this strategy requires absolute paths to work, which is usually only available when `POWERLEVEL9K_DIR_PATH_ABSOLUTE` is set to true. This fix works around this limitation by using absolute paths and then changing the path at the end to `~/...` format if required.

This requires the use of a helper function `getUniqueHomeFolder` to determine the unique name of the home folder in order to replace that with `~`.