### PR TITLE
[Enhancement] New Background Jobs segment (070 update)

### DIFF
--- a/segments/background_jobs.p9k
+++ b/segments/background_jobs.p9k
@@ -8,14 +8,20 @@
 # Register segment
 # Parameters:
 #   segment_name  context  foreground  background  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                            ⚙                                                               
+#                                                                   ⚙                                                               
 p9k::register_segment 'BACKGROUND_JOBS' '' "$DEFAULT_COLOR" "cyan" $'\u2699'  $'\uE82F '  $'\uF013 '  '\u'$CODEPOINT_OF_AWESOME_COG' '  $'\uF013 '
 
-################################################################
-# Register segment default values
+__p9k_background_jobs() {
+  # See https://unix.stackexchange.com/questions/68571/show-jobs-count-only-if-it-is-more-than-0
+  jobs_running=${(M)#${jobstates%%:*}:#running}
+  jobs_suspended=${(M)#${jobstates%%:*}:#suspended}
+}
+
+add-zsh-hook precmd __p9k_background_jobs
+
 p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE true
 p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS false
-
+p9k::set_default P9K_BACKGROUND_JOBS_EXPANDED false
 ################################################################
 # @description
 #   Displays the number of background jobs with an icon.
@@ -26,17 +32,20 @@ p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS false
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_background_jobs() {
-  local background_jobs_number=${$(jobs -l | wc -l)// /}
-  local wrong_lines=`jobs -l | awk '/pwd now/{ count++ } END {print count}'`
-  if [[ wrong_lines -gt 0 ]]; then
-     background_jobs_number=$(( $background_jobs_number - $wrong_lines ))
-  fi
-  if [[ background_jobs_number -gt 0 ]]; then
-    local background_jobs_number_print=""
-    if [[ "$P9K_BACKGROUND_JOBS_VERBOSE" == "true" ]] && ([[ "$background_jobs_number" -gt 1 ]] || [[ "$P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS" == "true" ]]); then
-      background_jobs_number_print="$background_jobs_number"
+  local jobs_print=""
+  local total_jobs=$(( ${jobs_running} + ${jobs_suspended} ))
+
+  if [[ "${(L)P9K_BACKGROUND_JOBS_VERBOSE}" == "true" || "${(L)P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS}" == "true" ]]; then
+    jobs_print=0
+    if (( ${total_jobs} > 0 )); then
+      if [[ "${(L)P9K_BACKGROUND_JOBS_EXPANDED}" == "true" ]]; then
+        jobs_print="${jobs_running}r ${jobs_suspended}s"
+      else
+        jobs_print="${total_jobs}"
+      fi
     fi
-    p9k::prepare_segment "$0" "" "$1" "$2" "$3" "$background_jobs_number_print" \
-      "[[ ${(L)P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS} == true || ${background_jobs_number} -gt 0 ]]"
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${jobs_print}" \
+      "[[ ${(L)P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS} == true ]] || (( ${total_jobs} > 0 ))"
 }

--- a/segments/background_jobs.p9k
+++ b/segments/background_jobs.p9k
@@ -17,6 +17,8 @@ __p9k_background_jobs() {
   jobs_suspended=${(M)#${jobstates%%:*}:#suspended}
 }
 
+# initialize hooks
+autoload -Uz add-zsh-hook
 add-zsh-hook precmd __p9k_background_jobs
 
 p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE true

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -40,6 +40,8 @@ function testJoiningWithConditionalSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local P9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
   source segments/background_jobs.p9k
+  local jobs_running=0
+  local jobs_suspended=0
 
   cd /tmp
 

--- a/test/segments/background_jobs.spec
+++ b/test/segments/background_jobs.spec
@@ -14,6 +14,8 @@ function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(background_jobs custom_world)
+  local jobs_running=0
+  local jobs_suspended=0
 
   # Load Powerlevel9k
   source segments/background_jobs.p9k
@@ -21,31 +23,37 @@ function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
-function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
-  unset P9K_BACKGROUND_JOBS_VERBOSE
+function testBackgroundJobsSegmentVerboseAlwaysPrintsZeroWithoutBackgroundJobs() {
+  local P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS=true
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(background_jobs)
-  jobs() {
-      echo '[1]  + 30444 suspended  nvim xx'
-  }
+  local jobs_running=0
+  local jobs_suspended=0
 
   # Load Powerlevel9k
   source segments/background_jobs.p9k
 
-  assertEquals "%K{000} %F{006}⚙ %f%F{006}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{006}⚙ %f%F{006}0 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+}
 
-  unfunction jobs
+function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
+  local P9K_BACKGROUND_JOBS_VERBOSE=false
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs)
+  local jobs_running=0
+  local jobs_suspended=1
+
+  # Load Powerlevel9k
+  source segments/background_jobs.p9k
+  assertEquals "%K{000} %F{006}⚙ %f%F{006}%k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
   local P9K_BACKGROUND_JOBS_VERBOSE=true
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(background_jobs)
-  jobs() {
-      echo "[1]    31190 suspended  nvim xx"
-      echo "[2]  - 31194 suspended  nvim xx2"
-      echo "[3]  + 31206 suspended  nvim xx3"
-  }
+  local jobs_running=0
+  local jobs_suspended=3
 
   # Load Powerlevel9k
   source segments/background_jobs.p9k
@@ -57,18 +65,27 @@ function testBackgroundJobsSegmentWithVerboseMode() {
     local P9K_BACKGROUND_JOBS_VERBOSE=true
     local -a P9K_LEFT_PROMPT_ELEMENTS
     P9K_LEFT_PROMPT_ELEMENTS=(background_jobs)
-    jobs() {
-        echo "[1]    31190 suspended  nvim xx"
-        echo "[2]  - 31194 suspended  nvim xx2"
-        echo "[3]  + 31206 suspended  nvim xx3"
-    }
+    local jobs_running=1
+    local jobs_suspended=2
 
     # Load Powerlevel9k
     source segments/background_jobs.p9k
 
     assertEquals "%K{000} %F{006}⚙ %f%F{006}3 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+}
 
-    unfunction jobs
+function testBackgroundJobsSegmentWorksWithExpandedMode() {
+  local P9K_BACKGROUND_JOBS_VERBOSE=true
+  local P9K_BACKGROUND_JOBS_EXPANDED=true
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs)
+  local jobs_running=1
+  local jobs_suspended=2
+
+  # Load Powerlevel9k
+  source segments/background_jobs.p9k
+
+  assertEquals "%K{000} %F{006}⚙ %f%F{006}1r 2s %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
#### New background jobs segment
This update gets rid of the external calls. In addition, it can now show Running jobs as well as Suspended jobs.
 
#### Description
If `POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE` is set, the segment will display if the job count is more than 0.

If `POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE_ALWAYS` is set, it will always show the segment, with `⚙ 0` - if there are none. (Note that this will _always_ override `POWERLEVEL9K_BACKGROUND_JOBS_VERBOSE` to be true).

If `POWERLEVEL9K_BACKGROUND_JOBS_EXPANDED` is set, the new format will display
`⚙ 2r 1s` - indicating (r)unning and (s)uspended jobs,
otherwise it will display just the total of the two,
`⚙ 3` - indicating the total.

This PR replaces #935 