### PR TITLE
[PoC] Fix broken prompt when quickly pressing ctrl-c

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -351,8 +351,8 @@ function __p9k_prepare_prompts() {
   local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
 
   if [[ "$P9K_PROMPT_ON_NEWLINE" == true ]]; then
-    PROMPT='${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
-${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}'
+    PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
+${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
     if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left
       # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
@@ -366,13 +366,13 @@ ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}'
       RPROMPT_SUFFIX=''
     fi
   else
-    PROMPT='%f%b%k$(__p9k_build_left_prompt)'
+    PROMPT="%f%b%k$(__p9k_build_left_prompt)"
     RPROMPT_PREFIX=''
     RPROMPT_SUFFIX=''
   fi
 
   if [[ "$P9K_DISABLE_RPROMPT" != true ]]; then
-    RPROMPT="$RPROMPT_PREFIX"'%f%b%k$(__p9k_build_right_prompt)%{$reset_color%}'"$RPROMPT_SUFFIX"
+    RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{$reset_color%}${RPROMPT_SUFFIX}"
   fi
 
 local NEWLINE='

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -146,7 +146,7 @@ function +vi-git-aheadbehind() {
   local ahead behind branch_name
   local -a gitstatus
 
-  branch_name=$(command git symbolic-ref --short HEAD 2>/dev/null)
+  branch_name=${(q)$(command git symbolic-ref --short HEAD 2>/dev/null)}
 
   # for git prior to 1.7
   # ahead=$(command git rev-list origin/${branch_name}..HEAD | wc -l)
@@ -183,7 +183,7 @@ function +vi-git-remotebranch() {
     fi
   fi
 
-  hook_com[branch]="${__P9K_ICONS[VCS_BRANCH]}${hook_com[branch]}"
+  hook_com[branch]="${__P9K_ICONS[VCS_BRANCH]}${(q)hook_com[branch]}"
   # Always show the remote
   #if [[ -n ${remote} ]] ; then
   # Only show the remote if it differs from the local
@@ -192,7 +192,7 @@ function +vi-git-remotebranch() {
         "${P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH}" == 'true' \
         || "${remote#*/}" != "${branch_name#heads/}" \
       ) ]]; then
-    hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${remote// /}"
+    hook_com[branch]+="${__P9K_ICONS[VCS_REMOTE_BRANCH]}${(q)remote// /}"
   fi
 }
 
@@ -216,7 +216,7 @@ function +vi-git-tagname() {
         hook_com[branch]="${__P9K_ICONS[VCS_BRANCH]}${revision} ${__P9K_ICONS[VCS_TAG]}${tag}"
       else
         # We are on both a tag and a branch; print both by appending the tag name.
-        hook_com[branch]+=" ${__P9K_ICONS[VCS_TAG]}${tag}"
+        hook_com[branch]+=" ${__P9K_ICONS[VCS_TAG]}${(q)tag}"
       fi
     fi
   fi
@@ -229,13 +229,13 @@ function +vi-git-stash() {
 
   if [[ -s $(command git rev-parse --git-dir)/refs/stash ]] ; then
     stashes=$(command git stash list 2>/dev/null | wc -l)
-    hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${stashes// /}"
+    hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${(q)stashes// /}"
   fi
 }
 
 function +vi-hg-bookmarks() {
   if [[ -n "${hgbmarks[@]}" ]]; then
-    hook_com[hg-bookmark-string]=" ${__P9K_ICONS[VCS_BOOKMARK]}${hgbmarks[@]}"
+    hook_com[hg-bookmark-string]=" ${__P9K_ICONS[VCS_BOOKMARK]}${(q)hgbmarks[@]}"
 
     # To signal that we want to use the sting we just generated, set the special
     # variable `ret' to something other than the default zero:


### PR DESCRIPTION
The fix for double expansion of prompt was to delay the rendering of the prompt as much as possible, and leave it to ZSH to escape everything correctly. This led $PROMPT to just contain '$(__p9k_build_left_prompt)'. Before it contained the contents of that evaluation. The current fix is now to quote all input values coming from VCS_INFO and work on the quoted values.
This fix is for poisoned VCS repos only. It may occur on other segments too, if it is possible to create such output. To test test poisoned VCS repos, there is [njhartwell/pw3nage](https://github.com/njhartwell/pw3nage).

The original fix was from @belak in #486 

This fixes #812 