### PR TITLE
[Enhancement] Adds support for multiple batteries in battery segment (on linux)

### DIFF
--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -72,38 +72,27 @@ prompt_battery() {
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
+    local bats=(${$(ls -d $sysp/(battery|BAT*))})
 
-    # Reported BAT0 or BAT1 depending on kernel version
-    [[ -a $sysp/BAT0 ]] && local bat0=$sysp/BAT0
-    [[ -a $sysp/BAT1 ]] && local bat1=$sysp/BAT1
+    # Return if no battery found
+    [[ -z $bats ]] && return
 
-    # Android-related
-    # Tested on: Moto G falcon (CM 13.0)
-    [[ -a $sysp/battery ]] && local bat0=$sysp/battery
+    local numerator="0"
+    local denominator="0"
+    local battery_status_full=true
+    local battery_status_charging=false
+    for bat in $bats; do
+      numerator+="+ $(cat $bat/capacity) * $(cat $bat/(energy|charge)_full)"
+      denominator+="+ $(cat $bat/(energy|charge)_full)"
+      [[ $(cat $bat/status) != Full ]] && battery_status_full=false
+      [[ $(cat $bat/status) == Charging ]] && battery_status_charging=true
+    done
 
-    local capacity battery_status
-    if (( ${+bat0} && ${+bat1} )); then
-      # two batteries
-      capacity=$(( ( $(cat $bat0/capacity) * $(cat $bat0/(energy|charge)_full) \
-        + $(cat $bat1/capacity) * $(cat $bat1/(energy|charge)_full) )          \
-        / ( $(cat $bat0/(energy|charge)_full) + $(cat $bat1/(energy|charge)_full) ) ))
-      [[ $(<${bat0}/status) =~ Charging || $(<${bat1}/status) =~ Charging ]] \
-        && battery_status=Charging
-      [[ $(<${bat0}/status) =~ Full && $(<${bat1}/status) =~ Full ]] \
-        && battery_status=Full
-    elif (( ${+bat0} ^^ ${+bat1} )); then
-      # only bat0 OR bat1 isset
-      capacity=$(<${bat0}${bat1}/capacity)
-      battery_status=$(<${bat0}${bat1}/status)
-    else
-      # Return if no battery found
-      return
-    fi
-
+    local capacity=$(( ($numerator)/($denominator) ))
     [[ $capacity -gt 100 ]] \
       && local bat_percent=100 \
       || local bat_percent=$capacity
-    [[ $battery_status =~ Charging || $battery_status =~ Full ]] \
+    [[ $battery_status_full == true || $battery_status_charging == true ]] \
       && local connected=true
 
     if [[ -z $connected ]]; then
@@ -115,11 +104,14 @@ prompt_battery() {
       [[ $bat_percent -lt 100 ]] && current_state="charging"
     fi
     if [[ -f ${ROOT_PREFIX}/usr/bin/acpi ]]; then
-      local time_remaining1=${${(s: :)${(s:Battery:)$(${ROOT_PREFIX}/usr/bin/acpi)}[1]}[4]}
-      local time_remaining2=${${(s: :)${(s:Battery:)$(${ROOT_PREFIX}/usr/bin/acpi)}[2]}[4]}
-      [[ -z $time_remaining2 ]] \
-        && local time_remaining=$time_remaining1 \
-        || local time_remaining=$time_remaining2
+      local time_remaining
+      local acpi_lines="$(${ROOT_PREFIX}/usr/bin/acpi)"
+      acpi_lines=(${(@f)acpi_lines})
+      for line in $acpi_lines; do
+        [[ -n ${${(s: :)line}[5]} ]] \
+          && local time_remaining=${${(s: :)line}[5]}
+      done
+
       if [[ $time_remaining =~ "rate" ]]; then
         local tstring="..."
       elif [[ $time_remaining =~ "[[:digit:]]+" ]]; then

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -105,12 +105,13 @@ prompt_battery() {
     fi
     if [[ -f ${ROOT_PREFIX}/usr/bin/acpi ]]; then
       local time_remaining
-      local acpi_lines="$(${ROOT_PREFIX}/usr/bin/acpi)"
-      acpi_lines=(${(@f)acpi_lines})
+      declare -a acpi_lines
+      acpi_lines=( "${(@f)$(${ROOT_PREFIX}/usr/bin/acpi)}" )
       for line in $acpi_lines; do
         [[ -n ${${(s: :)line}[5]} ]] \
           && local time_remaining=${${(s: :)line}[5]}
       done
+      unset acpi_lines
 
       if [[ $time_remaining =~ "rate" ]]; then
         local tstring="..."

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -72,10 +72,10 @@ prompt_battery() {
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
-    local bats=(${$(ls -d $sysp/(battery|BAT*))})
-
-    # Return if no battery found
-    [[ -z $bats ]] && return
+    local potential_bats=( "$sysp/*" )
+    [[ ${#${(M)potential_bats:#*(BAT|battery)*}} ]] \
+      && local bats=(${$(ls -d $sysp/(battery|BAT*))}) \
+      || return
 
     local numerator="0"
     local denominator="0"
@@ -104,13 +104,9 @@ prompt_battery() {
       [[ $bat_percent -lt 100 ]] && current_state="charging"
     fi
     if [[ -f ${ROOT_PREFIX}/usr/bin/acpi ]]; then
-      local time_remaining
       declare -a acpi_lines
       acpi_lines=( "${(@f)$(${ROOT_PREFIX}/usr/bin/acpi)}" )
-      for line in $acpi_lines; do
-        [[ -n ${${(s: :)line}[5]} ]] \
-          && local time_remaining=${${(s: :)line}[5]}
-      done
+      local time_remaining=${${=${(M)acpi_lines:#*([[:digit:]][[:digit:]]:|rate)*}}[5]}
       unset acpi_lines
 
       if [[ $time_remaining =~ "rate" ]]; then

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -74,27 +74,52 @@ prompt_battery() {
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
 
     # Reported BAT0 or BAT1 depending on kernel version
-    [[ -a $sysp/BAT0 ]] && local bat=$sysp/BAT0
-    [[ -a $sysp/BAT1 ]] && local bat=$sysp/BAT1
+    [[ -a $sysp/BAT0 ]] && local bat0=$sysp/BAT0
+    [[ -a $sysp/BAT1 ]] && local bat1=$sysp/BAT1
 
     # Android-related
     # Tested on: Moto G falcon (CM 13.0)
-    [[ -a $sysp/battery ]] && local bat=$sysp/battery
+    [[ -a $sysp/battery ]] && local bat0=$sysp/battery
 
-    # Return if no battery found
-    [[ -z $bat ]] && return
-    local capacity=$(<$bat/capacity)
-    local battery_status=$(<$bat/status)
-    [[ $capacity -gt 100 ]] && local bat_percent=100 || local bat_percent=$capacity
-    [[ $battery_status =~ Charging || $battery_status =~ Full ]] && local connected=true
+    local capacity battery_status
+    if (( ${+bat0} && ${+bat1} )); then
+      # two batteries
+      capacity=$(( ( $(cat $bat0/capacity) * $(cat $bat0/(energy|charge)_full) \
+        + $(cat $bat1/capacity) * $(cat $bat1/(energy|charge)_full) )          \
+        / ( $(cat $bat0/(energy|charge)_full) + $(cat $bat1/(energy|charge)_full) ) ))
+      [[ $(<${bat0}/status) =~ Charging || $(<${bat1}/status) =~ Charging ]] \
+        && battery_status=Charging
+      [[ $(<${bat0}/status) =~ Full && $(<${bat1}/status) =~ Full ]] \
+        && battery_status=Full
+    elif (( ${+bat0} ^^ ${+bat1} )); then
+      # only bat0 OR bat1 isset
+      capacity=$(<${bat0}${bat1}/capacity)
+      battery_status=$(<${bat0}${bat1}/status)
+    else
+      # Return if no battery found
+      return
+    fi
+
+    [[ $capacity -gt 100 ]] \
+      && local bat_percent=100 \
+      || local bat_percent=$capacity
+    [[ $battery_status =~ Charging || $battery_status =~ Full ]] \
+      && local connected=true
+
     if [[ -z $connected ]]; then
-      [[ $bat_percent -lt $P9K_BATTERY_LOW_THRESHOLD ]] && current_state="low" || current_state="disconnected"
+      [[ $bat_percent -lt $P9K_BATTERY_LOW_THRESHOLD ]] \
+        && current_state="low" \
+        || current_state="disconnected"
     else
       [[ $bat_percent =~ 100 ]] && current_state="charged"
       [[ $bat_percent -lt 100 ]] && current_state="charging"
     fi
     if [[ -f ${ROOT_PREFIX}/usr/bin/acpi ]]; then
-      local time_remaining=${${(s: :)$(${ROOT_PREFIX}/usr/bin/acpi)}[5]}
+      local time_remaining1=${${(s: :)${(s:Battery:)$(${ROOT_PREFIX}/usr/bin/acpi)}[1]}[4]}
+      local time_remaining2=${${(s: :)${(s:Battery:)$(${ROOT_PREFIX}/usr/bin/acpi)}[2]}[4]}
+      [[ -z $time_remaining2 ]] \
+        && local time_remaining=$time_remaining1 \
+        || local time_remaining=$time_remaining2
       if [[ $time_remaining =~ "rate" ]]; then
         local tstring="..."
       elif [[ $time_remaining =~ "[[:digit:]]+" ]]; then

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -153,7 +153,7 @@ function testBatterySegmentIfBatteryIsFullOnLinux() {
 function testBatterySegmentIfBatteryIsNormalWithAcpiEnabledOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "50" "Discharging"
-  echo "echo 'Battery 0: Discharging, 50%, 01:38:54 remaining'" > ${FOLDER}/usr/bin/acpi
+  echo "echo 'Battery 0: Unknown, 50%\nBattery 1: Discharging, 50%, 01:38:54 remaining\n'" > ${FOLDER}/usr/bin/acpi
   chmod +x ${FOLDER}/usr/bin/acpi
   # For running on Mac, we need to mock date :(
   [[ -f /usr/local/bin/gdate ]] && alias date=gdate
@@ -168,7 +168,7 @@ function testBatterySegmentIfBatteryIsCalculatingWithAcpiEnabledOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "50" "Discharging"
   # Todo: Include real acpi output!
-  echo "echo 'Battery 0: Discharging, 50%, rate remaining'" > ${FOLDER}/usr/bin/acpi
+  echo "echo 'Battery 0: Discharging, 50%, rate remaining\nBattery 1: Unknown, 98%'" > ${FOLDER}/usr/bin/acpi
   chmod +x ${FOLDER}/usr/bin/acpi
 
   assertEquals "%K{000} %F{015}🔋 %f%F{015}50%% (...) " "$(prompt_battery left 1 false ${FOLDER})"

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -63,6 +63,8 @@ function makeBatterySay() {
   local battery_status="$2"
   echo "$battery_status" > $BATTERY_PATH/BAT0/status
   echo "$battery_status" > $BATTERY_PATH/BAT1/status
+  echo "21510000" > $BATTERY_PATH/BAT0/energy_full
+  echo "21510000" > $BATTERY_PATH/BAT1/energy_full
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnOSX() {


### PR DESCRIPTION
I added support for two batteries.

Most of the logic stays the same. It does take into account if the capacities of the batteries are different and should work normally if only one battery is present.

The time remaining or until full charge is taken from the two `acpi` lines. I could only see one "active" at a time. Active being a battery being charged or discharged with a time count. That's why I don't aggregate the time valuesand just pick the one that is not empty.