### PR TITLE
[Enhancement] Add option to always show remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ customization is provided via:
 |`P9K_VCS_HG_HOOKS`|`(vcs-detect-changes)`|Layout of the segment for Mercurial repositories.|
 |`P9K_VCS_SVN_HOOKS`|`(vcs-detect-changes svn-detect-changes)`|Layout of the segment for SVN repositories.|
 |`P9K_VCS_ACTIONFORMAT_FOREGROUND`|`red`|The color of the foreground font during actions (e.g., `REBASE`).|
+|`P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH`|`false`|Set to true If you would to always see the remote branch.|
 
 
 ##### vcs symbols

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -160,6 +160,7 @@ function +vi-git-aheadbehind() {
   hook_com[misc]+=${(j::)gitstatus}
 }
 
+p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 function +vi-git-remotebranch() {
   local remote branch_name
 
@@ -186,7 +187,10 @@ function +vi-git-remotebranch() {
   # Always show the remote
   #if [[ -n ${remote} ]] ; then
   # Only show the remote if it differs from the local
-  if [[ -n ${remote} ]] && [[ "${remote#*/}" != "${branch_name#heads/}" ]] ; then
+  if [[ -n ${remote} ]] &&
+      ([[ -n "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" ]] ||
+      [[ "${remote#*/}" != "${branch_name#heads/}" ]]) ;
+  then
     hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${remote// /}"
   fi
 }

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -122,6 +122,7 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
 ################################################################
 # Register segment helper default values
 p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
+p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
   # TODO: check git >= 1.7.2 - see function git_compare_version()
@@ -160,7 +161,6 @@ function +vi-git-aheadbehind() {
   hook_com[misc]+=${(j::)gitstatus}
 }
 
-p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 function +vi-git-remotebranch() {
   local remote branch_name
 
@@ -187,10 +187,11 @@ function +vi-git-remotebranch() {
   # Always show the remote
   #if [[ -n ${remote} ]] ; then
   # Only show the remote if it differs from the local
-  if [[ -n ${remote} ]] &&
-      ([[ "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" == 'true' ]] ||
-      [[ "${remote#*/}" != "${branch_name#heads/}" ]]) ;
-  then
+  if [[ -n ${remote} \
+      && ( \
+        "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" == 'true' \
+        || "${remote#*/}" != "${branch_name#heads/}" \
+      ) ]]; then
     hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${remote// /}"
   fi
 }

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -188,7 +188,7 @@ function +vi-git-remotebranch() {
   #if [[ -n ${remote} ]] ; then
   # Only show the remote if it differs from the local
   if [[ -n ${remote} ]] &&
-      ([[ "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" === 'true' ]] ||
+      ([[ "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" == 'true' ]] ||
       [[ "${remote#*/}" != "${branch_name#heads/}" ]]) ;
   then
     hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${remote// /}"

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -188,7 +188,7 @@ function +vi-git-remotebranch() {
   #if [[ -n ${remote} ]] ; then
   # Only show the remote if it differs from the local
   if [[ -n ${remote} ]] &&
-      ([[ -n "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" ]] ||
+      ([[ "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" === 'true' ]] ||
       [[ "${remote#*/}" != "${branch_name#heads/}" ]]) ;
   then
     hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${remote// /}"

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -448,7 +448,7 @@ function testAlwaysShowRemoteBranch()
 
   assertEquals "%K{002} %F{000} master→origin/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
-  local POWERLEVEL9K_VCS_HIDE_TAGS='false'
+  local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='false'
   assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -438,20 +438,13 @@ function testRemoteBranchNameIdenticalToTag() {
 
 function testAlwaysShowRemoteBranch()
 {
-  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
-  P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH=true
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
 
-  FOLDER=/tmp/powerlevel9k-test/vcs-test
-  mkdir -p $FOLDER
-  cd $FOLDER
-  git clone https://github.com/bhilburn/powerlevel9k.git "$FOLDER" 1>/dev/null 2>&1
+  mkdir repo
+  cd repo
+  git clone https://github.com/bhilburn/powerlevel9k.git . 1>/dev/null 2>&1
 
   assertEquals "%K{002} %F{000} master →origin/master %k%F{002}%f " "$(build_left_prompt)"
-
-  cd -
-  rm -fr /tmp/powerlevel9k-test
-
-  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unset POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH
 }
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -416,20 +416,20 @@ function testRemoteBranchNameIdenticalToTag() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
 
   echo "test" > test.txt
-  git add test.txt
-  git commit -m "Initial commit"
+  git add test.txt 1>/dev/null
+  git commit -m "Initial commit" 1>/dev/null
 
   # Prepare a tag named "test"
-  git tag test
+  git tag test 1>/dev/null
 
   # Prepare branch named "test"
-  git checkout -b test
+  git checkout -b test 1>/dev/null 2>&1
 
   # Clone Repo
-  git clone . ../vcs-test2
+  git clone . ../vcs-test2 1>/dev/null 2>&1
   cd ../vcs-test2
 
-  git checkout test
+  git checkout test 1>/dev/null 2>&1
 
   assertEquals "%K{002} %F{000} test test %k%F{002}%f " "$(__p9k_build_left_prompt)"
 

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -436,4 +436,22 @@ function testRemoteBranchNameIdenticalToTag() {
   cd -
 }
 
+function testAlwaysShowRemoteBranch()
+{
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH=true
+
+  FOLDER=/tmp/powerlevel9k-test/vcs-test
+  mkdir -p $FOLDER
+  cd $FOLDER
+  git clone https://github.com/bhilburn/powerlevel9k.git "$FOLDER" 1>/dev/null 2>&1
+
+  assertEquals "%K{green} %F{black} master →origin/master %k%F{green}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+
+  unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  unset POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH
+}
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -446,6 +446,6 @@ function testAlwaysShowRemoteBranch()
   cd repo
   git clone https://github.com/bhilburn/powerlevel9k.git . 1>/dev/null 2>&1
 
-  assertEquals "%K{002} %F{000} master →origin/master %k%F{002}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} master→origin/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -440,6 +440,7 @@ function testAlwaysShowRemoteBranch()
 {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
+  local POWERLEVEL9K_VCS_HIDE_TAGS='true'
 
   mkdir repo
   cd repo

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -447,5 +447,8 @@ function testAlwaysShowRemoteBranch()
   git clone https://github.com/bhilburn/powerlevel9k.git . 1>/dev/null 2>&1
 
   assertEquals "%K{002} %F{000} master→origin/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+
+  local POWERLEVEL9K_VCS_HIDE_TAGS='false'
+  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -446,7 +446,7 @@ function testAlwaysShowRemoteBranch()
   cd $FOLDER
   git clone https://github.com/bhilburn/powerlevel9k.git "$FOLDER" 1>/dev/null 2>&1
 
-  assertEquals "%K{green} %F{black} master →origin/master %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} master →origin/master %k%F{002}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -442,13 +442,18 @@ function testAlwaysShowRemoteBranch()
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
   local P9K_VCS_HIDE_TAGS='true'
 
-  mkdir repo
-  cd repo
-  git clone https://github.com/bhilburn/powerlevel9k.git . 1>/dev/null 2>&1
+  echo "test" > test.txt
+  git add . 1>/dev/null
+  git commit -m "Initial Commit" 1>/dev/null
+
+  git clone . ../vcs-test2 1>/dev/null 2>&1
+  cd ../vcs-test2
 
   assertEquals "%K{002} %F{000} master→origin/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='false'
   assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+
+  cd -
 }
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -438,9 +438,9 @@ function testRemoteBranchNameIdenticalToTag() {
 
 function testAlwaysShowRemoteBranch()
 {
-  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(vcs)
-  local POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
-  local POWERLEVEL9K_VCS_HIDE_TAGS='true'
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
+  local P9K_VCS_HIDE_TAGS='true'
 
   mkdir repo
   cd repo


### PR DESCRIPTION
Add `POWERLEVEL9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='1'` to your zshrc if you would to see remote branch in any cases.
 