### PR TITLE
[Enhancement] Add support for RHEL icon

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -52,6 +52,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_DEBIAN_ICON              $'\uE271'              # 
       LINUX_UBUNTU_ICON              $'\uE271'              # 
       LINUX_CENTOS_ICON              $'\uE271'              # 
+      LINUX_RHEL_ICON                $'\uE271'              # 
       LINUX_COREOS_ICON              $'\uE271'              # 
       LINUX_ELEMENTARY_ICON          $'\uE271'              # 
       LINUX_MINT_ICON                $'\uE271'              # 
@@ -152,6 +153,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_DEBIAN_ICON              $'\uF17C'              # 
       LINUX_UBUNTU_ICON              $'\uF17C'              # 
       LINUX_CENTOS_ICON              $'\uF17C'              # 
+      LINUX_RHEL_ICON                $'\uF17C'              # 
       LINUX_COREOS_ICON              $'\uF17C'              # 
       LINUX_ELEMENTARY_ICON          $'\uF17C'              # 
       LINUX_MINT_ICON                $'\uF17C'              # 
@@ -254,6 +256,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_DEBIAN_ICON              '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       LINUX_UBUNTU_ICON              '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       LINUX_CENTOS_ICON              '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
+      LINUX_RHEL_ICON                '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       LINUX_COREOS_ICON              '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       LINUX_ELEMENTARY_ICON          '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
       LINUX_MINT_ICON                '\u'$CODEPOINT_OF_AWESOME_LINUX                # 
@@ -347,6 +350,7 @@ case $POWERLEVEL9K_MODE in
       ANDROID_ICON                   $'\uF17B'              # 
       LINUX_ARCH_ICON                $'\uF303'              # 
       LINUX_CENTOS_ICON              $'\uF304'              # 
+      LINUX_RHEL_ICON                $'\uE7BB'              # 
       LINUX_COREOS_ICON              $'\uF305'              # 
       LINUX_DEBIAN_ICON              $'\uF306'              # 
       LINUX_ELEMENTARY_ICON          $'\uF309'              # 
@@ -446,6 +450,7 @@ case $POWERLEVEL9K_MODE in
       LINUX_DEBIAN_ICON              'Deb'
       LINUX_UBUNTU_ICON              'Ubu'
       LINUX_CENTOS_ICON              'Cen'
+      LINUX_RHEL_ICON                'Rhe'
       LINUX_COREOS_ICON              'Cor'
       LINUX_ELEMENTARY_ICON          'Elm'
       LINUX_MINT_ICON                'LMi'

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -131,6 +131,9 @@ case $(uname) in
        *centos*)
         OS_ICON=$(print_icon 'LINUX_CENTOS_ICON')
         ;;
+       *rhel*)
+        OS_ICON=$(print_icon 'LINUX_RHEL_ICON')
+        ;;
        *opensuse*|*tumbleweed*)
         OS_ICON=$(print_icon 'LINUX_OPENSUSE_ICON')
         ;;

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -102,7 +102,7 @@ case $(uname) in
       ;;
     Linux)
       OS='Linux'
-      os_release_id="$(grep -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
+      os_release_id="$(grep -s -E '^ID=([a-zA-Z]*)' /etc/os-release | cut -d '=' -f 2)"
       case "$os_release_id" in
         *arch*)
         OS_ICON=$(print_icon 'LINUX_ARCH_ICON')


### PR DESCRIPTION
Adds support for Redhat icon in nerdfont-complete if `os_release_id` == 'rhel'.  Also added -s flag to grep command used to assign `os_release_id` in utilities.zsh.  This prevents an error from being displayed if /etc/os-release does not exist (e.g. rhel/centos 6).  Grep flag change fixes Bug https://github.com/bhilburn/powerlevel9k/issues/974 and duplicates PR https://github.com/bhilburn/powerlevel9k/pull/981.  I had not seen that PR until after I created this.
