### PR TITLE
Speedup vcs: Get rid of git status

### DIFF
--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -125,19 +125,14 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
 
 ################################################################
 # Register segment helper default values
-p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
+p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
-  # TODO: check git >= 1.7.2 - see function git_compare_version()
-  local FLAGS
-  FLAGS=('--porcelain')
-
-  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "false" ]]; then
-    FLAGS+='--ignore-submodules=dirty'
-  fi
-
-  if [[ "$(command git status ${FLAGS})" =~ "\?\?" ]]; then
+  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach 'git ls-files --others --exclude-standard')" != "" ]]; then
+    hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
+    VCS_WORKDIR_HALF_DIRTY=true
+  elif [[ "$(command git ls-files --others --exclude-standard)" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
   else

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -129,7 +129,7 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
-  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach 'git ls-files --others --exclude-standard')" != "" ]]; then
+  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'git ls-files --others --exclude-standard')" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
   elif [[ "$(command git ls-files --others --exclude-standard)" != "" ]]; then

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -488,6 +488,8 @@ function testGitDirClobber() {
   assertEquals "%K{001} %F{000}✘  /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   cd -
+  unset GIT_DIR
+  unset GIT_WORK_TREE
 }
 
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -503,14 +503,87 @@ function testDetectingUntrackedFilesInSubmodulesWork() {
   git init 1>/dev/null
   touch "i-am-tracked.txt"
   git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
-  # Create untracked file
-  touch "i-am-untracked.txt"
 
   local submodulePath="${PWD}"
 
   cd -
   git submodule add "${submodulePath}" 2>/dev/null
   git commit -m "Add submodule" 1>/dev/null
+
+  # Go into checked-out submodule path
+  cd submodule
+  # Create untracked file
+  touch "i-am-untracked.txt"
+  cd -
+
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+}
+
+function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
+  unset P9K_VCS_UNTRACKED_BACKGROUND
+
+  mkdir ../submodule
+  cd ../submodule
+  git init 1>/dev/null
+  touch "i-am-tracked.txt"
+  git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
+
+  local submodulePath="${PWD}"
+
+  cd -
+  git submodule add "${submodulePath}" 2>/dev/null
+  git commit -m "Add submodule" 1>/dev/null
+
+  # Create untracked file
+  touch "i-am-untracked.txt"
+
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+}
+
+function testDetectingUntrackedFilesInNestedSubmodulesWork() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
+  unset P9K_VCS_UNTRACKED_BACKGROUND
+
+  local mainRepo="${PWD}"
+
+  mkdir ../submodule
+  cd ../submodule
+  git init 1>/dev/null
+  touch "i-am-tracked.txt"
+  git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
+
+  local submodulePath="${PWD}"
+
+  mkdir ../subsubmodule
+  cd ../subsubmodule
+  git init 1>/dev/null
+  touch "i-am-tracked-too.txt"
+  git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
+
+  local subsubmodulePath="${PWD}"
+
+  cd "${submodulePath}"
+  git submodule add "${subsubmodulePath}" 2>/dev/null
+  git commit -m "Add subsubmodule" 1>/dev/null
+  cd "${mainRepo}"
+  git submodule add "${submodulePath}" 2>/dev/null
+  git commit -m "Add submodule" 1>/dev/null
+
+  git submodule update --init --recursive 2>/dev/null
+
+  cd submodule/subsubmodule
+  # Create untracked file
+  touch "i-am-untracked.txt"
+  cd -
 
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -492,4 +492,29 @@ function testGitDirClobber() {
   unset GIT_WORK_TREE
 }
 
+function testDetectingUntrackedFilesInSubmodulesWork() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
+  unset P9K_VCS_UNTRACKED_BACKGROUND
+
+  mkdir ../submodule
+  cd ../submodule
+  git init 1>/dev/null
+  touch "i-am-tracked.txt"
+  git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
+  # Create untracked file
+  touch "i-am-untracked.txt"
+
+  local submodulePath="${PWD}"
+
+  cd -
+  git submodule add "${submodulePath}" 2>/dev/null
+  git commit -m "Add submodule" 1>/dev/null
+
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
This PR gets rid of the slow `git status` part. It makes use of `git ls-files`, which is much faster (thanks to @tupton for the hint in https://github.com/bhilburn/powerlevel9k/issues/60#issuecomment-368130608). Even git submodules are covered by  `git submodule foreach --recursive`.

This PR currently flips `P9K_VCS_SHOW_SUBMODULE_DIRTY`, so that new users won't see changed files in submodules.. Probably this is not necessary any more (my first version used the old `git status`, thus I added an if) and can be flipped back.