### PR TITLE
[Bugfix] updates package name for docker (5.0.2 and 5.5.1)

### DIFF
--- a/docker/base-5.0.3/Dockerfile
+++ b/docker/base-5.0.3/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh=5.0.2-3ubuntu6.2 \
+  zsh=5.0.2-3ubuntu6.3 \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.5.1/Dockerfile
+++ b/docker/base-5.5.1/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh=5.5.1-1ubuntu1 \
+  zsh=5.5.1-1ubuntu2 \
   mercurial \
   subversion \
   golang \


### PR DESCRIPTION
I used [this](https://launchpad.net/ubuntu/+source/zsh) as a reference to update some package names for Dockerfiles

This relates to @dritter's commit 4f2286265bd18bf37bfd931cefafea1b86917391