### PR TITLE
[Bugfix] Resolve #918 Transparent background

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -79,6 +79,10 @@ function getColorCode() {
     else
       echo -n "$1"
     fi
+  # Check if value is none with any case.
+  elif [[ $1 = [nN][oO][nN][eE] ]]
+  then
+    echo -n 'none'
   else
     typeset -A codes
     # https://jonasjacek.github.io/colors/

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -80,7 +80,7 @@ function getColorCode() {
       echo -n "$1"
     fi
   # Check if value is none with any case.
-  elif [[ $1 = [nN][oO][nN][eE] ]]
+  elif [[ "${(L)1}" == "none" ]]
   then
     echo -n 'none'
   else


### PR DESCRIPTION
Before function getColorCode consider value 'none' like a bad value and search for another value that could match.
Now function getColorCode consider value 'none' like a good value and no longer seeks to replace it.
When it's use to set background the segment become transparent.