### PR TITLE
[Fix] Replace calls to basename

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -88,7 +88,7 @@ function __p9k_detect_terminal() {
       # test if we are in a sudo su -
       if [[ ${termtest} == "-" || ${termtest} == "root" ]]; then
         termtest=($(ps -o 'command=' -p $(ps -o 'ppid=' -p $(ps -o 'ppid='$$))))
-        termtest=$(basename $termtest[1])
+        termtest=${termtest[1]:t}
       fi
     else
       local termtest=$(ps -o 'cmd=' -p $(ps -o 'ppid=' -p $$) | tail -1 | awk '{print $NF}')

--- a/segments/anaconda.p9k
+++ b/segments/anaconda.p9k
@@ -30,6 +30,6 @@ prompt_anaconda() {
   # variant works even if both are set.
   _path=$CONDA_ENV_PATH$CONDA_PREFIX
   if ! [ -z "$_path" ]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER$(basename $_path)$P9K_ANACONDA_RIGHT_DELIMITER"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER"
   fi
 }


### PR DESCRIPTION
This PR replaces two instances of `$(basename $x)` with `${x:t}`