### PR TITLE
Bugfix: Don't show remote branch if ambiguous due to tag

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -70,7 +70,7 @@ function +vi-git-remotebranch() {
     # Always show the remote
     #if [[ -n ${remote} ]] ; then
     # Only show the remote if it differs from the local
-    if [[ -n ${remote} ]] && [[ "${remote#*/}" != "${branch_name}" ]] ; then
+    if [[ -n ${remote} ]] && [[ "${remote#*/}" != "${branch_name#heads/}" ]] ; then
         hook_com[branch]+="$(print_icon 'VCS_REMOTE_BRANCH_ICON')${remote// /}"
     fi
 }


### PR DESCRIPTION
If there is a tag with the same name as the remote branch, `git symbolic-ref --short HEAD` will display `heads/$branchname` instead of a simple `$branchname`.

This patch will drop the `heads/` from the tracking branch check.


