### PR TITLE
[Bugfix] truncate_with_package_name outputs "null" if name is missing

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -930,6 +930,10 @@ prompt_dir() {
           || node -e 'console.log(require(process.argv[1]).name);' ${pkgFile} 2>/dev/null \
           || cat "${pkgFile}" 2> /dev/null | grep -m 1 "\"name\"" | awk -F ':' '{print $2}' | awk -F '"' '{print $2}' 2>/dev/null \
           )
+        if [ "$packageName" = null ]; then
+          # fix for missing name in pkgFile
+          packageName=$(basename `git rev-parse --show-toplevel`)
+        fi
         if [[ -n "${packageName}" ]]; then
           # Instead of printing out the full path, print out the name of the package
           # from the package.json and append the current subdirectory

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -266,6 +266,38 @@ function testTruncateWithPackageNameWorks() {
   cd $p9kFolder
   rm -fr $BASEFOLDER
 }
+function testTruncateWithPackageNameWorksIfNoPackageNameIsSet() {
+  local p9kFolder=$(pwd)
+  local BASEFOLDER=/tmp/powerlevel9k-test
+  local FOLDER=$BASEFOLDER/1/12/123/1234/12345/123456/1234567/12345678/123456789
+  mkdir -p $FOLDER
+
+  cd /tmp/powerlevel9k-test
+  echo '
+{
+  "private": true
+}
+' > package.json
+  # Unfortunately: The main folder must be a git repo..
+  git init &>/dev/null
+
+  # Go back to deeper folder
+  cd "${FOLDER}"
+
+  local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  local POWERLEVEL9K_SHORTEN_DIR_LENGTH=2
+  local POWERLEVEL9K_SHORTEN_STRATEGY='truncate_with_package_name'
+
+  # Load Powerlevel9k
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  assertEquals "%K{004} %F{000}powerlevel9k-test/1/12/123/12…/12…/12…/12…/12…/123456789 %k%F{004}%f " "$(build_left_prompt)"
+
+  # Go back
+  cd $p9kFolder
+  rm -fr $BASEFOLDER
+}
 
 function testTruncateWithPackageNameIfRepoIsSymlinkedInsideDeepFolder() {
   local p9kFolder=$(pwd)


### PR DESCRIPTION
Given a package.json without a name for the project the truncate_with_package_name strategy outputs "null" instead of a package name and keeps truncating.

This happens for example within laravel projects, as laravel defaults to using a [package.json](https://github.com/laravel/laravel/blob/master/package.json) without a name in it.

Of course it is possible to work around this with better configuration (trying composer.json before package.json) -- but I presume outputting "null" as the package name can still be considered a bug and should be avoided.

As the name of the projects root folder most likely resembles something like the project name I personally would prefer using that instead of not truncating at all.

This is what I did in this PR.

before:
![outputs_null](https://user-images.githubusercontent.com/19490174/47435055-18792100-d7a4-11e8-9008-4c0d2aaa2a99.png)

after:
![outputs_base_folder](https://user-images.githubusercontent.com/19490174/47435101-29299700-d7a4-11e8-806a-ffe915a91fc4.png)

