### PR TITLE
Fix root indicator

### DIFF
--- a/segments/root_indicator.p9k
+++ b/segments/root_indicator.p9k
@@ -9,7 +9,7 @@
 # Parameters:
 #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
 #                                                                       ⚡                                                              
-p9k::register_segment "ROOT_INDICATOR" "" "${DEFAULT_COLOR}" "yellow"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}  $'\uE614 '
+p9k::register_segment "ROOT_INDICATOR" "" "${DEFAULT_COLOR}" "yellow"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}  $'\uF0E7'
 
 ################################################################
 # @description

--- a/segments/root_indicator.p9k
+++ b/segments/root_indicator.p9k
@@ -22,6 +22,6 @@ p9k::register_segment "ROOT_INDICATOR" "" "${DEFAULT_COLOR}" "yellow"  $'\u26A1'
 ##
 prompt_root_indicator() {
   if [[ "$UID" -eq 0 ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "true"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "[[ true ]]"
   fi
 }


### PR DESCRIPTION
This fixes #1010 

The root indicator segment did not print anything, because the condition was wrong (it needs to include the `[[` brackets).
Additionally I updated the flash icon to NerdFonts v2.0.