### PR TITLE
[Enhancement] Add custom path option for disk_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,13 +462,14 @@ You can also color the separator separately by setting the color using `POWERLEV
 
 ##### disk_usage
 
-The `disk_usage` segment will show the usage level of the partition that your current working directory resides in. It can be configured with the following variables.
+The `disk_usage` segment will show the usage level of the partition that your current working directory (or a directory of your choice) resides in. It can be configured with the following variables.
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |POWERLEVEL9K_DISK_USAGE_ONLY_WARNING|false|Hide the segment except when usage levels have hit warning or critical levels.|
 |POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL|90|The usage level that triggers a warning state.|
 |POWERLEVEL9K_DISK_USAGE_CRITICAL_LEVEL|95|The usage level that triggers a critical state.|
+|POWERLEVEL9K_DISK_USAGE_PATH|`.` (working directory)|Set a path to use a fixed directory instead of the working directory.|
 
 ##### host
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -359,6 +359,7 @@ prompt_newline() {
 set_default POWERLEVEL9K_DISK_USAGE_ONLY_WARNING false
 set_default POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL 90
 set_default POWERLEVEL9K_DISK_USAGE_CRITICAL_LEVEL 95
+set_default POWERLEVEL9K_DISK_USAGE_PATH "."
 prompt_disk_usage() {
   local current_state="unknown"
   typeset -AH hdd_usage_forecolors
@@ -374,7 +375,7 @@ prompt_disk_usage() {
     'critical'      'red'
   )
 
-  local disk_usage="${$(\df -P . | sed -n '2p' | awk '{ print $5 }')%%\%}"
+  local disk_usage="${$(\df -P $POWERLEVEL9K_DISK_USAGE_PATH | sed -n '2p' | awk '{ print $5 }')%%\%}"
 
   if [ "$disk_usage" -ge "$POWERLEVEL9K_DISK_USAGE_WARNING_LEVEL" ]; then
     current_state='warning'


### PR DESCRIPTION
#### Description
This PR adds support for a custom path option to the `disk_usage` segment, and updates the readme accordingly.

New variable `POWERLEVEL9K_DISK_USAGE_PATH` defaults to current working directory, maintaining existing functionality, but can be set to a different path as required.

This is useful in server environments where the user may only care about the disk usage of a specific volume.
