### PR TITLE
[Enhancement] Dir - truncate_from_left (070 update)

### DIFF
--- a/functions/autoload/__p9k_truncate_path
+++ b/functions/autoload/__p9k_truncate_path
@@ -82,8 +82,8 @@ if (( ${#1} > 1 )); then
       done
     ;;
     left)
-      # include the delimiter length in the threshhold
-      threshold=$(( $2 + ${#3} ))
+      # include the delimiter length in the threshold
+      threshold=$(( $2 + ${delim_len} ))
       # loop through the paths
       for (( i=1; i<${#paths}; i++ )); do
         # get the current directory value
@@ -92,9 +92,9 @@ if (( ${#1} > 1 )); then
         # only truncate if the resulting truncation will be shorter than
         # the truncation + delimiter length and at least 3 characters
         if (( $test_dir_length > $threshold )) && (( $test_dir_length > 3 )); then
-          # use the delimiter and the first $2 characters
+          # use the delimiter and the last $2 characters
           last_pos=$(( $test_dir_length - $2 ))
-          trunc_path+="$3${test_dir:$last_pos:$test_dir_length}/"
+          trunc_path+="${delim}${test_dir:$last_pos:$2}/"
         else
           # use the full path
           trunc_path+="${test_dir}/"

--- a/functions/autoload/__p9k_truncate_path
+++ b/functions/autoload/__p9k_truncate_path
@@ -19,7 +19,7 @@ setopt localoptions # extendedglob
 #   $1 string The directory path to be truncated.
 #   $2 integer Length to truncate to.
 #   $3 string Delimiter to use.
-#   $4 string Where to truncate from - "right" | "middle". If omited, assumes right.
+#   $4 string Where to truncate from is "right" | "middle" | "left". If omitted, assumes right.
 ##
 # @function __p9k_truncate_path() {}
 # if the current path is not 1 character long (e.g. "/" or "~")
@@ -81,7 +81,27 @@ if (( ${#1} > 1 )); then
         fi
       done
     ;;
-esac
+    left)
+      # include the delimiter length in the threshhold
+      threshold=$(( $2 + ${#3} ))
+      # loop through the paths
+      for (( i=1; i<${#paths}; i++ )); do
+        # get the current directory value
+        test_dir=$paths[$i]
+        test_dir_length=${#test_dir}
+        # only truncate if the resulting truncation will be shorter than
+        # the truncation + delimiter length and at least 3 characters
+        if (( $test_dir_length > $threshold )) && (( $test_dir_length > 3 )); then
+          # use the delimiter and the first $2 characters
+          last_pos=$(( $test_dir_length - $2 ))
+          trunc_path+="$3${test_dir:$last_pos:$test_dir_length}/"
+        else
+          # use the full path
+          trunc_path+="${test_dir}/"
+        fi
+      done
+    ;;
+  esac
   # return the truncated path + the current directory
   echo $trunc_path${1:t}
 else # current path is 1 character long (e.g. "/" or "~")

--- a/segments/dir.p9k
+++ b/segments/dir.p9k
@@ -56,6 +56,10 @@ prompt_dir() {
         # truncate characters from the middle of the path
         current_path=$(__p9k_truncate_path "$current_path" $P9K_DIR_SHORTEN_LENGTH "$P9K_DIR_SHORTEN_DELIMITER" "middle")
       ;;
+      truncate_from_left)
+        # truncate characters from the left of the path
+        current_path=$(__p9k_truncate_path "$current_path" $P9K_DIR_SHORTEN_LENGTH "$P9K_DIR_SHORTEN_DELIMITER" "left")
+      ;;
       truncate_absolute|truncate_absolute_chars)
         # truncate all characters except the last P9K_DIR_SHORTEN_LENGTH characters
         if [ ${#current_path} -gt $(( $P9K_DIR_SHORTEN_LENGTH + ${#P9K_DIR_SHORTEN_DELIMITER} )) ]; then

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -64,6 +64,22 @@ function testTruncateFolderWithHomeDirWorks() {
   cd ${CURRENT_DIR}
 }
 
+function testTruncationFromRightWorks() {
+  typeset -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(dir)
+  local P9K_DIR_SHORTEN_LENGTH=2
+  local P9K_DIR_SHORTEN_STRATEGY='truncate_from_right'
+
+  local FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{004} %F{000}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{004}%f " "$(__p9k_build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+}
+
 function testTruncateMiddleWorks() {
   typeset -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(dir)
@@ -80,17 +96,17 @@ function testTruncateMiddleWorks() {
   rm -fr /tmp/powerlevel9k-test
 }
 
-function testTruncationFromRightWorks() {
+function testTruncationFromLeftWorks() {
   typeset -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(dir)
   local P9K_DIR_SHORTEN_LENGTH=2
-  local P9K_DIR_SHORTEN_STRATEGY='truncate_from_right'
+  local P9K_DIR_SHORTEN_STRATEGY='truncate_from_left'
 
   local FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{004} %F{000}/tmp/po…/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}/tmp/…st/1/12/123/…34/…45/…56/…67/…78/123456789 %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -156,6 +172,23 @@ function testTruncationFromRightWithEmptyDelimiter() {
   cd $FOLDER
 
   assertEquals "%K{004} %F{000}/tmp/po/1/12/123/12/12/12/12/12/123456789 %k%F{004}%f " "$(__p9k_build_left_prompt)"
+
+  cd -
+  rm -fr /tmp/powerlevel9k-test
+}
+
+function testTruncationFromLeftWithEmptyDelimiter() {
+  typeset -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(dir)
+  local P9K_DIR_SHORTEN_LENGTH=2
+  local P9K_DIR_SHORTEN_DELIMITER=""
+  local P9K_DIR_SHORTEN_STRATEGY='truncate_from_left'
+
+  local FOLDER=/tmp/powerlevel9k-test/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+  cd $FOLDER
+
+  assertEquals "%K{004} %F{000}/tmp/st/1/12/123/34/45/56/67/78/123456789 %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test


### PR DESCRIPTION
New strategy for the dir segment - truncate_from_left

This adds the ability to shorten a directory from the left. It leaves just the end of a folder name untouched. E.g. your folders will be truncated like so: "/..9k/..st/segments". How many characters will be untouched is controlled by P9K_SHORTEN_DIR_LENGTH.

NOTE: Created in response to #885

This PR replaces #889