### PR TITLE
Show number of steps to go when rebasing/merging

### DIFF
--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -342,6 +342,10 @@ __p9k_vcs_init() {
     VCS_CHANGESET_PREFIX="${__P9K_ICONS[VCS_COMMIT]}%0.${P9K_VCS_INTERNAL_HASH_LENGTH}i "
   fi
 
+  # Show number of applied patches. This is used during merges and rebases
+  # %c number of unapplied patches | %n number of applied patched | %a number of all patches
+  zstyle ':vcs_info:*' patch-format ' %n/%a'
+
   # Load supported version control backends
   zstyle ':vcs_info:*' enable git hg svn
 
@@ -353,7 +357,7 @@ __p9k_vcs_init() {
   zstyle ':vcs_info:*' formats "${VCS_DEFAULT_FORMAT}"
 
   # A list of formats, used if there is a special action going on in your current repository; like an interactive rebase or a merge conflict.
-  zstyle ':vcs_info:*' actionformats "%b $(p9k::foreground_color ${P9K_VCS_ACTIONFORMAT_FOREGROUND})| %a%f"
+  zstyle ':vcs_info:*' actionformats "%b $(p9k::foreground_color ${P9K_VCS_ACTIONFORMAT_FOREGROUND})| %a%m%f"
 
   # This string will be used in the %c escape if there are staged changes in the repository.
   zstyle ':vcs_info:*' stagedstr " ${__P9K_ICONS[VCS_STAGED]}"

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -261,7 +261,7 @@ function testActionHintWorks() {
   git commit -a -m "Provoke conflict" &>/dev/null
   git pull &>/dev/null
 
-  assertEquals "%K{003} %F{000} master %F{001}| merge%f %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000} master %F{001}| merge 1/1 ↑1 ↓1%f %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testIncomingHintWorks() {


### PR DESCRIPTION
This fixes #691 

VCS_INFO has showing the number of steps in a rebase already builtin. Just need to activate and define the format ([documentation](http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#vcs_005finfo-Configuration)):
![bildschirmfoto 2018-10-27 um 12 23 50](https://user-images.githubusercontent.com/1544760/47602787-ccb4ba80-d9e3-11e8-9fda-32b939adc128.png)

Caveat:
We can only apply one `actionformat`, thus this information is also printed on other actions (like `merge`), where it is rather useless..
Secondly, this change now prints if there are incoming/outgoing changes when merging/rebasing (See 207874b21cedc0fa54ca11863a4ad660a05b35d0).

I haven't changed the tests yet, so I expect a couple of failures there. Just wanted to discuss the feature first.

//cc @cybercussion