### PR TITLE
[Bugfix] Fix for #974

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -103,7 +103,7 @@ case $(uname) in
     Linux)
       OS='Linux'
       if [ -f /etc/os-release ]; then
-        os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
+        [[ ${(f)"$((</etc/os-release) 2>/dev/null)"} =~ "ID=([A-Za-z]+)" ]] && os_release_id="${match[1]}"
       fi
       case "$os_release_id" in
         *arch*)

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -102,7 +102,9 @@ case $(uname) in
       ;;
     Linux)
       OS='Linux'
-      os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
+      if [ -f /etc/os-release ]; then
+        os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
+      fi
       case "$os_release_id" in
         *arch*)
         OS_ICON=$(print_icon 'LINUX_ARCH_ICON')


### PR DESCRIPTION
Hi, I have a quick fix for #974; we simply check if a file `/etc/os-release` exists, and grep for the appropriate release id if it does. If it does not the case statement reverts back to the default linux icon. This isn't so nice if you *do* in face have one of the pre-made icons (e.g. centos), but if the files are named inconsistently between different hosts, I don't see a good way of getting around that.

