### PR TITLE
Add missing colors to fix color comparison

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -313,7 +313,7 @@ function foregroundColor() {
 # into ZSH-Style color codes.
 function getColorCode() {
   # Early exit: Check if given value is already numerical
-  if [[ "$1" = <-> ]]; then
+  if [[ "$1" == <-> ]]; then
     # Pad color with zeroes
     echo -n "${(l:3::0:)1}"
     return

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -6,6 +6,270 @@
 # https://github.com/bhilburn/powerlevel9k
 ################################################################
 
+typeset -gAh __P9K_COLORS
+# https://jonasjacek.github.io/colors/
+# use color names by default to allow dark/light themes to adjust colors based on names
+__P9K_COLORS=(
+  black 000
+  maroon 001
+  green 002
+  olive 003
+  navy 004
+  purple 005
+  teal 006
+  silver 007
+  grey 008
+  red 009
+  lime 010
+  yellow 011
+  blue 012
+  fuchsia 013
+  magenta 013
+  aqua 014
+  cyan 014
+  white 015
+  grey0 016
+  navyblue 017
+  darkblue 018
+  blue3 019
+  blue3 020
+  blue1 021
+  darkgreen 022
+  deepskyblue4 023
+  deepskyblue4 024
+  deepskyblue4 025
+  dodgerblue3 026
+  dodgerblue2 027
+  green4 028
+  springgreen4 029
+  turquoise4 030
+  deepskyblue3 031
+  deepskyblue3 032
+  dodgerblue1 033
+  green3 034
+  springgreen3 035
+  darkcyan 036
+  lightseagreen 037
+  deepskyblue2 038
+  deepskyblue1 039
+  green3 040
+  springgreen3 041
+  springgreen2 042
+  cyan3 043
+  darkturquoise 044
+  turquoise2 045
+  green1 046
+  springgreen2 047
+  springgreen1 048
+  mediumspringgreen 049
+  cyan2 050
+  cyan1 051
+  darkred 052
+  deeppink4 053
+  purple4 054
+  purple4 055
+  purple3 056
+  blueviolet 057
+  orange4 058
+  grey37 059
+  mediumpurple4 060
+  slateblue3 061
+  slateblue3 062
+  royalblue1 063
+  chartreuse4 064
+  darkseagreen4 065
+  paleturquoise4 066
+  steelblue 067
+  steelblue3 068
+  cornflowerblue 069
+  chartreuse3 070
+  darkseagreen4 071
+  cadetblue 072
+  cadetblue 073
+  skyblue3 074
+  steelblue1 075
+  chartreuse3 076
+  palegreen3 077
+  seagreen3 078
+  aquamarine3 079
+  mediumturquoise 080
+  steelblue1 081
+  chartreuse2 082
+  seagreen2 083
+  seagreen1 084
+  seagreen1 085
+  aquamarine1 086
+  darkslategray2 087
+  darkred 088
+  deeppink4 089
+  darkmagenta 090
+  darkmagenta 091
+  darkviolet 092
+  purple 093
+  orange4 094
+  lightpink4 095
+  plum4 096
+  mediumpurple3 097
+  mediumpurple3 098
+  slateblue1 099
+  yellow4 100
+  wheat4 101
+  grey53 102
+  lightslategrey 103
+  mediumpurple 104
+  lightslateblue 105
+  yellow4 106
+  darkolivegreen3 107
+  darkseagreen 108
+  lightskyblue3 109
+  lightskyblue3 110
+  skyblue2 111
+  chartreuse2 112
+  darkolivegreen3 113
+  palegreen3 114
+  darkseagreen3 115
+  darkslategray3 116
+  skyblue1 117
+  chartreuse1 118
+  lightgreen 119
+  lightgreen 120
+  palegreen1 121
+  aquamarine1 122
+  darkslategray1 123
+  red3 124
+  deeppink4 125
+  mediumvioletred 126
+  magenta3 127
+  darkviolet 128
+  purple 129
+  darkorange3 130
+  indianred 131
+  hotpink3 132
+  mediumorchid3 133
+  mediumorchid 134
+  mediumpurple2 135
+  darkgoldenrod 136
+  lightsalmon3 137
+  rosybrown 138
+  grey63 139
+  mediumpurple2 140
+  mediumpurple1 141
+  gold3 142
+  darkkhaki 143
+  navajowhite3 144
+  grey69 145
+  lightsteelblue3 146
+  lightsteelblue 147
+  yellow3 148
+  darkolivegreen3 149
+  darkseagreen3 150
+  darkseagreen2 151
+  lightcyan3 152
+  lightskyblue1 153
+  greenyellow 154
+  darkolivegreen2 155
+  palegreen1 156
+  darkseagreen2 157
+  darkseagreen1 158
+  paleturquoise1 159
+  red3 160
+  deeppink3 161
+  deeppink3 162
+  magenta3 163
+  magenta3 164
+  magenta2 165
+  darkorange3 166
+  indianred 167
+  hotpink3 168
+  hotpink2 169
+  orchid 170
+  mediumorchid1 171
+  orange3 172
+  lightsalmon3 173
+  lightpink3 174
+  pink3 175
+  plum3 176
+  violet 177
+  gold3 178
+  lightgoldenrod3 179
+  tan 180
+  mistyrose3 181
+  thistle3 182
+  plum2 183
+  yellow3 184
+  khaki3 185
+  lightgoldenrod2 186
+  lightyellow3 187
+  grey84 188
+  lightsteelblue1 189
+  yellow2 190
+  darkolivegreen1 191
+  darkolivegreen1 192
+  darkseagreen1 193
+  honeydew2 194
+  lightcyan1 195
+  red1 196
+  deeppink2 197
+  deeppink1 198
+  deeppink1 199
+  magenta2 200
+  magenta1 201
+  orangered1 202
+  indianred1 203
+  indianred1 204
+  hotpink 205
+  hotpink 206
+  mediumorchid1 207
+  darkorange 208
+  salmon1 209
+  lightcoral 210
+  palevioletred1 211
+  orchid2 212
+  orchid1 213
+  orange1 214
+  sandybrown 215
+  lightsalmon1 216
+  lightpink1 217
+  pink1 218
+  plum1 219
+  gold1 220
+  lightgoldenrod2 221
+  lightgoldenrod2 222
+  navajowhite1 223
+  mistyrose1 224
+  thistle1 225
+  yellow1 226
+  lightgoldenrod1 227
+  khaki1 228
+  wheat1 229
+  cornsilk1 230
+  grey100 231
+  grey3 232
+  grey7 233
+  grey11 234
+  grey15 235
+  grey19 236
+  grey23 237
+  grey27 238
+  grey30 239
+  grey35 240
+  grey39 241
+  grey42 242
+  grey46 243
+  grey50 244
+  grey54 245
+  grey58 246
+  grey62 247
+  grey66 248
+  grey70 249
+  grey74 250
+  grey78 251
+  grey82 252
+  grey85 253
+  grey89 254
+  grey93 255
+)
+
 function termColors() {
   if [[ $POWERLEVEL9K_IGNORE_TERM_COLORS == true ]]; then
     return
@@ -68,277 +332,15 @@ function getColorCode() {
       echo -n "$1"
     fi
   else
-    typeset -A codes
-    # https://jonasjacek.github.io/colors/
-    # use color names by default to allow dark/light themes to adjust colors based on names
-    codes[black]=000
-    codes[maroon]=001
-    codes[green]=002
-    codes[olive]=003
-    codes[navy]=004
-    codes[purple]=005
-    codes[teal]=006
-    codes[silver]=007
-    codes[grey]=008
-    codes[red]=009
-    codes[lime]=010
-    codes[yellow]=011
-    codes[blue]=012
-    codes[fuchsia]=013
-    codes[magenta]=013
-    codes[aqua]=014
-    codes[cyan]=014
-    codes[white]=015
-    codes[grey0]=016
-    codes[navyblue]=017
-    codes[darkblue]=018
-    codes[blue3]=019
-    codes[blue3]=020
-    codes[blue1]=021
-    codes[darkgreen]=022
-    codes[deepskyblue4]=023
-    codes[deepskyblue4]=024
-    codes[deepskyblue4]=025
-    codes[dodgerblue3]=026
-    codes[dodgerblue2]=027
-    codes[green4]=028
-    codes[springgreen4]=029
-    codes[turquoise4]=030
-    codes[deepskyblue3]=031
-    codes[deepskyblue3]=032
-    codes[dodgerblue1]=033
-    codes[green3]=034
-    codes[springgreen3]=035
-    codes[darkcyan]=036
-    codes[lightseagreen]=037
-    codes[deepskyblue2]=038
-    codes[deepskyblue1]=039
-    codes[green3]=040
-    codes[springgreen3]=041
-    codes[springgreen2]=042
-    codes[cyan3]=043
-    codes[darkturquoise]=044
-    codes[turquoise2]=045
-    codes[green1]=046
-    codes[springgreen2]=047
-    codes[springgreen1]=048
-    codes[mediumspringgreen]=049
-    codes[cyan2]=050
-    codes[cyan1]=051
-    codes[darkred]=052
-    codes[deeppink4]=053
-    codes[purple4]=054
-    codes[purple4]=055
-    codes[purple3]=056
-    codes[blueviolet]=057
-    codes[orange4]=058
-    codes[grey37]=059
-    codes[mediumpurple4]=060
-    codes[slateblue3]=061
-    codes[slateblue3]=062
-    codes[royalblue1]=063
-    codes[chartreuse4]=064
-    codes[darkseagreen4]=065
-    codes[paleturquoise4]=066
-    codes[steelblue]=067
-    codes[steelblue3]=068
-    codes[cornflowerblue]=069
-    codes[chartreuse3]=070
-    codes[darkseagreen4]=071
-    codes[cadetblue]=072
-    codes[cadetblue]=073
-    codes[skyblue3]=074
-    codes[steelblue1]=075
-    codes[chartreuse3]=076
-    codes[palegreen3]=077
-    codes[seagreen3]=078
-    codes[aquamarine3]=079
-    codes[mediumturquoise]=080
-    codes[steelblue1]=081
-    codes[chartreuse2]=082
-    codes[seagreen2]=083
-    codes[seagreen1]=084
-    codes[seagreen1]=085
-    codes[aquamarine1]=086
-    codes[darkslategray2]=087
-    codes[darkred]=088
-    codes[deeppink4]=089
-    codes[darkmagenta]=090
-    codes[darkmagenta]=091
-    codes[darkviolet]=092
-    codes[purple]=093
-    codes[orange4]=094
-    codes[lightpink4]=095
-    codes[plum4]=096
-    codes[mediumpurple3]=097
-    codes[mediumpurple3]=098
-    codes[slateblue1]=099
-    codes[yellow4]=100
-    codes[wheat4]=101
-    codes[grey53]=102
-    codes[lightslategrey]=103
-    codes[mediumpurple]=104
-    codes[lightslateblue]=105
-    codes[yellow4]=106
-    codes[darkolivegreen3]=107
-    codes[darkseagreen]=108
-    codes[lightskyblue3]=109
-    codes[lightskyblue3]=110
-    codes[skyblue2]=111
-    codes[chartreuse2]=112
-    codes[darkolivegreen3]=113
-    codes[palegreen3]=114
-    codes[darkseagreen3]=115
-    codes[darkslategray3]=116
-    codes[skyblue1]=117
-    codes[chartreuse1]=118
-    codes[lightgreen]=119
-    codes[lightgreen]=120
-    codes[palegreen1]=121
-    codes[aquamarine1]=122
-    codes[darkslategray1]=123
-    codes[red3]=124
-    codes[deeppink4]=125
-    codes[mediumvioletred]=126
-    codes[magenta3]=127
-    codes[darkviolet]=128
-    codes[purple]=129
-    codes[darkorange3]=130
-    codes[indianred]=131
-    codes[hotpink3]=132
-    codes[mediumorchid3]=133
-    codes[mediumorchid]=134
-    codes[mediumpurple2]=135
-    codes[darkgoldenrod]=136
-    codes[lightsalmon3]=137
-    codes[rosybrown]=138
-    codes[grey63]=139
-    codes[mediumpurple2]=140
-    codes[mediumpurple1]=141
-    codes[gold3]=142
-    codes[darkkhaki]=143
-    codes[navajowhite3]=144
-    codes[grey69]=145
-    codes[lightsteelblue3]=146
-    codes[lightsteelblue]=147
-    codes[yellow3]=148
-    codes[darkolivegreen3]=149
-    codes[darkseagreen3]=150
-    codes[darkseagreen2]=151
-    codes[lightcyan3]=152
-    codes[lightskyblue1]=153
-    codes[greenyellow]=154
-    codes[darkolivegreen2]=155
-    codes[palegreen1]=156
-    codes[darkseagreen2]=157
-    codes[darkseagreen1]=158
-    codes[paleturquoise1]=159
-    codes[red3]=160
-    codes[deeppink3]=161
-    codes[deeppink3]=162
-    codes[magenta3]=163
-    codes[magenta3]=164
-    codes[magenta2]=165
-    codes[darkorange3]=166
-    codes[indianred]=167
-    codes[hotpink3]=168
-    codes[hotpink2]=169
-    codes[orchid]=170
-    codes[mediumorchid1]=171
-    codes[orange3]=172
-    codes[lightsalmon3]=173
-    codes[lightpink3]=174
-    codes[pink3]=175
-    codes[plum3]=176
-    codes[violet]=177
-    codes[gold3]=178
-    codes[lightgoldenrod3]=179
-    codes[tan]=180
-    codes[mistyrose3]=181
-    codes[thistle3]=182
-    codes[plum2]=183
-    codes[yellow3]=184
-    codes[khaki3]=185
-    codes[lightgoldenrod2]=186
-    codes[lightyellow3]=187
-    codes[grey84]=188
-    codes[lightsteelblue1]=189
-    codes[yellow2]=190
-    codes[darkolivegreen1]=191
-    codes[darkolivegreen1]=192
-    codes[darkseagreen1]=193
-    codes[honeydew2]=194
-    codes[lightcyan1]=195
-    codes[red1]=196
-    codes[deeppink2]=197
-    codes[deeppink1]=198
-    codes[deeppink1]=199
-    codes[magenta2]=200
-    codes[magenta1]=201
-    codes[orangered1]=202
-    codes[indianred1]=203
-    codes[indianred1]=204
-    codes[hotpink]=205
-    codes[hotpink]=206
-    codes[mediumorchid1]=207
-    codes[darkorange]=208
-    codes[salmon1]=209
-    codes[lightcoral]=210
-    codes[palevioletred1]=211
-    codes[orchid2]=212
-    codes[orchid1]=213
-    codes[orange1]=214
-    codes[sandybrown]=215
-    codes[lightsalmon1]=216
-    codes[lightpink1]=217
-    codes[pink1]=218
-    codes[plum1]=219
-    codes[gold1]=220
-    codes[lightgoldenrod2]=221
-    codes[lightgoldenrod2]=222
-    codes[navajowhite1]=223
-    codes[mistyrose1]=224
-    codes[thistle1]=225
-    codes[yellow1]=226
-    codes[lightgoldenrod1]=227
-    codes[khaki1]=228
-    codes[wheat1]=229
-    codes[cornsilk1]=230
-    codes[grey100]=231
-    codes[grey3]=232
-    codes[grey7]=233
-    codes[grey11]=234
-    codes[grey15]=235
-    codes[grey19]=236
-    codes[grey23]=237
-    codes[grey27]=238
-    codes[grey30]=239
-    codes[grey35]=240
-    codes[grey39]=241
-    codes[grey42]=242
-    codes[grey46]=243
-    codes[grey50]=244
-    codes[grey54]=245
-    codes[grey58]=246
-    codes[grey62]=247
-    codes[grey66]=248
-    codes[grey70]=249
-    codes[grey74]=250
-    codes[grey78]=251
-    codes[grey82]=252
-    codes[grey85]=253
-    codes[grey89]=254
-    codes[grey93]=255
-
     # for testing purposes in terminal
     if [[ "$1" == "foreground"  ]]; then
         # call via `getColorCode foreground`
-        for i in "${(k@)codes}"; do
+        for i in "${(k@)__P9K_COLORS}"; do
             print -P "$(foregroundColor $i)$(getColor $i) - $i%f"
         done
     elif [[ "$1" == "background"  ]]; then
         # call via `getColorCode background`
-        for i in "${(k@)codes}"; do
+        for i in "${(k@)__P9K_COLORS}"; do
             print -P "$(backgroundColor $i)$(getColor $i) - $i%k"
         done
     else
@@ -349,7 +351,7 @@ function getColorCode() {
         1=${1#fg-}
         # Strip eventual "br" prefixes ("bright" colors)
         1=${1#br}
-        echo -n $codes[$1]
+        echo -n $__P9K_COLORS[$1]
     fi
   fi
 }

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -36,7 +36,7 @@ function getColor() {
     local default="$'\033'\[49m"
     # http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html
     local quoted=$(printf "%q" $(print -P "$named"))
-    if [[ $quoted = "$'\033'\[49m" && $1 != "black" ]]; then
+    if [[ $quoted == "$'\033'\[49m" && $1 != "black" ]]; then
         # color not found, so try to get the code
         1=$(getColorCode $1)
     fi

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -28,12 +28,8 @@ function termColors() {
 
 # get the proper color code if it does not exist as a name.
 function getColor() {
-  # no need to check numerical values
-  if [[ "$1" = <-> ]]; then
-    if [[ "$1" = <8-15> ]]; then
-      1=$(($1 - 8))
-    fi
-  else
+  # If Color is not numerical, try to get the color code.
+  if [[ "$1" != <-> ]]; then
     # named color added to parameter expansion print -P to test if the name exists in terminal
     local named="%K{$1}"
     # https://misc.flogisoft.com/bash/tip_colors_and_formatting

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -314,7 +314,8 @@ function foregroundColor() {
 function getColorCode() {
   # Early exit: Check if given value is already numerical
   if [[ "$1" = <-> ]]; then
-    echo -n "$1"
+    # Pad color with zeroes
+    echo -n "${(l:3::0:)1}"
     return
   fi
 

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -294,16 +294,7 @@ function termColors() {
 function getColor() {
   # If Color is not numerical, try to get the color code.
   if [[ "$1" != <-> ]]; then
-    # named color added to parameter expansion print -P to test if the name exists in terminal
-    local named="%K{$1}"
-    # https://misc.flogisoft.com/bash/tip_colors_and_formatting
-    local default="$'\033'\[49m"
-    # http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html
-    local quoted=$(printf "%q" $(print -P "$named"))
-    if [[ $quoted == "$'\033'\[49m" && $1 != "black" ]]; then
-        # color not found, so try to get the code
-        1=$(getColorCode $1)
-    fi
+    1=$(getColorCode $1)
   fi
   echo -n "$1"
 }
@@ -321,32 +312,32 @@ function foregroundColor() {
 # Get numerical color codes. That way we translate ANSI codes
 # into ZSH-Style color codes.
 function getColorCode() {
-  # Check if given value is already numerical
+  # Early exit: Check if given value is already numerical
   if [[ "$1" = <-> ]]; then
-      echo -n "$1"
-    fi
+    echo -n "$1"
+    return
+  fi
+
+  local colorName="${1}"
+  # for testing purposes in terminal
+  if [[ "${colorName}" == "foreground"  ]]; then
+      # call via `getColorCode foreground`
+      for i in "${(k@)__P9K_COLORS}"; do
+          print -P "$(foregroundColor $i)$(getColor $i) - $i%f"
+      done
+  elif [[ "${colorName}" == "background"  ]]; then
+      # call via `getColorCode background`
+      for i in "${(k@)__P9K_COLORS}"; do
+          print -P "$(backgroundColor $i)$(getColor $i) - $i%k"
+      done
   else
-    # for testing purposes in terminal
-    if [[ "$1" == "foreground"  ]]; then
-        # call via `getColorCode foreground`
-        for i in "${(k@)__P9K_COLORS}"; do
-            print -P "$(foregroundColor $i)$(getColor $i) - $i%f"
-        done
-    elif [[ "$1" == "background"  ]]; then
-        # call via `getColorCode background`
-        for i in "${(k@)__P9K_COLORS}"; do
-            print -P "$(backgroundColor $i)$(getColor $i) - $i%k"
-        done
-    else
-        #[[ -n "$1" ]] bg="%K{$1}" || bg="%k"
-        # Strip eventual "bg-" prefixes
-        1=${1#bg-}
-        # Strip eventual "fg-" prefixes
-        1=${1#fg-}
-        # Strip eventual "br" prefixes ("bright" colors)
-        1=${1#br}
-        echo -n $__P9K_COLORS[$1]
-    fi
+      # Strip eventual "bg-" prefixes
+      colorName=${colorName#bg-}
+      # Strip eventual "fg-" prefixes
+      colorName=${colorName#fg-}
+      # Strip eventual "br" prefixes ("bright" colors)
+      colorName=${colorName#br}
+      echo -n $__P9K_COLORS[$colorName]
   fi
 }
 

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -50,20 +50,12 @@ function getColor() {
 
 # empty paramenter resets (stops) background color
 function backgroundColor() {
-  if [[ -z $1 ]]; then
-    echo -n "%k"
-  else
-    echo -n "%K{$(getColor $1)}"
-  fi
+  echo -n "%K{$(getColor $1)}"
 }
 
 # empty paramenter resets (stops) foreground color
 function foregroundColor() {
-  if [[ -z $1 ]]; then
-    echo -n "%f"
-  else
-    echo -n "%F{$(getColor $1)}"
-  fi
+  echo -n "%F{$(getColor $1)}"
 }
 
 # Get numerical color codes. That way we translate ANSI codes
@@ -346,12 +338,12 @@ function getColorCode() {
     if [[ "$1" == "foreground"  ]]; then
         # call via `getColorCode foreground`
         for i in "${(k@)codes}"; do
-            print -P "$(foregroundColor $i)$(getColor $i) - $i$(foregroundColor)"
+            print -P "$(foregroundColor $i)$(getColor $i) - $i%f"
         done
     elif [[ "$1" == "background"  ]]; then
         # call via `getColorCode background`
         for i in "${(k@)codes}"; do
-            print -P "$(backgroundColor $i)$(getColor $i) - $i$(backgroundColor)"
+            print -P "$(backgroundColor $i)$(getColor $i) - $i%k"
         done
     else
         #[[ -n "$1" ]] bg="%K{$1}" || bg="%k"

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -323,12 +323,6 @@ function foregroundColor() {
 function getColorCode() {
   # Check if given value is already numerical
   if [[ "$1" = <-> ]]; then
-    # ANSI color codes distinguish between "foreground"
-    # and "background" colors. We don't need to do that,
-    # as ZSH uses a 256 color space anyway.
-    if [[ "$1" = <8-15> ]]; then
-      echo -n $(($1 - 8))
-    else
       echo -n "$1"
     fi
   else

--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -97,7 +97,9 @@ function getColorCode() {
     codes[yellow]=011
     codes[blue]=012
     codes[fuchsia]=013
+    codes[magenta]=013
     codes[aqua]=014
+    codes[cyan]=014
     codes[white]=015
     codes[grey0]=016
     codes[navyblue]=017

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -173,7 +173,7 @@ left_prompt_segment() {
   [[ -n "$5" ]] && echo -n "${fg}${5}"
   echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS}"
 
-  CURRENT_BG=$3
+  CURRENT_BG="$(getColorCode ${3})"
   last_left_element_index=$current_index
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -172,7 +172,7 @@ left_prompt_segment() {
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)${segment_name}#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable "${foregroundColor}"
-      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
+      visual_identifier="$(foregroundColor ${(P)visual_identifier_color_variable})${visual_identifier}%f"
     fi
   fi
 
@@ -274,7 +274,7 @@ right_prompt_segment() {
       # Allow users to overwrite the color for the visual identifier only.
       local visual_identifier_color_variable=POWERLEVEL9K_${(U)${segment_name}#prompt_}_VISUAL_IDENTIFIER_COLOR
       set_default $visual_identifier_color_variable "${foregroundColor}"
-      visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
+      visual_identifier="$(foregroundColor ${(P)visual_identifier_color_variable})${visual_identifier}%f"
     fi
   fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -189,7 +189,7 @@ left_prompt_segment() {
 # End the left prompt, closes the final segment.
 left_prompt_end() {
   if [[ -n $CURRENT_BG ]]; then
-    echo -n "%k%F{$CURRENT_BG}$(print_icon 'LEFT_SEGMENT_SEPARATOR')"
+    echo -n "%k$(foregroundColor ${CURRENT_BG})$(print_icon 'LEFT_SEGMENT_SEPARATOR')"
   else
     echo -n "%k"
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -278,11 +278,6 @@ right_prompt_segment() {
 # Prompt Segment Definitions
 ################################################################
 
-# The `CURRENT_BG` variable is used to remember what the last BG color used was
-# when building the left-hand prompt. Because the RPROMPT is created from
-# right-left but reads the opposite, this isn't necessary for the other side.
-CURRENT_BG='NONE'
-
 ################################################################
 # Anaconda Environment
 prompt_anaconda() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -231,7 +231,7 @@ right_prompt_segment() {
   # Overwrite given foreground-color by user defined variable for this segment.
   local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)${segment_name}#prompt_}_FOREGROUND
   local FG_COLOR_MODIFIER=${(P)FOREGROUND_USER_VARIABLE}
-  [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
+  [[ -n $FG_COLOR_MODIFIER ]] && foregroundColor="$FG_COLOR_MODIFIER"
 
   # Get color codes here to save some calls later on
   backgroundColor="$(getColorCode ${backgroundColor})"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -111,45 +111,54 @@ CURRENT_BG='NONE'
 set_default last_left_element_index 1
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS " "
 left_prompt_segment() {
+  local segment_name="${1}"
   local current_index=$2
   # Check if the segment should be joined with the previous one
   local joined
   segmentShouldBeJoined $current_index $last_left_element_index "$POWERLEVEL9K_LEFT_PROMPT_ELEMENTS" && joined=true || joined=false
 
+  # Colors
+  local backgroundColor="${3}"
+  local foregroundColor="${4}"
+
   # Overwrite given background-color by user defined variable for this segment.
-  local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_BACKGROUND
+  local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)${segment_name}#prompt_}_BACKGROUND
   local BG_COLOR_MODIFIER=${(P)BACKGROUND_USER_VARIABLE}
-  [[ -n $BG_COLOR_MODIFIER ]] && 3="$BG_COLOR_MODIFIER"
+  [[ -n $BG_COLOR_MODIFIER ]] && backgroundColor="$BG_COLOR_MODIFIER"
 
   # Overwrite given foreground-color by user defined variable for this segment.
-  local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_FOREGROUND
+  local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)${segment_name}#prompt_}_FOREGROUND
   local FG_COLOR_MODIFIER=${(P)FOREGROUND_USER_VARIABLE}
-  [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
+  [[ -n $FG_COLOR_MODIFIER ]] && foregroundColor="$FG_COLOR_MODIFIER"
 
-  local bg fg
-  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="%k"
-  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="%f"
+  # Get color codes here to save some calls later on
+  backgroundColor="$(getColorCode ${backgroundColor})"
+  foregroundColor="$(getColorCode ${foregroundColor})"
 
-  if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$3" "$CURRENT_BG"; then
-    echo -n "$bg%F{$CURRENT_BG}"
+  local background foreground
+  [[ -n "${backgroundColor}" ]] && background="$(backgroundColor ${backgroundColor})" || background="%k"
+  [[ -n "${foregroundColor}" ]] && foreground="$(foregroundColor ${foregroundColor})" || foreground="%f"
+
+  if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "${backgroundColor}" "$CURRENT_BG"; then
+    echo -n "${background}%F{$CURRENT_BG}"
     if [[ $joined == false ]]; then
       # Middle segment
       echo -n "$(print_icon 'LEFT_SEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
     fi
-  elif isSameColor "$CURRENT_BG" "$3"; then
+  elif isSameColor "$CURRENT_BG" "${backgroundColor}"; then
     # Middle segment with same color as previous segment
     # We take the current foreground color as color for our
     # subsegment (or the default color). This should have
     # enough contrast.
     local complement
-    [[ -n "$4" ]] && complement="$fg" || complement="$(foregroundColor $DEFAULT_COLOR)"
-    echo -n "${bg}${complement}"
+    [[ -n "${foregroundColor}" ]] && complement="${foreground}" || complement="$(foregroundColor $DEFAULT_COLOR)"
+    echo -n "${background}${complement}"
     if [[ $joined == false ]]; then
       echo -n "$(print_icon 'LEFT_SUBSEGMENT_SEPARATOR')$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
     fi
   else
     # First segment
-    echo -n "${bg}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+    echo -n "${background}$POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
   fi
 
   local visual_identifier
@@ -161,8 +170,8 @@ left_prompt_segment() {
       # we need to color both the visual identifier and the whitespace.
       [[ -n "$5" ]] && visual_identifier="$visual_identifier "
       # Allow users to overwrite the color for the visual identifier only.
-      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-      set_default $visual_identifier_color_variable $4
+      local visual_identifier_color_variable=POWERLEVEL9K_${(U)${segment_name}#prompt_}_VISUAL_IDENTIFIER_COLOR
+      set_default $visual_identifier_color_variable "${foregroundColor}"
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     fi
   fi
@@ -170,10 +179,10 @@ left_prompt_segment() {
   # Print the visual identifier
   echo -n "${visual_identifier}"
   # Print the content of the segment, if there is any
-  [[ -n "$5" ]] && echo -n "${fg}${5}"
+  [[ -n "$5" ]] && echo -n "${foreground}${5}"
   echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS}"
 
-  CURRENT_BG="$(getColorCode ${3})"
+  CURRENT_BG="${backgroundColor}"
   last_left_element_index=$current_index
 }
 
@@ -203,25 +212,34 @@ CURRENT_RIGHT_BG='NONE'
 set_default last_right_element_index 1
 set_default POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS " "
 right_prompt_segment() {
+  local segment_name="${1}"
   local current_index=$2
 
   # Check if the segment should be joined with the previous one
   local joined
   segmentShouldBeJoined $current_index $last_right_element_index "$POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS" && joined=true || joined=false
 
+  # Colors
+  local backgroundColor="${3}"
+  local foregroundColor="${4}"
+
   # Overwrite given background-color by user defined variable for this segment.
-  local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_BACKGROUND
+  local BACKGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)${segment_name}#prompt_}_BACKGROUND
   local BG_COLOR_MODIFIER=${(P)BACKGROUND_USER_VARIABLE}
-  [[ -n $BG_COLOR_MODIFIER ]] && 3="$BG_COLOR_MODIFIER"
+  [[ -n $BG_COLOR_MODIFIER ]] && backgroundColor="$BG_COLOR_MODIFIER"
 
   # Overwrite given foreground-color by user defined variable for this segment.
-  local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)1#prompt_}_FOREGROUND
+  local FOREGROUND_USER_VARIABLE=POWERLEVEL9K_${(U)${segment_name}#prompt_}_FOREGROUND
   local FG_COLOR_MODIFIER=${(P)FOREGROUND_USER_VARIABLE}
   [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
-  local bg fg
-  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="%k"
-  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="%f"
+  # Get color codes here to save some calls later on
+  backgroundColor="$(getColorCode ${backgroundColor})"
+  foregroundColor="$(getColorCode ${foregroundColor})"
+
+  local background foreground
+  [[ -n "${backgroundColor}" ]] && background="$(backgroundColor ${backgroundColor})" || background="%k"
+  [[ -n "${foregroundColor}" ]] && foreground="$(foregroundColor ${foregroundColor})" || foreground="%f"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
 
@@ -231,17 +249,17 @@ right_prompt_segment() {
   fi
 
   if [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]]; then
-    if isSameColor "$CURRENT_RIGHT_BG" "$3"; then
+    if isSameColor "$CURRENT_RIGHT_BG" "${backgroundColor}"; then
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment (or the default color). This should have
       # enough contrast.
       local complement
-      [[ -n "$4" ]] && complement="$fg" || complement="$(foregroundColor $DEFAULT_COLOR)"
+      [[ -n "${foregroundColor}" ]] && complement="${foreground}" || complement="$(foregroundColor $DEFAULT_COLOR)"
       echo -n "$complement$(print_icon 'RIGHT_SUBSEGMENT_SEPARATOR')%f"
     else
-      # Use the new BG color for the foreground with separator
-      echo -n "$(foregroundColor $3)$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f"
+      # Use the new Background Color as the foreground of the segment separator
+      echo -n "$(foregroundColor ${backgroundColor})$(print_icon 'RIGHT_SEGMENT_SEPARATOR')%f"
     fi
   fi
 
@@ -254,13 +272,13 @@ right_prompt_segment() {
       # we need to color both the visual identifier and the whitespace.
       [[ -n "$5" ]] && visual_identifier=" $visual_identifier"
       # Allow users to overwrite the color for the visual identifier only.
-      local visual_identifier_color_variable=POWERLEVEL9K_${(U)1#prompt_}_VISUAL_IDENTIFIER_COLOR
-      set_default $visual_identifier_color_variable $4
+      local visual_identifier_color_variable=POWERLEVEL9K_${(U)${segment_name}#prompt_}_VISUAL_IDENTIFIER_COLOR
+      set_default $visual_identifier_color_variable "${foregroundColor}"
       visual_identifier="%F{${(P)visual_identifier_color_variable}%}$visual_identifier%f"
     fi
   fi
 
-  echo -n "${bg}${fg}"
+  echo -n "${background}${foreground}"
 
   # Print whitespace only if segment is not joined or first right segment
   [[ $joined == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
@@ -270,7 +288,7 @@ right_prompt_segment() {
   # Print the visual identifier
   echo -n "${visual_identifier}"
 
-  CURRENT_RIGHT_BG=$3
+  CURRENT_RIGHT_BG="${backgroundColor}"
   last_right_element_index=$current_index
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -127,8 +127,8 @@ left_prompt_segment() {
   [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="$(backgroundColor)"
-  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="$(foregroundColor)"
+  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="%k"
+  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="%f"
 
   if [[ $CURRENT_BG != 'NONE' ]] && ! isSameColor "$3" "$CURRENT_BG"; then
     echo -n "$bg%F{$CURRENT_BG}"
@@ -220,8 +220,8 @@ right_prompt_segment() {
   [[ -n $FG_COLOR_MODIFIER ]] && 4="$FG_COLOR_MODIFIER"
 
   local bg fg
-  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="$(backgroundColor)"
-  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="$(foregroundColor)"
+  [[ -n "$3" ]] && bg="$(backgroundColor $3)" || bg="%k"
+  [[ -n "$4" ]] && fg="$(foregroundColor $4)" || fg="%f"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
 

--- a/test/functions/colors.spec
+++ b/test/functions/colors.spec
@@ -30,8 +30,8 @@ function testIsSameColorComparesAnsiBackgroundAndNumericalColorCorrectly() {
   assertTrue "isSameColor 'bg-green' '002'"
 }
 
-function testIsSameColorComparesNumericalBackgroundAndNumericalColorCorrectly() {
-  assertTrue "isSameColor '010' '2'"
+function testIsSameColorComparesShortCodesCorrectly() {
+  assertTrue "isSameColor '002' '2'"
 }
 
 function testIsSameColorDoesNotYieldNotEqualColorsTruthy() {

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -65,7 +65,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{012} %F{green%}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{002}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -86,7 +86,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{011} %F{green%}icon-here %f%F{009}/tmp %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{011} %F{002}icon-here %f%F{009}/tmp %k%F{011}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -106,7 +106,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{012} %F{000%}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_FOLDER_ICON

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -20,7 +20,7 @@ function testJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
   cd /tmp
 
-  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black}%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000}%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   cd -
@@ -30,7 +30,7 @@ function testTransitiveJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
   cd /tmp
 
-  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black}%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000}%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   cd -
@@ -40,7 +40,7 @@ function testJoiningWithConditionalSegment() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
   cd /tmp
 
-  assertEquals "%K{blue} %F{black}/tmp %K{blue}%F{black} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   cd -
@@ -51,7 +51,7 @@ function testDynamicColoringOfSegmentsWork() {
   POWERLEVEL9K_DIR_DEFAULT_BACKGROUND='red'
   cd /tmp
 
-  assertEquals "%K{red} %F{black}/tmp %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{000}/tmp %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_BACKGROUND
@@ -65,7 +65,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{blue} %F{green%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{green%}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -86,7 +86,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{yellow} %F{green%}icon-here %f%F{red}/tmp %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{011} %F{green%}icon-here %f%F{009}/tmp %k%F{011}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_DEFAULT_VISUAL_IDENTIFIER_COLOR
@@ -106,7 +106,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{blue} %F{black%}icon-here %f%F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_DIR_FOLDER_ICON
@@ -123,7 +123,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 
   powerlevel9k_prepare_prompts
-  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[47m [30mworld [49m[37m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[37m[39m[47m[30m rworld[K[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
+  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[107m [30mworld [49m[97m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[97m[39m[107m[30m rworld[K[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
 
   unset POWERLEVEL9K_PROMPT_ON_NEWLINE
   unset POWERLEVEL9K_RPROMPT_ON_NEWLINE

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -16,7 +16,7 @@ function testCommandExecutionTimeIsNotShownIfTimeIsBelowThreshold() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   _P9K_COMMAND_DURATION=2
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
@@ -28,7 +28,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}2.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}2.03 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -40,7 +40,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}0.03 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}0.03 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -53,7 +53,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=4
   _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}0.0001 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}0.0001 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -66,7 +66,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=0
   _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}23 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}23 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -77,7 +77,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}03:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}03:00 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -87,7 +87,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{red} %F{yellow1%}Dur %f%F{yellow1}02:00:00 %k%F{red}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226%}Dur %f%F{226}02:00:00 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -28,7 +28,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}2.03 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}2.03 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -40,7 +40,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}0.03 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}0.03 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -53,7 +53,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=4
   _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}0.0001 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}0.0001 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -66,7 +66,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION=0
   _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}23 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}23 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -77,7 +77,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}03:00 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}03:00 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION
@@ -87,7 +87,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{009} %F{226%}Dur %f%F{226}02:00:00 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{226}Dur %f%F{226}02:00:00 %k%F{009}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset _P9K_COMMAND_DURATION

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -329,7 +329,7 @@ function testHomeFolderDetectionWorks() {
   POWERLEVEL9K_HOME_ICON='home-icon'
 
   cd ~
-  assertEquals "%K{012} %F{000%}home-icon %f%F{000}~ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}home-icon %f%F{000}~ %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_HOME_ICON
@@ -341,7 +341,7 @@ function testHomeSubfolderDetectionWorks() {
   FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{012} %F{000%}sub-icon %f%F{000}~/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}sub-icon %f%F{000}~/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -355,7 +355,7 @@ function testOtherFolderDetectionWorks() {
   FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -407,7 +407,7 @@ function testOmittingFirstCharacterWorks() {
   POWERLEVEL9K_FOLDER_ICON='folder-icon'
   cd /tmp
 
-  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}folder-icon %f%F{000}tmp %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_FOLDER_ICON
@@ -421,7 +421,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -22,7 +22,7 @@ function testDirPathAbsoluteWorks() {
   POWERLEVEL9K_DIR_PATH_ABSOLUTE=true
 
   cd ~
-  assertEquals "%K{blue} %F{black}/home/travis %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/home/travis %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_ABSOLUTE
@@ -36,7 +36,7 @@ function testTruncateFoldersWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}…/12345678/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}…/12345678/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -57,7 +57,7 @@ function testTruncateFolderWithHomeDirWorks() {
   # Switch back to home folder as this causes the problem.
   cd ..
 
-  assertEquals "%K{blue} %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}~ %k%F{012}%f " "$(build_left_prompt)"
 
   rmdir $FOLDER
   cd ${CURRENT_DIR}
@@ -75,7 +75,7 @@ function testTruncateMiddleWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}/tmp/po…st/1/12/123/1234/12…45/12…56/12…67/12…78/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/po…st/1/12/123/1234/12…45/12…56/12…67/12…78/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -93,7 +93,7 @@ function testTruncationFromRightWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -111,7 +111,7 @@ function testTruncateToLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -129,7 +129,7 @@ function testTruncateToFirstAndLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -147,7 +147,7 @@ function testTruncateAbsoluteWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}…89 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}…89 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -166,7 +166,7 @@ function testTruncationFromRightWithEmptyDelimiter() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}/tmp/po/1/12/123/12/12/12/12/12/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/po/1/12/123/12/12/12/12/12/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -187,7 +187,7 @@ function testTruncateWithFolderMarkerWorks() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{blue} %F{black}/…/12/123/1234/12345/123456/1234567 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -208,7 +208,7 @@ function testTruncateWithFolderMarkerWithChangedFolderMarker() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.xxx
   cd $FOLDER
-  assertEquals "%K{blue} %F{black}/…/12/123/1234/12345/123456/1234567 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -241,7 +241,7 @@ function testTruncateWithPackageNameWorks() {
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_with_package_name'
 
-  assertEquals "%K{blue} %F{black}My_Package/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}My_Package/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{012}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -280,7 +280,7 @@ function testTruncateWithPackageNameIfRepoIsSymlinkedInsideDeepFolder() {
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_with_package_name'
 
-  assertEquals "%K{blue} %F{black}My_Package/as…/qwerqwer %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}My_Package/as…/qwerqwer %k%F{012}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -315,7 +315,7 @@ function testTruncateWithPackageNameIfRepoIsSymlinkedInsideGitDir() {
   POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
   POWERLEVEL9K_SHORTEN_STRATEGY='truncate_with_package_name'
 
-  assertEquals "%K{blue} %F{black}My_Package/.g…/re…/heads %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}My_Package/.g…/re…/heads %k%F{012}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -329,7 +329,7 @@ function testHomeFolderDetectionWorks() {
   POWERLEVEL9K_HOME_ICON='home-icon'
 
   cd ~
-  assertEquals "%K{blue} %F{black%}home-icon %f%F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}home-icon %f%F{000}~ %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_HOME_ICON
@@ -341,7 +341,7 @@ function testHomeSubfolderDetectionWorks() {
   FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}sub-icon %f%F{black}~/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}sub-icon %f%F{000}~/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -355,7 +355,7 @@ function testOtherFolderDetectionWorks() {
   FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}/tmp/powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -369,7 +369,7 @@ function testChangingDirPathSeparator() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{blue} %F{black}xXxtmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}xXxtmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset FOLDER
@@ -384,20 +384,20 @@ function testHomeFolderAbbreviation() {
   cd ~/
   # default
   POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='~'
-  assertEquals "%K{blue} %F{black}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}~ %k%F{012}%f " "$(build_left_prompt)"
 
   # substituted
   POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
-  assertEquals "%K{blue} %F{black}qQq %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}qQq %k%F{012}%f " "$(build_left_prompt)"
 
   cd /tmp
   # default
   POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='~'
-  assertEquals "%K{blue} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   # substituted
   POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
-  assertEquals "%K{blue} %F{black}/tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
 
   cd "$dir"
 }
@@ -407,7 +407,7 @@ function testOmittingFirstCharacterWorks() {
   POWERLEVEL9K_FOLDER_ICON='folder-icon'
   cd /tmp
 
-  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}tmp %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_FOLDER_ICON
@@ -421,7 +421,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black%}folder-icon %f%F{black}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000%}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -445,7 +445,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndDefaultTrunc
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black}xXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}xXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -463,7 +463,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndMiddleTrunca
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black}tmpxXxpo…stxXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}tmpxXxpo…stxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -481,7 +481,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndRightTruncat
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{blue} %F{black}tmpxXxpo…xXx1xXx2 %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}tmpxXxpo…xXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -502,7 +502,7 @@ function testTruncateToUniqueWorks() {
   mkdir -p /tmp/powerlevel9k-test/bob/docs
   cd /tmp/powerlevel9k-test/alice/devl
 
-  assertEquals "%K{blue} %F{black}txXxpxXxalxXxde %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}txXxpxXxalxXxde %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -516,7 +516,7 @@ function testBoldHomeDirWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD=true
   cd ~
 
-  assertEquals "%K{blue} %F{black}%B~%b %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}%B~%b %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD
@@ -527,7 +527,7 @@ function testBoldHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}~/%Bpowerlevel9k-test%b %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}~/%Bpowerlevel9k-test%b %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -538,7 +538,7 @@ function testBoldRootDirWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD=true
   cd /
 
-  assertEquals "%K{blue} %F{black}%B/%b %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}%B/%b %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD
@@ -548,7 +548,7 @@ function testBoldRootSubdirWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD=true
   cd /tmp
 
-  assertEquals "%K{blue} %F{black}/%Btmp%b %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/%Btmp%b %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_BOLD
@@ -559,7 +559,7 @@ function testBoldRootSubSubdirWorks() {
   mkdir -p /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}/tmp/%Bpowerlevel9k-test%b %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/%Bpowerlevel9k-test%b %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -570,7 +570,7 @@ function testHighlightHomeWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND='red'
   cd ~
 
-  assertEquals "%K{blue} %F{black}%F{red}~ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}%F{red}~ %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND
@@ -581,7 +581,7 @@ function testHighlightHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}~/%F{red}powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}~/%F{red}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -592,7 +592,7 @@ function testHighlightRootWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND='red'
   cd /
 
-  assertEquals "%K{blue} %F{black}%F{red}/ %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}%F{red}/ %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND
@@ -602,7 +602,7 @@ function testHighlightRootSubdirWorks() {
   POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND='red'
   cd /tmp
 
-  assertEquals "%K{blue} %F{black}/%F{red}tmp %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/%F{red}tmp %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   unset POWERLEVEL9K_DIR_PATH_HIGHLIGHT_FOREGROUND
@@ -613,7 +613,7 @@ function testHighlightRootSubSubdirWorks() {
   mkdir /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}/tmp/%F{red}powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}/tmp/%F{red}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -625,7 +625,7 @@ function testDirSeparatorColorHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}~%F{red}/%F{black}powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}~%F{red}/%F{black}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -637,7 +637,7 @@ function testDirSeparatorColorRootSubSubdirWorks() {
   mkdir -p /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{blue} %F{black}%F{red}/%F{black}tmp%F{red}/%F{black}powerlevel9k-test %k%F{blue}%f " "$(build_left_prompt)"
+  assertEquals "%K{012} %F{000}%F{red}/%F{black}tmp%F{red}/%F{black}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -40,7 +40,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{green} %F{grey93%} %f%F{grey93}go1.5.3 %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{255%} %f%F{255}go1.5.3 %k%F{002}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_GO_ICON
   unset PWD
@@ -53,7 +53,7 @@ function testGoSegmentPrintsNothingIfEmptyGopath() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
@@ -65,7 +65,7 @@ function testGoSegmentPrintsNothingIfNotInGopath() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
@@ -76,7 +76,7 @@ function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -40,7 +40,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{002} %F{255%} %f%F{255}go1.5.3 %k%F{002}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{255} %f%F{255}go1.5.3 %k%F{002}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_GO_ICON
   unset PWD

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -69,7 +69,7 @@ function testKubeContext() {
   alias kubectl=mockKubectl
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/default %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{013} %F{015%}⎈ %f%F{015}minikube/default %k%F{013}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -78,7 +78,7 @@ function testKubeContextOtherNamespace() {
   alias kubectl=mockKubectlOtherNamespace
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{magenta} %F{white%}⎈ %f%F{white}minikube/kube-system %k%F{magenta}%f " "$(build_left_prompt)"
+  assertEquals "%K{013} %F{015%}⎈ %f%F{015}minikube/kube-system %k%F{013}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -88,7 +88,7 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world kubecontext)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -69,7 +69,7 @@ function testKubeContext() {
   alias kubectl=mockKubectl
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{013} %F{015%}⎈ %f%F{015}minikube/default %k%F{013}%f " "$(build_left_prompt)"
+  assertEquals "%K{013} %F{015}⎈ %f%F{015}minikube/default %k%F{013}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -78,7 +78,7 @@ function testKubeContextOtherNamespace() {
   alias kubectl=mockKubectlOtherNamespace
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{013} %F{015%}⎈ %f%F{015}minikube/kube-system %k%F{013}%f " "$(build_left_prompt)"
+  assertEquals "%K{013} %F{015}⎈ %f%F{015}minikube/kube-system %k%F{013}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -31,7 +31,7 @@ function testLaravelVersionSegment() {
   POWERLEVEL9K_LARAVEL_ICON='x'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
 
-  assertEquals "%K{001} %F{015%}x %f%F{015}5.4.23 %k%F{001}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{015}x %f%F{015}5.4.23 %k%F{001}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_LARAVEL_ICON

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -31,7 +31,7 @@ function testLaravelVersionSegment() {
   POWERLEVEL9K_LARAVEL_ICON='x'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
 
-  assertEquals "%K{001} %F{white%}x %f%F{white}5.4.23 %k%F{maroon}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{015%}x %f%F{015}5.4.23 %k%F{001}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_LARAVEL_ICON
@@ -44,7 +44,7 @@ function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
   POWERLEVEL9K_LARAVEL_ICON='x'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_LARAVEL_ICON
@@ -58,7 +58,7 @@ function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   POWERLEVEL9K_LARAVEL_ICON='x'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_LARAVEL_ICON

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -32,7 +32,7 @@ function testRust() {
   mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{000%}Rust %f%F{000}0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{000}Rust %f%F{000}0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
 }

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -32,7 +32,7 @@ function testRust() {
   mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{black%}Rust %f%F{black}0.4.1a-alpha %k%F{darkorange}%f " "$(build_left_prompt)"
+  assertEquals "%K{208} %F{000%}Rust %f%F{000}0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
 }
@@ -41,7 +41,7 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
 
-  assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -31,7 +31,7 @@ function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
     local POWERLEVEL9K_STATUS_HIDE_SIGNAME=true
     local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
 
-    assertEquals "%K{000} %F{002%}✔%f %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{002}✔%f %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testStatusInGeneralErrorCase() {
@@ -40,7 +40,7 @@ function testStatusInGeneralErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
 
-    assertEquals "%K{009} %F{226%}↵ %f%F{226}1 %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226}↵ %f%F{226}1 %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testPipestatusInErrorCase() {
@@ -50,7 +50,7 @@ function testPipestatusInErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=true
 
-    assertEquals "%K{009} %F{226%}↵ %f%F{226}0|0|1|0 %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226}↵ %f%F{226}0|0|1|0 %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testStatusCrossWinsOverVerbose() {
@@ -60,7 +60,7 @@ function testStatusCrossWinsOverVerbose() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_CROSS=true
 
-    assertEquals "%K{000} %F{009%}✘%f %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{009}✘%f %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testStatusShowsSignalNameInErrorCase() {
@@ -70,7 +70,7 @@ function testStatusShowsSignalNameInErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_HIDE_SIGNAME=false
 
-    assertEquals "%K{009} %F{226%}↵ %f%F{226}SIGILL(4) %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226}↵ %f%F{226}SIGILL(4) %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testStatusSegmentIntegrated() {
@@ -79,7 +79,7 @@ function testStatusSegmentIntegrated() {
 
     false; powerlevel9k_prepare_prompts
 
-    assertEquals "%f%b%k%K{000} %F{009%}✘%f %k%F{000}%f " "${(e)PROMPT}"
+    assertEquals "%f%b%k%K{000} %F{009}✘%f %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/source/2.1/src/shunit2

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -22,7 +22,7 @@ function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
     local POWERLEVEL9K_STATUS_VERBOSE=false
     local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
 
-    assertEquals "%K{white} %F{black}world %k%F{white}%f " "$(build_left_prompt)"
+    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
 }
 
 function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
@@ -31,7 +31,7 @@ function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
     local POWERLEVEL9K_STATUS_HIDE_SIGNAME=true
     local POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(status)
 
-    assertEquals "%K{black} %F{green%}✔%f %k%F{black}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{002%}✔%f %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testStatusInGeneralErrorCase() {
@@ -40,7 +40,7 @@ function testStatusInGeneralErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=false
 
-    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}1 %k%F{red}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226%}↵ %f%F{226}1 %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testPipestatusInErrorCase() {
@@ -50,7 +50,7 @@ function testPipestatusInErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_SHOW_PIPESTATUS=true
 
-    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}0|0|1|0 %k%F{red}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226%}↵ %f%F{226}0|0|1|0 %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testStatusCrossWinsOverVerbose() {
@@ -60,7 +60,7 @@ function testStatusCrossWinsOverVerbose() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_CROSS=true
 
-    assertEquals "%K{black} %F{red%}✘%f %k%F{black}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{009%}✘%f %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testStatusShowsSignalNameInErrorCase() {
@@ -70,7 +70,7 @@ function testStatusShowsSignalNameInErrorCase() {
     local POWERLEVEL9K_STATUS_VERBOSE=true
     local POWERLEVEL9K_STATUS_HIDE_SIGNAME=false
 
-    assertEquals "%K{red} %F{yellow1%}↵ %f%F{yellow1}SIGILL(4) %k%F{red}%f " "$(build_left_prompt)"
+    assertEquals "%K{009} %F{226%}↵ %f%F{226}SIGILL(4) %k%F{009}%f " "$(build_left_prompt)"
 }
 
 function testStatusSegmentIntegrated() {
@@ -79,7 +79,7 @@ function testStatusSegmentIntegrated() {
 
     false; powerlevel9k_prepare_prompts
 
-    assertEquals "%f%b%k%K{black} %F{red%}✘%f %k%F{black}%f " "${(e)PROMPT}"
+    assertEquals "%f%b%k%K{000} %F{009%}✘%f %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/source/2.1/src/shunit2

--- a/test/segments/vcs.spec
+++ b/test/segments/vcs.spec
@@ -21,7 +21,7 @@ function testColorOverridingForCleanStateWorks() {
   cd $FOLDER
   git init 1>/dev/null
 
-  assertEquals "%K{white} %F{cyan} master %k%F{white}%f " "$(build_left_prompt)"
+  assertEquals "%K{015} %F{014} master %k%F{015}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -47,7 +47,7 @@ function testColorOverridingForModifiedStateWorks() {
   git commit -m "test" 1>/dev/null
   echo "test" > testfile
 
-  assertEquals "%K{yellow} %F{red} master ● %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{011} %F{009} master ● %k%F{011}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -68,7 +68,7 @@ function testColorOverridingForUntrackedStateWorks() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{yellow} %F{cyan} master ? %k%F{yellow}%f " "$(build_left_prompt)"
+  assertEquals "%K{011} %F{014} master ? %k%F{011}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -90,10 +90,10 @@ function testBranchNameTruncatingShortenLength() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} master ? %k%F{002}%f " "$(build_left_prompt)"
 
   POWERLEVEL9K_VCS_SHORTEN_LENGTH=3
-  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} mas… ? %k%F{002}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -116,11 +116,11 @@ function testBranchNameTruncatingMinLength() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} master ? %k%F{002}%f " "$(build_left_prompt)"
 
   POWERLEVEL9K_VCS_SHORTEN_MIN_LENGTH=7
 
-  assertEquals "%K{green} %F{black} master ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} master ? %k%F{002}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -143,11 +143,11 @@ function testBranchNameTruncatingShortenStrategy() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{green} %F{black} mas… ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} mas… ? %k%F{002}%f " "$(build_left_prompt)"
 
   POWERLEVEL9K_VCS_SHORTEN_STRATEGY="truncate_middle"
 
-  assertEquals "%K{green} %F{black} mas…ter ? %k%F{green}%f " "$(build_left_prompt)"
+  assertEquals "%K{002} %F{000} mas…ter ? %k%F{002}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test


### PR DESCRIPTION
Added magenta and cyan that were only present with their alternative
names (fuchsia and aqua). See [here](https://en.wikipedia.org/wiki/X11_color_names#Clashes_between_web_and_X11_colors_in_the_CSS_color_scheme).

This fixes #921 

@vaskark could you checkout this PR and see if that helps?
Disclaimer: 
By the help of the wikipedia article, I just found `cyan` and `magenta` to have problems. Please post here, if you found other colors that do not work as intended.

For everyone to test:
You need to set a background color for a segment that is unknown to our internal colors array. If that happens, the segment separator to the next segment shows up in black. This is how you know that this color is unknown.
