### PR TITLE
Fix dir_writable segment

### DIFF
--- a/segments/dir_writable.p9k
+++ b/segments/dir_writable.p9k
@@ -22,6 +22,6 @@ p9k::register_segment 'DIR_WRITABLE' 'FORBIDDEN' "red" "yellow1" $'\uE0A2'  $'\u
 ##
 prompt_dir_writable() {
   if [[ ! -w "$PWD" ]]; then
-    p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" "true"
+    p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" "[[ true ]]"
   fi
 }


### PR DESCRIPTION
Segments without content (besides a visual identifier) need to overwrite the condition. This condition gets evaluated, hence we need to enclose the condition with `[[` brackets.