### PR TITLE
[Discussion] Change bright colors to old version

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -11,23 +11,23 @@ typeset -gAh __P9K_COLORS
 # use color names by default to allow dark/light themes to adjust colors based on names
 __P9K_COLORS=(
   black 000
-  maroon 001
+  red 001
   green 002
-  olive 003
-  navy 004
-  purple 005
-  teal 006
-  silver 007
+  yellow 003
+  blue 004
+  magenta 005
+  cyan 006
+  white 007
   grey 008
-  red 009
+  maroon 009
   lime 010
-  yellow 011
-  blue 012
+  olive 011
+  navy 012
   fuchsia 013
-  magenta 013
+  purple 013
   aqua 014
-  cyan 014
-  white 015
+  teal 014
+  silver 015
   grey0 016
   navyblue 017
   darkblue 018

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -16,7 +16,7 @@ function testDynamicColoringOfSegmentsWork() {
   local POWERLEVEL9K_DATE_ICON="date-icon"
   local POWERLEVEL9K_DATE_BACKGROUND='red'
 
-  assertEquals "%K{009} %F{000}date-icon %f%F{000}%D{%d.%m.%y} %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{000}date-icon %f%F{000}%D{%d.%m.%y} %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testDynamicColoringOfVisualIdentifiersWork() {
@@ -24,7 +24,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
   local POWERLEVEL9K_DATE_ICON="date-icon"
   local POWERLEVEL9K_DATE_VISUAL_IDENTIFIER_COLOR='green'
 
-  assertEquals "%K{015} %F{002}date-icon %f%F{000}%D{%d.%m.%y} %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{002}date-icon %f%F{000}%D{%d.%m.%y} %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
@@ -34,7 +34,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
   local POWERLEVEL9K_DATE_FOREGROUND='red'
   local POWERLEVEL9K_DATE_BACKGROUND='yellow'
 
-  assertEquals "%K{011} %F{002}date-icon %f%F{009}%D{%d.%m.%y} %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{002}date-icon %f%F{001}%D{%d.%m.%y} %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testColorOverridingOfStatefulSegment() {
@@ -45,7 +45,7 @@ function testColorOverridingOfStatefulSegment() {
   # Provoke state
   local SSH_CLIENT="x"
 
-  assertEquals "%K{009} %F{002}ssh-icon %f%F{002}%m %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{002}ssh-icon %f%F{002}%m %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testColorOverridingOfCustomSegment() {
@@ -56,7 +56,7 @@ function testColorOverridingOfCustomSegment() {
   local POWERLEVEL9K_CUSTOM_WORLD_FOREGROUND='red'
   local POWERLEVEL9K_CUSTOM_WORLD_BACKGROUND='red'
 
-  assertEquals "%K{009} %F{002}CW %f%F{009}world %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{002}CW %f%F{001}world %k%F{001}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -21,7 +21,7 @@ function testLeftNormalSegmentsShouldNotBeJoined() {
   local POWERLEVEL9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD6="echo world6"
   
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000} %F{000}world2 %K{015}%F{000} %F{000}world4 %K{015}%F{000} %F{000}world6 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000} %F{000}world2 %K{007}%F{000} %F{000}world4 %K{007}%F{000} %F{000}world6 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftJoinedSegments() {
@@ -30,7 +30,7 @@ function testLeftJoinedSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD1="echo world1"
   local POWERLEVEL9K_CUSTOM_WORLD2="echo world2"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000}%F{000}world2 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000}%F{000}world2 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftTransitiveJoinedSegments() {
@@ -40,7 +40,7 @@ function testLeftTransitiveJoinedSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD2="echo world2"
   local POWERLEVEL9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000}%F{000}world2 %K{015}%F{000}%F{000}world3 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000}%F{000}world2 %K{007}%F{000}%F{000}world3 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
@@ -51,7 +51,7 @@ function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
   local POWERLEVEL9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000}%F{000}world2 %K{015}%F{000}%F{000}world4 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000}%F{000}world2 %K{007}%F{000}%F{000}world4 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithConditionalPredecessor() {
@@ -61,7 +61,7 @@ function testLeftPromotingSegmentWithConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000} %F{000}world3 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000} %F{000}world3 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
@@ -72,7 +72,7 @@ function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000} %F{000}world4 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000} %F{000}world4 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
@@ -85,7 +85,7 @@ function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%K{015} %F{000}world1 %K{015}%F{000} %F{000}world4 %K{015}%F{000}%F{000}world6 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %K{007}%F{000} %F{000}world4 %K{007}%F{000}%F{000}world6 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testLeftJoiningBuiltinSegmentWorks() {
@@ -108,7 +108,7 @@ function testRightNormalSegmentsShouldNotBeJoined() {
   local POWERLEVEL9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%F{000}%f%K{015}%F{000} world2 %f%F{000}%f%K{015}%F{000} world4 %f%F{000}%f%K{015}%F{000} world6%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%F{000}%f%K{007}%F{000} world2 %f%F{000}%f%K{007}%F{000} world4 %f%F{000}%f%K{007}%F{000} world6%E" "$(build_right_prompt)"
 }
 
 function testRightJoinedSegments() {
@@ -117,7 +117,7 @@ function testRightJoinedSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD1="echo world1"
   local POWERLEVEL9K_CUSTOM_WORLD2="echo world2"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%K{015}%F{000}world2%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%K{007}%F{000}world2%E" "$(build_right_prompt)"
 }
 
 function testRightTransitiveJoinedSegments() {
@@ -127,7 +127,7 @@ function testRightTransitiveJoinedSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD2="echo world2"
   local POWERLEVEL9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%K{015}%F{000}world2 %f%K{015}%F{000}world3%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%K{007}%F{000}world2 %f%K{007}%F{000}world3%E" "$(build_right_prompt)"
 }
 
 function testRightTransitiveJoiningWithConditionalJoinedSegment() {
@@ -138,7 +138,7 @@ function testRightTransitiveJoiningWithConditionalJoinedSegment() {
   local POWERLEVEL9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%K{015}%F{000}world2 %f%K{015}%F{000}world4%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%K{007}%F{000}world2 %f%K{007}%F{000}world4%E" "$(build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithConditionalPredecessor() {
@@ -148,7 +148,7 @@ function testRightPromotingSegmentWithConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%F{000}%f%K{015}%F{000} world3%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%F{000}%f%K{007}%F{000} world3%E" "$(build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
@@ -159,7 +159,7 @@ function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%F{000}%f%K{015}%F{000} world4%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%F{000}%f%K{007}%F{000} world4%E" "$(build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
@@ -172,7 +172,7 @@ function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local POWERLEVEL9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local POWERLEVEL9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1 %f%F{000}%f%K{015}%F{000} world4 %f%K{015}%F{000}world6%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1 %f%F{000}%f%K{007}%F{000} world4 %f%K{007}%F{000}world6%E" "$(build_right_prompt)"
 }
 
 function testRightJoiningBuiltinSegmentWorks() {

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -22,7 +22,7 @@ function testSegmentOnRightSide() {
     powerlevel9k_prepare_prompts
 
     local reset_attributes=$'\e[00m'
-    assertEquals "%f%b%k%F{015}%f%K{015}%F{000} world1 %f%F{000}%f%K{015}%F{000} world2%E%{${reset_attributes}%}" "${(e)RPROMPT}"
+    assertEquals "%f%b%k%F{007}%f%K{007}%F{000} world1 %f%F{000}%f%K{007}%F{000} world2%E%{${reset_attributes}%}" "${(e)RPROMPT}"
 }
 
 function testDisablingRightPrompt() {
@@ -48,7 +48,7 @@ function testLeftMultilinePrompt() {
     powerlevel9k_prepare_prompts
 
     local nl=$'\n'
-    assertEquals "╭─%f%b%k%K{015} %F{000}world1 %k%F{015}%f ${nl}╰─ " "${(e)PROMPT}"
+    assertEquals "╭─%f%b%k%K{007} %F{000}world1 %k%F{007}%f ${nl}╰─ " "${(e)PROMPT}"
 }
 
 function testRightPromptOnSameLine() {
@@ -70,7 +70,7 @@ function testRightPromptOnSameLine() {
     startSkipping
 
     powerlevel9k_prepare_prompts
-    assertEquals "%{\e[1A%}%F{015}%f%K{015}%F{000} world1 %f%{\e[1B%}" "${(e)RPROMPT}"
+    assertEquals "%{\e[1A%}%F{007}%f%K{007}%F{000} world1 %f%{\e[1B%}" "${(e)RPROMPT}"
 }
 
 function testPrefixingFirstLineOnLeftPrompt() {
@@ -84,7 +84,7 @@ function testPrefixingFirstLineOnLeftPrompt() {
     powerlevel9k_prepare_prompts
 
     local nl=$'\n'
-    assertEquals "XXX%f%b%k%K{015} %F{000}world1 %k%F{015}%f ${nl}╰─ " "${(e)PROMPT}"
+    assertEquals "XXX%f%b%k%K{007} %F{000}world1 %k%F{007}%f ${nl}╰─ " "${(e)PROMPT}"
 }
 
 function testPrefixingSecondLineOnLeftPrompt() {
@@ -98,7 +98,7 @@ function testPrefixingSecondLineOnLeftPrompt() {
     powerlevel9k_prepare_prompts
 
     local nl=$'\n'
-    assertEquals "╭─%f%b%k%K{015} %F{000}world1 %k%F{015}%f ${nl}XXX" "${(e)PROMPT}"
+    assertEquals "╭─%f%b%k%K{007} %F{000}world1 %k%F{007}%f ${nl}XXX" "${(e)PROMPT}"
 }
 
 source shunit2/shunit2

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -18,7 +18,7 @@ function testOverwritingIconsWork() {
   local POWERLEVEL9K_CUSTOM_WORLD1='echo world1'
   local POWERLEVEL9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %f%F{000}world1 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}icon-here %f%F{000}world1 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
@@ -27,7 +27,7 @@ function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD1='echo world1'
   local POWERLEVEL9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %f%F{000}world1 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}icon-here %f%F{000}world1 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
@@ -36,7 +36,7 @@ function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
   local POWERLEVEL9K_CUSTOM_WORLD1='echo world1'
   local POWERLEVEL9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%F{015}%f%K{015}%F{000} world1%F{000} icon-here%f%E" "$(build_right_prompt)"
+  assertEquals "%F{007}%f%K{007}%F{000} world1%F{000} icon-here%f%E" "$(build_right_prompt)"
 }
 
 function testVisualIdentifierPrintsNothingIfNotAvailable() {
@@ -44,7 +44,7 @@ function testVisualIdentifierPrintsNothingIfNotAvailable() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
   local POWERLEVEL9K_CUSTOM_WORLD1='echo world1'
 
-  assertEquals "%K{015} %F{000}world1 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world1 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testVisualIdentifierIsPrintedInNumericalColorCode() {
@@ -54,7 +54,7 @@ function testVisualIdentifierIsPrintedInNumericalColorCode() {
   local POWERLEVEL9K_CUSTOM_WORLD1_ICON="xxx"
   local POWERLEVEL9K_CUSTOM_WORLD1_VISUAL_IDENTIFIER_COLOR="purple3"
 
-  assertEquals "%K{015} %F{056}xxx %f%F{000}world1 %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{056}xxx %f%F{000}world1 %k%F{007}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/functions/colors.spec
+++ b/test/functions/colors.spec
@@ -59,9 +59,9 @@ function testBrightColorsWork() {
   # with normal ones. This code is now gone, and this test should
   # ensure that all input channels for bright colors are handled
   # correctly.
-  assertTrue "isSameColor 'cyan' '014'"
-  assertEquals '014' "$(getColorCode 'cyan')"
-  assertEquals '014' "$(getColor 'cyan')"
+  assertTrue "isSameColor 'cyan' '006'"
+  assertEquals '006' "$(getColorCode 'cyan')"
+  assertEquals '006' "$(getColor 'cyan')"
 }
 
 source shunit2/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -117,7 +117,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 
   powerlevel9k_prepare_prompts
-  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[107m [30mworld [49m[97m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[97m[39m[107m[30m rworld[K[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
+  assertEquals '$(print_icon MULTILINE_FIRST_PROMPT_PREFIX)[39m[0m[49m[47m [30mworld [49m[37m[39m  $(print_icon MULTILINE_LAST_PROMPT_PREFIX)[1A[39m[0m[49m[37m[39m[47m[30m rworld[K[00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
 }
 
 source shunit2/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -21,7 +21,7 @@ function testJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
   cd /tmp
 
-  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000}%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp %K{004}%F{000}%F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -31,7 +31,7 @@ function testTransitiveJoinedSegments() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
   cd /tmp
 
-  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000}%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp %K{004}%F{000}%F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -41,7 +41,7 @@ function testJoiningWithConditionalSegment() {
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
   cd /tmp
 
-  assertEquals "%K{012} %F{000}/tmp %K{012}%F{000} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp %K{004}%F{000} %F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -52,7 +52,7 @@ function testDynamicColoringOfSegmentsWork() {
   local POWERLEVEL9K_DIR_DEFAULT_BACKGROUND='red'
   cd /tmp
 
-  assertEquals "%K{009} %F{000}/tmp %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{000}/tmp %k%F{001}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -65,7 +65,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{012} %F{002}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{002}icon-here %f%F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -84,7 +84,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{011} %F{002}icon-here %f%F{009}/tmp %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{002}icon-here %f%F{001}/tmp %k%F{003}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -100,7 +100,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{012} %F{000}icon-here %f%F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here %f%F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   # rm -fr ~/$testFolder

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -21,7 +21,7 @@ function testAnacondaSegmentPrintsNothingIfNoAnacondaPathIsSet() {
     unset CONDA_ENV_PATH
     unset CONDA_PREFIX
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testAnacondaSegmentWorksIfOnlyAnacondaPathIsSet() {
@@ -35,7 +35,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPathIsSet() {
     CONDA_ENV_PATH=/tmp
     unset CONDA_PREFIX
 
-    assertEquals "%K{012} %F{000}icon-here %f%F{000}(tmp) %k%F{012}%f " "$(build_left_prompt)"
+    assertEquals "%K{004} %F{000}icon-here %f%F{000}(tmp) %k%F{004}%f " "$(build_left_prompt)"
 }
 
 function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
@@ -49,7 +49,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
     unset CONDA_ENV_PATH
     local CONDA_PREFIX="test"
 
-    assertEquals "%K{012} %F{000}icon-here %f%F{000}(test) %k%F{012}%f " "$(build_left_prompt)"
+    assertEquals "%K{004} %F{000}icon-here %f%F{000}(test) %k%F{004}%f " "$(build_left_prompt)"
 }
 
 function testAnacondaSegmentWorks() {
@@ -63,7 +63,7 @@ function testAnacondaSegmentWorks() {
     local CONDA_ENV_PATH=/tmp
     local CONDA_PREFIX="test"
 
-    assertEquals "%K{012} %F{000}icon-here %f%F{000}(tmptest) %k%F{012}%f " "$(build_left_prompt)"
+    assertEquals "%K{004} %F{000}icon-here %f%F{000}(tmptest) %k%F{004}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/aws_eb_env.spec
+++ b/test/segments/aws_eb_env.spec
@@ -17,7 +17,7 @@ function testAwsEbEnvSegmentPrintsNothingIfNoElasticBeanstalkEnvironmentIsSet() 
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testAwsEbEnvSegmentWorksIfElasticBeanstalkEnvironmentIsSet() {

--- a/test/segments/background_jobs.spec
+++ b/test/segments/background_jobs.spec
@@ -18,7 +18,7 @@ function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias jobs
 }
@@ -34,7 +34,7 @@ function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{014}⚙%f %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{006}⚙%f %k%F{000}%f " "$(build_left_prompt)"
 
     unfunction jobs
 }
@@ -52,7 +52,7 @@ function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{014}⚙%f %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{006}⚙%f %k%F{000}%f " "$(build_left_prompt)"
 
     unfunction jobs
 }
@@ -70,7 +70,7 @@ function testBackgroundJobsSegmentWithVerboseMode() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{014}⚙ %f%F{014}3 %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{006}⚙ %f%F{006}3 %k%F{000}%f " "$(build_left_prompt)"
 
     unfunction jobs
 }

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -69,7 +69,7 @@ function testBatterySegmentIfBatteryIsLowWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; discharging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{009}🔋 %f%F{009}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
@@ -77,7 +77,7 @@ function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; charging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{011}🔋 %f%F{011}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsAlmostFullWhileDischargingOnOSX() {
@@ -85,7 +85,7 @@ function testBatterySegmentIfBatteryIsAlmostFullWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; discharging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{007}🔋 %f%F{007}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsAlmostFullWhileChargingOnOSX() {
@@ -93,7 +93,7 @@ function testBatterySegmentIfBatteryIsAlmostFullWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; charging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{011}🔋 %f%F{011}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnOSX() {
@@ -109,35 +109,35 @@ function testBatterySegmentIfBatteryIsCalculatingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	99%; discharging; (no estimate) present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{007}🔋 %f%F{007}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnLinux() {
   local OS='Linux' # Fake Linux
   makeBatterySay "4" "Discharging"
 
-  assertEquals "%K{000} %F{009}🔋 %f%F{009}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnLinux() {
   local OS='Linux' # Fake Linux
   makeBatterySay "4" "Charging"
 
-  assertEquals "%K{000} %F{011}🔋 %f%F{011}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
   local OS='Linux' # Fake Linux
   makeBatterySay "10" "Discharging"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}10%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{007}🔋 %f%F{007}10%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnLinux() {
   local OS='Linux' # Fake Linux
   makeBatterySay "10" "Charging"
 
-  assertEquals "%K{000} %F{011}🔋 %f%F{011}10%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}10%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {
@@ -155,7 +155,7 @@ function testBatterySegmentIfBatteryIsNormalWithAcpiEnabledOnLinux() {
   # For running on Mac, we need to mock date :(
   [[ -f /usr/local/bin/gdate ]] && alias date=gdate
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}50%% (1:38) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{007}🔋 %f%F{007}50%% (1:38) " "$(prompt_battery left 1 false ${FOLDER})"
 
   unalias date &>/dev/null
   # unaliasing date fails where it was never aliased (e.g. on Linux).
@@ -171,7 +171,7 @@ function testBatterySegmentIfBatteryIsCalculatingWithAcpiEnabledOnLinux() {
   echo "echo 'Batter 0: Discharging, 50%, rate remaining'" > ${FOLDER}/usr/bin/acpi
   chmod +x ${FOLDER}/usr/bin/acpi
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}50%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{007}🔋 %f%F{007}50%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -20,7 +20,7 @@ function testCommandExecutionTimeIsNotShownIfTimeIsBelowThreshold() {
   # Override payload
   local _P9K_COMMAND_DURATION=2
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeChanged() {
@@ -34,7 +34,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   # Override payload
   local _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}2.03 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}2.03 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeSetToZero() {
@@ -43,7 +43,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   local POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   local _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}0.03 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}0.03 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeChanged() {
@@ -58,7 +58,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   # Override payload
   local _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}0.0001 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}0.0001 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeSetToZero() {
@@ -72,7 +72,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   # Override payload
   local _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}23 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}23 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() {
@@ -85,7 +85,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   # Override payload
   local _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}03:00 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}03:00 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
@@ -98,7 +98,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   # Override payload
   local _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{009} %F{226}Dur %f%F{226}02:00:00 %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %f%F{226}02:00:00 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/context.spec
+++ b/test/segments/context.spec
@@ -29,7 +29,7 @@ function testContextSegmentDoesNotGetRenderedWithDefaultUser() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testContextSegmentDoesGetRenderedWhenSshConnectionIsOpen() {
@@ -43,7 +43,7 @@ function testContextSegmentDoesGetRenderedWhenSshConnectionIsOpen() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}%n@%m %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(build_left_prompt)"
 
     unfunction sudo
 }
@@ -58,7 +58,7 @@ function testContextSegmentWithForeignUser() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}%n@%m %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(build_left_prompt)"
 
     unfunction sudo
 }
@@ -72,7 +72,7 @@ function testContextSegmentWithRootUser() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}%n@%m %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testOverridingContextTemplate() {
@@ -83,7 +83,7 @@ function testOverridingContextTemplate() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}xx %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}xx %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testContextSegmentIsShownIfDefaultUserIsSetWhenForced() {
@@ -95,7 +95,7 @@ function testContextSegmentIsShownIfDefaultUserIsSetWhenForced() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}%n@%m %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testContextSegmentIsShownIfForced() {
@@ -107,7 +107,7 @@ function testContextSegmentIsShownIfForced() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}$(whoami) %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}$(whoami) %k%F{000}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/custom.spec
+++ b/test/segments/custom.spec
@@ -17,7 +17,7 @@ function testCustomDirectOutputSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testCustomClosureSegment() {
@@ -31,7 +31,7 @@ function testCustomClosureSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testSettingBackgroundForCustomSegment() {
@@ -43,7 +43,7 @@ function testSettingBackgroundForCustomSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{011} %F{000}world %k%F{011}%f " "$(build_left_prompt)"
+    assertEquals "%K{003} %F{000}world %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testSettingForegroundForCustomSegment() {
@@ -55,7 +55,7 @@ function testSettingForegroundForCustomSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{009}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{001}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testSettingVisualIdentifierForCustomSegment() {
@@ -67,7 +67,7 @@ function testSettingVisualIdentifierForCustomSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}hw %f%F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}hw %f%F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testSettingVisualIdentifierForegroundColorForCustomSegment() {
@@ -80,7 +80,7 @@ function testSettingVisualIdentifierForegroundColorForCustomSegment() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{009}hw %f%F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{001}hw %f%F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/detect_virt.spec
+++ b/test/segments/detect_virt.spec
@@ -20,7 +20,7 @@ function testDetectVirtSegmentPrintsNothingIfSystemdIsNotAvailable() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias systemd-detect-virt
 }
@@ -33,7 +33,7 @@ function testDetectVirtSegmentIfSystemdReturnsPlainName() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{000} %F{011}xxx %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}xxx %k%F{000}%f " "$(build_left_prompt)"
 
     unalias systemd-detect-virt
 }
@@ -53,7 +53,7 @@ function testDetectVirtSegmentIfRootFsIsOnExpectedInode() {
     # which translates to: Show the inode number of "/" and test if it is "2".
     alias ls="echo '2'"
 
-    assertEquals "%K{000} %F{011}none %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}none %k%F{000}%f " "$(build_left_prompt)"
 
     unalias ls
     unalias systemd-detect-virt
@@ -74,7 +74,7 @@ function testDetectVirtSegmentIfRootFsIsNotOnExpectedInode() {
     # which translates to: Show the inode number of "/" and test if it is "2".
     alias ls="echo '3'"
 
-    assertEquals "%K{000} %F{011}chroot %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{003}chroot %k%F{000}%f " "$(build_left_prompt)"
 
     unalias ls
     unalias systemd-detect-virt

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -29,9 +29,9 @@ function testDirPathAbsoluteWorks() {
   # of /home or /Users path.. That is why we change the test
   # according to the OS of the host.
   if [[ "${OS}" == 'Linux' ]]; then
-    assertEquals "%K{012} %F{000}/home/${USER} %k%F{012}%f " "$(build_left_prompt)"
+    assertEquals "%K{004} %F{000}/home/${USER} %k%F{004}%f " "$(build_left_prompt)"
   elif [[ "${OS}" == 'OSX' ]]; then
-    assertEquals "%K{012} %F{000}/Users/${USER} %k%F{012}%f " "$(build_left_prompt)"
+    assertEquals "%K{004} %F{000}/Users/${USER} %k%F{004}%f " "$(build_left_prompt)"
   fi
 
   cd -
@@ -50,7 +50,7 @@ function testTruncateFoldersWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}…/12345678/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}…/12345678/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -72,7 +72,7 @@ function testTruncateFolderWithHomeDirWorks() {
   # Switch back to home folder as this causes the problem.
   cd ..
 
-  assertEquals "%K{012} %F{000}~ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}~ %k%F{004}%f " "$(build_left_prompt)"
 
   rmdir $FOLDER
   cd ${CURRENT_DIR}
@@ -91,7 +91,7 @@ function testTruncateMiddleWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}/tmp/po…st/1/12/123/1234/12…45/12…56/12…67/12…78/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/po…st/1/12/123/1234/12…45/12…56/12…67/12…78/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -110,7 +110,7 @@ function testTruncationFromRightWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -129,7 +129,7 @@ function testTruncateToLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -148,7 +148,7 @@ function testTruncateToFirstAndLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -167,7 +167,7 @@ function testTruncateAbsoluteWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}…89 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}…89 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -187,7 +187,7 @@ function testTruncationFromRightWithEmptyDelimiter() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}/tmp/po/1/12/123/12/12/12/12/12/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/po/1/12/123/12/12/12/12/12/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -207,7 +207,7 @@ function testTruncateWithFolderMarkerWorks() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{012} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -228,7 +228,7 @@ function testTruncateWithFolderMarkerWithChangedFolderMarker() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.xxx
   cd $FOLDER
-  assertEquals "%K{012} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/…/12/123/1234/12345/123456/1234567 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -260,7 +260,7 @@ function testTruncateWithPackageNameWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}My_Package/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}My_Package/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{004}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -300,7 +300,7 @@ function testTruncateWithPackageNameIfRepoIsSymlinkedInsideDeepFolder() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}My_Package/as…/qwerqwer %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}My_Package/as…/qwerqwer %k%F{004}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -336,7 +336,7 @@ function testTruncateWithPackageNameIfRepoIsSymlinkedInsideGitDir() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}My_Package/.g…/re…/heads %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}My_Package/.g…/re…/heads %k%F{004}%f " "$(build_left_prompt)"
 
   # Go back
   cd $p9kFolder
@@ -352,7 +352,7 @@ function testHomeFolderDetectionWorks() {
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   cd ~
-  assertEquals "%K{012} %F{000}home-icon %f%F{000}~ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}home-icon %f%F{000}~ %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -368,7 +368,7 @@ function testHomeSubfolderDetectionWorks() {
   local FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{012} %F{000}sub-icon %f%F{000}~/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}sub-icon %f%F{000}~/powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -385,7 +385,7 @@ function testOtherFolderDetectionWorks() {
   local FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{012} %F{000}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -403,7 +403,7 @@ function testChangingDirPathSeparator() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{012} %F{000}xXxtmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}xXxtmpxXxpowerlevel9k-testxXx1xXx2 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -421,7 +421,7 @@ function testHomeFolderAbbreviation() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}~ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}~ %k%F{004}%f " "$(build_left_prompt)"
 
   # substituted
   local POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
@@ -429,7 +429,7 @@ function testHomeFolderAbbreviation() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}qQq %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}qQq %k%F{004}%f " "$(build_left_prompt)"
 
   cd /tmp
   # default
@@ -438,7 +438,7 @@ function testHomeFolderAbbreviation() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   # substituted
   local POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='qQq'
@@ -446,7 +446,7 @@ function testHomeFolderAbbreviation() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{012} %F{000}/tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd "$dir"
 }
@@ -462,7 +462,7 @@ function testOmittingFirstCharacterWorks() {
 
   cd /tmp
 
-  assertEquals "%K{012} %F{000}folder-icon %f%F{000}tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon %f%F{000}tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -480,7 +480,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{012} %F{000}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -507,7 +507,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndDefaultTrunc
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{012} %F{000}xXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}xXx1xXx2 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -527,7 +527,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndMiddleTrunca
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{012} %F{000}tmpxXxpo…stxXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}tmpxXxpo…stxXx1xXx2 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -547,7 +547,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparatorAndRightTruncat
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{012} %F{000}tmpxXxpo…xXx1xXx2 %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}tmpxXxpo…xXx1xXx2 %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -570,7 +570,7 @@ function testTruncateToUniqueWorks() {
   mkdir -p /tmp/powerlevel9k-test/bob/docs
   cd /tmp/powerlevel9k-test/alice/devl
 
-  assertEquals "%K{012} %F{000}txXxpxXxalxXxde %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}txXxpxXxalxXxde %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -586,7 +586,7 @@ function testBoldHomeDirWorks() {
 
   cd ~
 
-  assertEquals "%K{012} %F{000}%B~%b %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}%B~%b %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -602,7 +602,7 @@ function testBoldHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}~/%Bpowerlevel9k-test%b %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}~/%Bpowerlevel9k-test%b %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -618,7 +618,7 @@ function testBoldRootDirWorks() {
 
   cd /
 
-  assertEquals "%K{012} %F{000}%B/%b %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}%B/%b %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -633,7 +633,7 @@ function testBoldRootSubdirWorks() {
 
   cd /tmp
 
-  assertEquals "%K{012} %F{000}/%Btmp%b %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/%Btmp%b %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -649,7 +649,7 @@ function testBoldRootSubSubdirWorks() {
   mkdir -p /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}/tmp/%Bpowerlevel9k-test%b %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/%Bpowerlevel9k-test%b %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -665,7 +665,7 @@ function testHighlightHomeWorks() {
 
   cd ~
 
-  assertEquals "%K{012} %F{000}%F{red}~ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}%F{red}~ %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -681,7 +681,7 @@ function testHighlightHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}~/%F{red}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}~/%F{red}powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -697,7 +697,7 @@ function testHighlightRootWorks() {
 
   cd /
 
-  assertEquals "%K{012} %F{000}%F{red}/ %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}%F{red}/ %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -712,7 +712,7 @@ function testHighlightRootSubdirWorks() {
 
   cd /tmp
 
-  assertEquals "%K{012} %F{000}/%F{red}tmp %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/%F{red}tmp %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
 }
@@ -728,7 +728,7 @@ function testHighlightRootSubSubdirWorks() {
   mkdir /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}/tmp/%F{red}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/%F{red}powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -745,7 +745,7 @@ function testDirSeparatorColorHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}~%F{red}/%F{black}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}~%F{red}/%F{black}powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -762,7 +762,7 @@ function testDirSeparatorColorRootSubSubdirWorks() {
   mkdir -p /tmp/powerlevel9k-test
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{012} %F{000}%F{red}/%F{black}tmp%F{red}/%F{black}powerlevel9k-test %k%F{012}%f " "$(build_left_prompt)"
+  assertEquals "%K{004} %F{000}%F{red}/%F{black}tmp%F{red}/%F{black}powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/disk_usage.spec
+++ b/test/segments/disk_usage.spec
@@ -40,7 +40,7 @@ function testDiskUsageSegmentWhenDiskIsAlmostFull() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{009} %F{015}hdd  %f%F{015}97%% %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{007}hdd  %f%F{007}97%% %k%F{001}%f " "$(build_left_prompt)"
 
   unfunction df
 }
@@ -56,7 +56,7 @@ function testDiskUsageSegmentWhenDiskIsVeryFull() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000}hdd  %f%F{000}94%% %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd  %f%F{000}94%% %k%F{003}%f " "$(build_left_prompt)"
 
   unfunction df
 }
@@ -72,7 +72,7 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{011}hdd  %f%F{011}4%% %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{003}hdd  %f%F{003}4%% %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction df
 }
@@ -88,7 +88,7 @@ function testDiskUsageSegmentPrintsNothingIfDiskIsQuiteEmptyAndOnlyWarningsShoul
   local POWERLEVEL9K_DISK_USAGE_ONLY_WARNING=true
   local POWERLEVEL9K_CUSTOM_WORLD='echo world'
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unfunction df
 }
@@ -105,7 +105,7 @@ function testDiskUsageSegmentWarningLevelCouldBeAdjusted() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000}hdd  %f%F{000}11%% %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd  %f%F{000}11%% %k%F{003}%f " "$(build_left_prompt)"
 
   unfunction df
 }
@@ -123,7 +123,7 @@ function testDiskUsageSegmentCriticalLevelCouldBeAdjusted() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{009} %F{015}hdd  %f%F{015}11%% %k%F{009}%f " "$(build_left_prompt)"
+  assertEquals "%K{001} %F{007}hdd  %f%F{007}11%% %k%F{001}%f " "$(build_left_prompt)"
 
   unfunction df
 }

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -56,7 +56,7 @@ function testGoSegmentPrintsNothingIfEmptyGopath() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testGoSegmentPrintsNothingIfNotInGopath() {
@@ -68,7 +68,7 @@ function testGoSegmentPrintsNothingIfNotInGopath() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
@@ -80,7 +80,7 @@ function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias go
 }

--- a/test/segments/ip.spec
+++ b/test/segments/ip.spec
@@ -19,7 +19,7 @@ function testIpSegmentPrintsNothingOnOsxIfNotConnected() {
   source powerlevel9k.zsh-theme
   local OS="OSX" # Fake OSX
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias networksetup
 }
@@ -34,7 +34,7 @@ function testIpSegmentPrintsNothingOnLinuxIfNotConnected() {
   source powerlevel9k.zsh-theme
   local OS="Linux" # Fake Linux
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias ip
 }
@@ -68,7 +68,7 @@ function testIpSegmentWorksOnOsxWithNoInterfaceSpecified() {
   source powerlevel9k.zsh-theme
   local OS='OSX' # Fake OSX
 
-  assertEquals "%K{014} %F{000}IP %f%F{000}1.2.3.4 %k%F{014}%f " "$(build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(build_left_prompt)"
 
   unalias ipconfig
   unalias networksetup
@@ -123,7 +123,7 @@ function testIpSegmentWorksOnOsxWithMultipleInterfacesSpecified() {
   source powerlevel9k.zsh-theme
   local OS='OSX' # Fake OSX
 
-  assertEquals "%K{014} %F{000}IP %f%F{000}1.2.3.4 %k%F{014}%f " "$(build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(build_left_prompt)"
 
   unfunction ipconfig
   unalias networksetup
@@ -139,7 +139,7 @@ function testIpSegmentWorksOnOsxWithInterfaceSpecified() {
   source powerlevel9k.zsh-theme
   local OS='OSX' # Fake OSX
 
-  assertEquals "%K{014} %F{000}IP %f%F{000}1.2.3.4 %k%F{014}%f " "$(build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(build_left_prompt)"
 
   unalias ipconfig
 }
@@ -169,7 +169,7 @@ function testIpSegmentWorksOnLinuxWithNoInterfaceSpecified() {
     source powerlevel9k.zsh-theme
     local OS='Linux' # Fake Linux
 
-    assertEquals "%K{014} %F{000}IP %f%F{000}10.0.2.15 %k%F{014}%f " "$(build_left_prompt)"
+    assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(build_left_prompt)"
 
     unfunction ip
 }
@@ -204,7 +204,7 @@ function testIpSegmentWorksOnLinuxWithMultipleInterfacesSpecified() {
     source powerlevel9k.zsh-theme
     local OS='Linux' # Fake Linux
 
-    assertEquals "%K{014} %F{000}IP %f%F{000}10.0.2.15 %k%F{014}%f " "$(build_left_prompt)"
+    assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(build_left_prompt)"
 
     unfunction ip
 }
@@ -223,7 +223,7 @@ inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
   source powerlevel9k.zsh-theme
   local OS='Linux' # Fake Linux
 
-  assertEquals "%K{014} %F{000}IP %f%F{000}10.0.2.15 %k%F{014}%f " "$(build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(build_left_prompt)"
 
   unfunction ip
 }

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -71,7 +71,7 @@ function testKubeContext() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{013} %F{015}⎈ %f%F{015}minikube/default %k%F{013}%f " "$(build_left_prompt)"
+  assertEquals "%K{005} %F{007}⎈ %f%F{007}minikube/default %k%F{005}%f " "$(build_left_prompt)"
 
   unalias kubectl
 }
@@ -83,7 +83,7 @@ function testKubeContextOtherNamespace() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{013} %F{015}⎈ %f%F{015}minikube/kube-system %k%F{013}%f " "$(build_left_prompt)"
+  assertEquals "%K{005} %F{007}⎈ %f%F{007}minikube/kube-system %k%F{005}%f " "$(build_left_prompt)"
 
   unalias kubectl
 }
@@ -96,7 +96,7 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias kubectl
 }

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -34,7 +34,7 @@ function testLaravelVersionSegment() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{001} %F{015}x %f%F{015}5.4.23 %k%F{001}%f " "$(build_left_prompt)"
+  assertEquals "%K{009} %F{007}x %f%F{007}5.4.23 %k%F{009}%f " "$(build_left_prompt)"
 
   unalias php
 }
@@ -49,7 +49,7 @@ function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias php
 }
@@ -64,7 +64,7 @@ function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias php
 }

--- a/test/segments/load.spec
+++ b/test/segments/load.spec
@@ -121,7 +121,7 @@ function testLoadSegmentWarningState() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="Linux" # Fake Linux
 
-    assertEquals "%K{011} %F{000}L %f%F{000}2.01 " "$(prompt_load left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}L %f%F{000}2.01 " "$(prompt_load left 1 false ${FOLDER})"
 
     unalias nproc
 }
@@ -141,7 +141,7 @@ function testLoadSegmentCriticalState() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="Linux" # Fake Linux
 
-    assertEquals "%K{009} %F{000}L %f%F{000}2.81 " "$(prompt_load left 1 false ${FOLDER})"
+    assertEquals "%K{001} %F{000}L %f%F{000}2.81 " "$(prompt_load left 1 false ${FOLDER})"
 
     unalias nproc
 }

--- a/test/segments/node_version.spec
+++ b/test/segments/node_version.spec
@@ -18,7 +18,7 @@ function testNodeVersionSegmentPrintsNothingWithoutNode() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias node
 }
@@ -33,7 +33,7 @@ function testNodeVersionSegmentWorks() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{002} %F{015}⬢ %f%F{015}1.2.3 %k%F{002}%f " "$(build_left_prompt)"
+    assertEquals "%K{002} %F{007}⬢ %f%F{007}1.2.3 %k%F{002}%f " "$(build_left_prompt)"
 
     unfunction node
 }

--- a/test/segments/nodeenv.spec
+++ b/test/segments/nodeenv.spec
@@ -23,7 +23,7 @@ function testNodeenvSegmentPrintsNothingWithoutNode() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias node
 }
@@ -39,7 +39,7 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unfunction node
 }
@@ -57,7 +57,7 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvDisablePromptIsSet() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unset NODE_VIRTUAL_ENV_DISABLE_PROMPT
     unset NODE_VIRTUAL_ENV

--- a/test/segments/nvm.spec
+++ b/test/segments/nvm.spec
@@ -37,7 +37,7 @@ function testNvmSegmentPrintsNothingIfNvmIsNotAvailable() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testNvmSegmentWorksWithoutHavingADefaultAlias() {
@@ -51,7 +51,7 @@ function testNvmSegmentWorksWithoutHavingADefaultAlias() {
     [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v1.4.0'
   }
 
-  assertEquals "%K{013} %F{000}⬢ %f%F{000}4.6.0 %k%F{013}%f " "$(build_left_prompt)"
+  assertEquals "%K{005} %F{000}⬢ %f%F{000}4.6.0 %k%F{005}%f " "$(build_left_prompt)"
 }
 
 function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
@@ -66,7 +66,7 @@ function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
     [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v4.6.0'
   }
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/php_version.spec
+++ b/test/segments/php_version.spec
@@ -18,7 +18,7 @@ function testPhpVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias php
 }

--- a/test/segments/public_ip.spec
+++ b/test/segments/public_ip.spec
@@ -45,7 +45,7 @@ function testPublicIpSegmentPrintsNothingByDefaultIfHostIsNotAvailable() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
   unalias dig
 }
@@ -62,7 +62,7 @@ function testPublicIpSegmentPrintsNoticeIfNotConnected() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}disconnected %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}disconnected %k%F{000}%f " "$(build_left_prompt)"
 
   unalias dig
 }
@@ -79,7 +79,7 @@ function testPublicIpSegmentWorksWithWget() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}wget 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}wget 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction wget
   unalias dig
@@ -98,7 +98,7 @@ function testPublicIpSegmentUsesCurlAsFallbackMethodIfWgetIsNotAvailable() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}curl 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}curl 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction curl
   unalias dig
@@ -117,7 +117,7 @@ function testPublicIpSegmentUsesDigAsFallbackMethodIfWgetAndCurlAreNotAvailable(
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}dig 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}dig 1.2.3.4 %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction dig
   unalias curl
@@ -134,14 +134,14 @@ function testPublicIpSegmentCachesFile() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}first %k%F{000}%f " "$(build_left_prompt)"
 
   dig() {
       echo "second"
   }
 
   # Segment should not have changed!
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}first %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction dig
 }
@@ -157,7 +157,7 @@ function testPublicIpSegmentRefreshesCachesFileAfterTimeout() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}first %k%F{000}%f " "$(build_left_prompt)"
 
   sleep 3
   dig() {
@@ -165,7 +165,7 @@ function testPublicIpSegmentRefreshesCachesFileAfterTimeout() {
   }
 
   # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}second %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction dig
 }
@@ -180,7 +180,7 @@ function testPublicIpSegmentRefreshesCachesFileIfEmpty() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}first %k%F{000}%f " "$(build_left_prompt)"
 
   # Truncate cache file
   echo "" >! $POWERLEVEL9K_PUBLIC_IP_FILE
@@ -190,7 +190,7 @@ function testPublicIpSegmentRefreshesCachesFileIfEmpty() {
   }
 
   # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}second %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction dig
 }
@@ -205,7 +205,7 @@ function testPublicIpSegmentWhenGoingOnline() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}disconnected %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}disconnected %k%F{000}%f " "$(build_left_prompt)"
 
   unalias dig
 
@@ -214,7 +214,7 @@ function testPublicIpSegmentWhenGoingOnline() {
   }
 
   # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{007}second %k%F{000}%f " "$(build_left_prompt)"
 
   unfunction dig
 }

--- a/test/segments/ram.spec
+++ b/test/segments/ram.spec
@@ -36,7 +36,7 @@ Pages inactive:                         1313411.
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="OSX" # Fake OSX
 
-    assertEquals "%K{011} %F{000}RAM %f%F{000}6.15G " "$(prompt_ram left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}RAM %f%F{000}6.15G " "$(prompt_ram left 1 false ${FOLDER})"
 
     unalias vm_stat
 }
@@ -49,7 +49,7 @@ function testRamSegmentWorksOnBsd() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="BSD" # Fake BSD
 
-    assertEquals "%K{011} %F{000}RAM %f%F{000}0.29M " "$(prompt_ram left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}RAM %f%F{000}0.29M " "$(prompt_ram left 1 false ${FOLDER})"
 }
 
 function testRamSegmentWorksOnLinux() {
@@ -60,7 +60,7 @@ function testRamSegmentWorksOnLinux() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="Linux" # Fake Linux
 
-    assertEquals "%K{011} %F{000}RAM %f%F{000}0.29G " "$(prompt_ram left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}RAM %f%F{000}0.29G " "$(prompt_ram left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -45,7 +45,7 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/ssh.spec
+++ b/test/segments/ssh.spec
@@ -22,7 +22,7 @@ function testSshSegmentPrintsNothingIfNoSshConnection() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testSshSegmentWorksIfOnlySshClientIsSet() {
@@ -37,7 +37,7 @@ function testSshSegmentWorksIfOnlySshClientIsSet() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{011}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
 
   unset SSH_CLIENT
 }
@@ -54,7 +54,7 @@ function testSshSegmentWorksIfOnlySshTtyIsSet() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{011}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
 
   unset SSH_TTY
 }
@@ -71,7 +71,7 @@ function testSshSegmentWorksIfAllNecessaryVariablesAreSet() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{011}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(build_left_prompt)"
 
   unset SSH_TTY
   unset SSH_CLIENT

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -24,7 +24,7 @@ function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
     # Load Powerlevel9k
     source powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
@@ -50,7 +50,7 @@ function testStatusInGeneralErrorCase() {
     source powerlevel9k.zsh-theme
     local RETVAL=1
 
-    assertEquals "%K{009} %F{226}↵ %f%F{226}1 %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{001} %F{226}↵ %f%F{226}1 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testPipestatusInErrorCase() {
@@ -64,7 +64,7 @@ function testPipestatusInErrorCase() {
     local -a RETVALS
     RETVALS=(0 0 1 0)
 
-    assertEquals "%K{009} %F{226}↵ %f%F{226}0|0|1|0 %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{001} %F{226}↵ %f%F{226}0|0|1|0 %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testStatusCrossWinsOverVerbose() {
@@ -78,7 +78,7 @@ function testStatusCrossWinsOverVerbose() {
     source powerlevel9k.zsh-theme
     local RETVAL=1
 
-    assertEquals "%K{000} %F{009}✘%f %k%F{000}%f " "$(build_left_prompt)"
+    assertEquals "%K{000} %F{001}✘%f %k%F{000}%f " "$(build_left_prompt)"
 }
 
 function testStatusShowsSignalNameInErrorCase() {
@@ -92,7 +92,7 @@ function testStatusShowsSignalNameInErrorCase() {
     source powerlevel9k.zsh-theme
     local RETVAL=132
 
-    assertEquals "%K{009} %F{226}↵ %f%F{226}SIGILL(4) %k%F{009}%f " "$(build_left_prompt)"
+    assertEquals "%K{001} %F{226}↵ %f%F{226}SIGILL(4) %k%F{001}%f " "$(build_left_prompt)"
 }
 
 function testStatusSegmentIntegrated() {
@@ -107,7 +107,7 @@ function testStatusSegmentIntegrated() {
 
     false; powerlevel9k_prepare_prompts
 
-    assertEquals "%f%b%k%K{000} %F{009}✘%f %k%F{000}%f " "${(e)PROMPT}"
+    assertEquals "%f%b%k%K{000} %F{001}✘%f %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/shunit2

--- a/test/segments/swap.spec
+++ b/test/segments/swap.spec
@@ -36,7 +36,7 @@ function testSwapSegmentWorksOnOsx() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="OSX" # Fake OSX
 
-    assertEquals "%K{011} %F{000}SWP %f%F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}SWP %f%F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
 
     unfunction sysctl
 }
@@ -52,7 +52,7 @@ function testSwapSegmentWorksOnLinux() {
     source ${P9K_HOME}/powerlevel9k.zsh-theme
     local OS="Linux" # Fake Linux
 
-    assertEquals "%K{011} %F{000}SWP %f%F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"
+    assertEquals "%K{003} %F{000}SWP %f%F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/swift_version.spec
+++ b/test/segments/swift_version.spec
@@ -34,7 +34,7 @@ function testSwiftSegmentPrintsNothingIfSwiftIsNotAvailable() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias swift
 }
@@ -49,7 +49,7 @@ function testSwiftSegmentWorks() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{013} %F{015}Swift %f%F{015}3.0.1 %k%F{013}%f " "$(build_left_prompt)"
+    assertEquals "%K{005} %F{007}Swift %f%F{007}3.0.1 %k%F{005}%f " "$(build_left_prompt)"
 
     unfunction swift
 }

--- a/test/segments/symfony_version.spec
+++ b/test/segments/symfony_version.spec
@@ -34,7 +34,7 @@ function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unalias php
 }
@@ -50,7 +50,7 @@ function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
@@ -68,7 +68,7 @@ function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 
     unfunction php
 }

--- a/test/segments/todo.spec
+++ b/test/segments/todo.spec
@@ -38,7 +38,7 @@ function testTodoSegmentPrintsNothingIfTodoShIsNotInstalled() {
     # Load Powerlevel9k
     source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-    assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(build_left_prompt)"
+    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testTodoSegmentWorksAsExpected() {

--- a/test/segments/vcs-git.spec
+++ b/test/segments/vcs-git.spec
@@ -76,7 +76,7 @@ function testColorOverridingForCleanStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{014} master %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{006} master %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testColorOverridingForModifiedStateWorks() {
@@ -93,7 +93,7 @@ function testColorOverridingForModifiedStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{009} master ● %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{001} master ● %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testColorOverridingForUntrackedStateWorks() {
@@ -107,7 +107,7 @@ function testColorOverridingForUntrackedStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{014} master ? %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{006} master ? %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testGitIconWorks() {
@@ -194,7 +194,7 @@ function testStagedFilesIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000} master + %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000} master + %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testUnstagedFilesIconWorks() {
@@ -211,7 +211,7 @@ function testUnstagedFilesIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000} master M %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000} master M %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testStashIconWorks() {
@@ -289,7 +289,7 @@ function testActionHintWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000} master %F{red}| merge%f %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000} master %F{red}| merge%f %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testIncomingHintWorks() {

--- a/test/segments/vcs-hg.spec
+++ b/test/segments/vcs-hg.spec
@@ -40,7 +40,7 @@ function testColorOverridingForCleanStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{015} %F{014} default %k%F{015}%f " "$(build_left_prompt)"
+  assertEquals "%K{007} %F{006} default %k%F{007}%f " "$(build_left_prompt)"
 }
 
 function testColorOverridingForModifiedStateWorks() {
@@ -57,7 +57,7 @@ function testColorOverridingForModifiedStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{009} default ● %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{001} default ● %k%F{003}%f " "$(build_left_prompt)"
 }
 
 # There is no staging area in mercurial, therefore there are no "untracked"
@@ -74,7 +74,7 @@ function testAddedFilesIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000} default ● %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000} default ● %k%F{003}%f " "$(build_left_prompt)"
 }
 
 # We don't support tagging in mercurial right now..
@@ -137,7 +137,7 @@ function testActionHintWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{011} %F{000} default %F{red}| merging%f %k%F{011}%f " "$(build_left_prompt)"
+  assertEquals "%K{003} %F{000} default %F{red}| merging%f %k%F{003}%f " "$(build_left_prompt)"
 }
 
 function testShorteningCommitHashWorks() {

--- a/test/segments/vi_mode.spec
+++ b/test/segments/vi_mode.spec
@@ -15,7 +15,7 @@ function testViInsertModeWorks() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{012}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViInsertModeWorksWhenLabeledAsMain() {
@@ -24,7 +24,7 @@ function testViInsertModeWorksWhenLabeledAsMain() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{012}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViCommandModeWorks() {
@@ -33,7 +33,7 @@ function testViCommandModeWorks() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{015}NORMAL " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{007}NORMAL " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViInsertModeStringIsCustomizable() {
@@ -42,7 +42,7 @@ function testViInsertModeStringIsCustomizable() {
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{012}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
This should fix the second issue in #955 that @DuncanHuang brought up.

The colors were changed in `v0.6.5`. This PR updates the colors to the previous version.

So the colors `red`, `green`, `yellow`, `blue`, `magenta`, `cyan` and `white` point the bright colors:
```
'black'   '000'
'red'     '001'
'green'   '002'
'yellow'  '003'
'blue'    '004'
'magenta' '005'
'cyan'    '006'
'white'   '007'
```
I did a separate PR for this, because this needs a bit of discussion. The [page](https://jonasjacek.github.io/colors/) that was the source for the color names lists the colors mentioned above in the range of 8-15, like they are in `v.0.6.5`. But that means that users who upgrade may have to change their color definitions. That is why we need to discuss this here. The commit to look at is 8e966e3636ce7c7162b60763088252b7111985e5

In short:
- Option A
Change colors like in this PR. This means that users who upgrade P9K from an old Version (pre `v0.6.5`) get the _same_ colors as before, but if they upgrade from `v0.6.5`, colors change. Second downside is that we turn away from other color definitions.

- Option B
Leave colors as they are. This means that users who upgrade P9K from an old Version (pre `v0.6.5`) get _different_ colors.