### PR TITLE
[Bugfix] fix: command not found p9k::defined in debug/font-issues.zsh

### DIFF
--- a/debug/font-issues.zsh
+++ b/debug/font-issues.zsh
@@ -1,9 +1,9 @@
 #!/usr/bin/env zsh
 #vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
 
+source functions/utilities.zsh
 source functions/colors.zsh
 source functions/icons.zsh
-source functions/utilities.zsh
 # Map our $__P9K_OS to neofetch $os
 os="$__P9K_OS"
 


### PR DESCRIPTION
p9k::register_icon in functions/icons.zsh makes calls to p9k::defined which is defined functions/utilities.zsh

Before :
![image](https://user-images.githubusercontent.com/717869/46676340-9fdd6680-cbe0-11e8-946a-f37535114a1d.png)

After :
![image](https://user-images.githubusercontent.com/717869/46676282-7d4b4d80-cbe0-11e8-8f06-79c9b66f7041.png) 