### PR TITLE
Fixes zsh version for Dockerfile for zsh 5.6.2

### DIFF
--- a/docker/base-5.6.2/Dockerfile
+++ b/docker/base-5.6.2/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   git \
-  zsh=5.6.2-1 \
+  zsh=5.6.2-3 \
   mercurial \
   subversion \
   golang \


### PR DESCRIPTION
```
root@34366f8998aa:/# apt-cache policy zsh
zsh:
  Installed: (none)
  Candidate: 5.6.2-3
  Version table:
     5.6.2-3 500
        500 http://deb.debian.org/debian buster/main amd64 Packages
```

How about something like this to determine version first?
```
$ apt-cache policy zsh |grep 5.5.1 |head -1 |awk '{print $2}'
5.5.1-1ubuntu2
```