### PR TITLE
Fixes background reset for ending separator

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -40,7 +40,7 @@ function getColor() {
     local default="$'\033'\[49m"
     # http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html
     local quoted=$(printf "%q" $(print -P "$named"))
-    if [[ $quoted = "$'\033'\[49m" && $1 != "black" ]]; then
+    if [[ $quoted = "$'\033'\[49m" && $1 != "black" && $1 != "NONE" ]]; then
         # color not found, so try to get the code
         1=$(getColorCode $1)
     fi


### PR DESCRIPTION
#### Title
Fixes a bug that leads to a black background for the seperator
 - [Bugfix]
 
#### Description
The default was to reset to black at the end of the seperator instead of clear
As far as I can tell commit 4d18fdc6e9252a5d93ab9e046b3d98421d1be715 introduced this bug.
Before:
![image](https://user-images.githubusercontent.com/16988672/43284269-9213ee0c-911b-11e8-9dbe-ff8235a0967c.png)
After:
![image](https://user-images.githubusercontent.com/16988672/43284275-992bac02-911b-11e8-99a7-5ba0794b4250.png)
