### PR TITLE
[Enhancement] Fixed Konsole stashes display

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -108,7 +108,11 @@ function +vi-git-stash() {
 
   if [[ -s $(command git rev-parse --git-dir)/refs/stash ]] ; then
     stashes=$(command git stash list 2>/dev/null | wc -l)
-    hook_com[misc]+=" $(print_icon 'VCS_STASH_ICON')${stashes// /}"
+    if [ -n "${KONSOLE_PROFILE_NAME}" ] ; then
+      hook_com[misc]+=" $(print_icon 'VCS_STASH_ICON')${stashes// /} "
+    else
+      hook_com[misc]+=" $(print_icon 'VCS_STASH_ICON')${stashes// /}"
+    fi
   fi
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1634,7 +1634,11 @@ prompt_pyenv() {
     "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
   elif [ $commands[pyenv] ]; then
     local pyenv_version_name="$(pyenv version-name)"
-    local pyenv_global="$(pyenv version-file-read $(pyenv root)/version)"
+    local pyenv_global="system"
+    local pyenv_root="$(pyenv root)"
+    if [[ -f "${pyenv_root}/version" ]]; then
+      pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
+    fi
     if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$pyenv_version_name" 'PYTHON_ICON'
     fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1130,11 +1130,10 @@ prompt_vpn_ip() {
 ################################################################
 # Segment to display laravel version
 prompt_laravel_version() {
-  local laravel_version="$(php artisan --version 2>/dev/null)"
-  if [[ -n "${laravel_version}" ]]; then
-    # Remove unrelevant infos
-    laravel_version="${laravel_version//Laravel Framework version /}"
-
+  local laravel_version="$(php artisan --version 2> /dev/null)"
+  if [[ -n "${laravel_version}" && "${laravel_version}" =~ "Laravel Framework" ]]; then
+    # Strip out everything but the version
+    laravel_version="${laravel_version//Laravel Framework /}"
     "$1_prompt_segment" "$0" "$2" "maroon" "white" "${laravel_version}" 'LARAVEL_ICON'
   fi
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -745,6 +745,31 @@ prompt_command_execution_time() {
 }
 
 ################################################################
+# Determine the unique path - this is needed for the
+# truncate_to_unique strategy.
+#
+function getUniqueFolder() {
+  local trunc_path directory test_dir test_dir_length
+  local -a matching
+  local -a paths
+  local cur_path='/'
+  paths=(${(s:/:)1})
+  for directory in ${paths[@]}; do
+    test_dir=''
+    for (( i=0; i < ${#directory}; i++ )); do
+      test_dir+="${directory:$i:1}"
+      matching=("$cur_path"/"$test_dir"*/)
+      if [[ ${#matching[@]} -eq 1 ]]; then
+        break
+      fi
+    done
+    trunc_path+="$test_dir/"
+    cur_path+="$directory/"
+  done
+  echo "${trunc_path: : -1}"
+}
+
+################################################################
 # Dir: current working directory
 # Parameters:
 #   * $1 Alignment: string - left|right
@@ -811,23 +836,10 @@ prompt_dir() {
         # for each parent path component find the shortest unique beginning
         # characters sequence. Source: https://stackoverflow.com/a/45336078
         if (( ${#current_path} > 1 )); then # root and home are exceptions and won't have paths
-          local matching
-          local cur_path='/'
-          [[ $current_path != "~"* ]] && trunc_path='/' || trunc_path=''
-          for directory in ${paths[@]}; do
-            test_dir=''
-            for (( i=0; i<${#directory}; i++ )); do
-              test_dir+="${directory:$i:1}"
-              matching=("$cur_path"/"$test_dir"*/)
-              if [[ ${#matching[@]} -eq 1 ]]; then
-                break
-              fi
-            done
-            trunc_path+="$test_dir/"
-            cur_path+="$directory/"
-          done
-          [[ $current_path == "~"* ]] && trunc_path="~/$trunc_path"
-          current_path="${trunc_path: : -1}"
+          # cheating here to retain ~ as home folder
+          local home_path="$(getUniqueFolder $HOME)"
+          trunc_path="$(getUniqueFolder $PWD)"
+          [[ $current_path == "~"* ]] && current_path="~${trunc_path//${home_path}/}" || current_path="/${trunc_path}"
         fi
       ;;
       truncate_with_folder_marker)

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -14,16 +14,17 @@ function setUp() {
 function mockLaravelVersion() {
   case "$1" in
     "artisan")
-      echo "Laravel Framework version 5.4.23"
+      # artisan --version follows the format Laravel Framework <version>
+      echo "Laravel Framework 5.4.23"
       ;;
     default)
   esac
 }
 
 function mockNoLaravelVersion() {
-  # This should output some error
-  >&2 echo "Artisan not available"
-  return 1
+  # When php can't find a file it will output a message
+  echo "Could not open input file: artisan"
+  return 0
 }
 
 function testLaravelVersionSegment() {


### PR DESCRIPTION
I faced this problem while using p9k in Konsole. As you can see the number of stashed changes was cut off due to well known konsole glyphs problems.
![problem](https://user-images.githubusercontent.com/24912818/43215947-dd12751a-903d-11e8-9231-e21315a4d77b.png)
After this fix it is displayed correctly
![fixed](https://user-images.githubusercontent.com/24912818/43216017-08e68884-903e-11e8-82ad-12d8fee75ebd.png)

Fix description is in the commit and is really straightforward. Please test it as I haven't on other systems but I believe everything should be ok.