### PR TITLE
[Enhancement] Replacing acpi

### DIFF
--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -71,11 +71,10 @@ prompt_battery() {
   fi
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
+    setopt local_options null_glob
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
-    local potential_bats=( $sysp/* )
-    [[ ${#${(M)potential_bats:#*(BAT|battery)*}} > 0 ]] \
-      && local bats=(${$(ls -d $sysp/(battery|BAT*))}) \
-      || return
+    local bats=( $sysp/(BAT*|battery) )
+    [[ ${#bats} > 0 ]] || return
 
     local energy_now="0"
     local energy_full="0"

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -83,15 +83,19 @@ prompt_battery() {
     local battery_status_full=true
     local battery_status_charging=false
     for bat in $bats; do
-      local bat_files=( $bat/* )
+      [[ ${#$(ls $bat)} > 0 ]] \
+        && local bat_files=( $bat/* ) \
+        || continue
       [[ ${#${(M)bat_files:#*(energy|charge)_now*}} > 0 ]] \
         && energy_now+="+ $(cat $bat/(energy|charge)_now)"
       [[ ${#${(M)bat_files:#*(energy|charge)_full*}} > 0 ]] \
         && energy_full+="+ $(cat $bat/(energy|charge)_full)"
       [[ ${#${(M)bat_files:#*(power|current)_now*}} > 0 ]] \
         && power_now+="+ $(cat $bat/(power|current)_now)"
-      [[ $(cat $bat/status) != Full ]] && battery_status_full=false
-      [[ $(cat $bat/status) == Charging ]] && battery_status_charging=true
+      if [[ ${#${(M)bat_files:#*status*}} > 0 ]]; then
+        [[ $(<$bat/status) != Full ]] && battery_status_full=false
+        [[ $(<$bat/status) == Charging ]] && battery_status_charging=true
+      fi
     done
     energy_now=$(($energy_now))
     energy_full=$(($energy_full))

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -72,8 +72,8 @@ prompt_battery() {
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
-    local potential_bats=( "$sysp/*" )
-    [[ ${#${(M)potential_bats:#*(BAT|battery)*}} ]] \
+    local potential_bats=( $sysp/* )
+    [[ ${#${(M)potential_bats:#*(BAT|battery)*}} > 0 ]] \
       && local bats=(${$(ls -d $sysp/(battery|BAT*))}) \
       || return
 
@@ -83,9 +83,13 @@ prompt_battery() {
     local battery_status_full=true
     local battery_status_charging=false
     for bat in $bats; do
-      energy_now+="+ $(cat $bat/(energy|charge)_now)"
-      energy_full+="+ $(cat $bat/(energy|charge)_full)"
-      power_now+="+ $(cat $bat/(power|current)_now)"
+      local bat_files=( $bat/* )
+      [[ ${#${(M)bat_files:#*(energy|charge)_now*}} > 0 ]] \
+        && energy_now+="+ $(cat $bat/(energy|charge)_now)"
+      [[ ${#${(M)bat_files:#*(energy|charge)_full*}} > 0 ]] \
+        && energy_full+="+ $(cat $bat/(energy|charge)_full)"
+      [[ ${#${(M)bat_files:#*(power|current)_now*}} > 0 ]] \
+        && power_now+="+ $(cat $bat/(power|current)_now)"
       [[ $(cat $bat/status) != Full ]] && battery_status_full=false
       [[ $(cat $bat/status) == Charging ]] && battery_status_charging=true
     done
@@ -112,7 +116,7 @@ prompt_battery() {
     # calculate (dis)charging time
     if [[ $battery_status_full == true ]]; then
       # ignore full case (this just keeps a flat if structure)
-    elif [[ $power_now -gt 0 ]]; then
+    elif [[ $power_now > 0 ]]; then
       local tstring
       if [[ $battery_status_charging == true ]]; then
         tstring=$(( 60 * ($energy_full - $energy_now) / $power_now ))

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -71,6 +71,7 @@ prompt_battery() {
   fi
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
+    # needed if files or directory do not match globbing pattern
     setopt local_options null_glob
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
     local bats=( $sysp/(BAT*|battery) )
@@ -82,20 +83,25 @@ prompt_battery() {
     local battery_status_full=true
     local battery_status_charging=false
     for bat in $bats; do
-      [[ ${#$(ls $bat)} > 0 ]] \
-        && local bat_files=( $bat/* ) \
-        || continue
-      [[ ${#${(M)bat_files:#*(energy|charge)_now*}} > 0 ]] \
-        && energy_now+="+ $(cat $bat/(energy|charge)_now)"
-      [[ ${#${(M)bat_files:#*(energy|charge)_full*}} > 0 ]] \
-        && energy_full+="+ $(cat $bat/(energy|charge)_full)"
-      [[ ${#${(M)bat_files:#*(power|current)_now*}} > 0 ]] \
-        && power_now+="+ $(cat $bat/(power|current)_now)"
-      if [[ ${#${(M)bat_files:#*status*}} > 0 ]]; then
-        [[ $(<$bat/status) != Full ]] && battery_status_full=false
-        [[ $(<$bat/status) == Charging ]] && battery_status_charging=true
-      fi
+      # skip this loop if no files in $bat
+      local bat_tmp=( $bat/* )
+      [[ ${#bat_tmp} > 0 ]] || continue
+      # add + [number in file] if the file exists
+      local energy_now_tmp=( $bat/(energy|charge)_now )
+      energy_now+="+ 0$(<${energy_now_tmp[1]:-/dev/null})"
+      local energy_full_tmp=( $bat/(energy|charge)_full )
+      energy_full+="+ 0$(< ${energy_full_tmp[1]:-/dev/null})"
+      local power_now_tmp=( $bat/(power|current)_now )
+      power_now+="+ 0$(< ${power_now_tmp[1]:-/dev/null})"
+      # get kumulative battery status (ignore if no status file exists)
+      local battery_status=( $bat/status )
+      [[ $(<${battery_status[1]:-/dev/null}) != Full && -n $(<${battery_status[1]:-/dev/null}) ]] \
+        && battery_status_full=false
+      [[ $(<${battery_status[1]:-/dev/null}) == Charging ]] \
+        && battery_status_charging=true
     done
+
+    # replace values of varibales with evaluation of the sums
     energy_now=$(($energy_now))
     energy_full=$(($energy_full))
     power_now=$(($power_now))

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -77,18 +77,23 @@ prompt_battery() {
       && local bats=(${$(ls -d $sysp/(battery|BAT*))}) \
       || return
 
-    local numerator="0"
-    local denominator="0"
+    local energy_now="0"
+    local energy_full="0"
+    local power_now="0"
     local battery_status_full=true
     local battery_status_charging=false
     for bat in $bats; do
-      numerator+="+ $(cat $bat/capacity) * $(cat $bat/(energy|charge)_full)"
-      denominator+="+ $(cat $bat/(energy|charge)_full)"
+      energy_now+="+ $(cat $bat/(energy|charge)_now)"
+      energy_full+="+ $(cat $bat/(energy|charge)_full)"
+      power_now+="+ $(cat $bat/(power|current)_now)"
       [[ $(cat $bat/status) != Full ]] && battery_status_full=false
       [[ $(cat $bat/status) == Charging ]] && battery_status_charging=true
     done
+    energy_now=$(($energy_now))
+    energy_full=$(($energy_full))
+    power_now=$(($power_now))
 
-    local capacity=$(( ($numerator)/($denominator) ))
+    local capacity=$(( 100 * $energy_now / $energy_full ))
     [[ $capacity -gt 100 ]] \
       && local bat_percent=100 \
       || local bat_percent=$capacity
@@ -103,17 +108,21 @@ prompt_battery() {
       [[ $bat_percent =~ 100 ]] && current_state="charged"
       [[ $bat_percent -lt 100 ]] && current_state="charging"
     fi
-    if [[ -f ${ROOT_PREFIX}/usr/bin/acpi ]]; then
-      declare -a acpi_lines
-      acpi_lines=( "${(@f)$(${ROOT_PREFIX}/usr/bin/acpi)}" )
-      local time_remaining=${${=${(M)acpi_lines:#*([[:digit:]][[:digit:]]:|rate)*}}[5]}
-      unset acpi_lines
 
-      if [[ $time_remaining =~ "rate" ]]; then
-        local tstring="..."
-      elif [[ $time_remaining =~ "[[:digit:]]+" ]]; then
-        local tstring=${(f)$(date -u -d "$(echo $time_remaining)" +%k:%M 2> /dev/null)}
+    # calculate (dis)charging time
+    if [[ $battery_status_full == true ]]; then
+      # ignore full case (this just keeps a flat if structure)
+    elif [[ $power_now -gt 0 ]]; then
+      local tstring
+      if [[ $battery_status_charging == true ]]; then
+        tstring=$(( 60 * ($energy_full - $energy_now) / $power_now ))
+      else
+        tstring=$(( 60 * $energy_now / $power_now ))
       fi
+      # format to h:mm
+      tstring="$(($tstring/60)):${(l#2##0#)$(($tstring%60))}"
+    else
+      tstring="..."
     fi
     [[ -n $tstring ]] && local remain=" ($tstring)"
   fi

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -72,10 +72,10 @@ prompt_battery() {
 
   if [[ "$__P9K_OS" == 'Linux' ]] || [[ "$__P9K_OS" == 'Android' ]]; then
     # needed if files or directory do not match globbing pattern
-    setopt local_options null_glob
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
-    local bats=( $sysp/(BAT*|battery) )
-    [[ ${#bats} > 0 ]] || return
+    local -a bats
+    bats=( $sysp/(BAT*|battery)(N) )
+    [[ ${#bats} == 0 ]] && return
 
     local energy_now="0"
     local energy_full="0"
@@ -84,17 +84,22 @@ prompt_battery() {
     local battery_status_charging=false
     for bat in $bats; do
       # skip this loop if no files in $bat
-      local bat_tmp=( $bat/* )
-      [[ ${#bat_tmp} > 0 ]] || continue
-      # add + [number in file] if the file exists
-      local energy_now_tmp=( $bat/(energy|charge)_now )
+      local -a bat_tmp
+      bat_tmp=( $bat/*(N) )
+      [[ ${#bat_tmp} == 0 ]] && continue
+      # add "+ 0[number in file]" if the file exists (0 padding if glob fails)
+      local -a energy_now_tmp
+      energy_now_tmp=( $bat/(energy|charge)_now(N) )
       energy_now+="+ 0$(<${energy_now_tmp[1]:-/dev/null})"
-      local energy_full_tmp=( $bat/(energy|charge)_full )
+      local -a energy_full_tmp
+      energy_full_tmp=( $bat/(energy|charge)_full(N) )
       energy_full+="+ 0$(< ${energy_full_tmp[1]:-/dev/null})"
-      local power_now_tmp=( $bat/(power|current)_now )
+      local -a power_now_tmp
+      power_now_tmp=( $bat/(power|current)_now(N) )
       power_now+="+ 0$(< ${power_now_tmp[1]:-/dev/null})"
-      # get kumulative battery status (ignore if no status file exists)
-      local battery_status=( $bat/status )
+      # get cumulative battery status (ignore if no status file exists)
+      local -a battery_status
+      battery_status=( $bat/status(N) )
       [[ $(<${battery_status[1]:-/dev/null}) != Full && -n $(<${battery_status[1]:-/dev/null}) ]] \
         && battery_status_full=false
       [[ $(<${battery_status[1]:-/dev/null}) == Charging ]] \

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -24,6 +24,8 @@ function setUp() {
   # Prepare folder for ${BATTERY} (Linux)
   BATTERY_PATH=$FOLDER/sys/class/power_supply
   mkdir -p $BATTERY_PATH/BAT{0..2}
+  # empty battery
+  mkdir -p $BATTERY_PATH/BAT3
 }
 
 function tearDown() {
@@ -146,16 +148,16 @@ function testBatterySegmentIfBatteryIsLowWhileChargingOnLinux() {
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
-  makeBatterySay "10" "Discharging"
+  makeBatterySay "98" "Discharging"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}10%% (0:14) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% (2:17) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
-  makeBatterySay "10" "Charging"
+  makeBatterySay "98" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}10%% (2:06) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}98%% (0:02) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -23,9 +23,7 @@ function setUp() {
   mkdir -p $PMSET_PATH
   # Prepare folder for ${BATTERY} (Linux)
   BATTERY_PATH=$FOLDER/sys/class/power_supply
-  mkdir -p $BATTERY_PATH
-  mkdir -p $BATTERY_PATH/BAT0
-  mkdir -p $BATTERY_PATH/BAT1
+  mkdir -p $BATTERY_PATH/BAT{0..2}
 }
 
 function tearDown() {
@@ -57,14 +55,31 @@ function makeBatterySay() {
   chmod +x $PMSET_PATH/pmset
 
   # Linux
-  local capacity="$1"
-  echo "$capacity" > $BATTERY_PATH/BAT0/capacity
-  echo "$capacity" > $BATTERY_PATH/BAT1/capacity
   local battery_status="$2"
   echo "$battery_status" > $BATTERY_PATH/BAT0/status
   echo "$battery_status" > $BATTERY_PATH/BAT1/status
-  echo "21510000" > $BATTERY_PATH/BAT0/energy_full
-  echo "21510000" > $BATTERY_PATH/BAT1/energy_full
+  echo "$battery_status" > $BATTERY_PATH/BAT2/status
+
+  local capacity="$1"
+  if [[ $capacity =~ ^[0-9]*$ ]]; then
+    echo "10000000" > $BATTERY_PATH/BAT0/energy_full
+    echo  "5000000" > $BATTERY_PATH/BAT1/charge_full
+    echo  "2500000" > $BATTERY_PATH/BAT2/energy_full
+    echo  "$((10000000*$capacity/100))" > $BATTERY_PATH/BAT0/energy_now
+    echo  "$(( 5000000*$capacity/100))" > $BATTERY_PATH/BAT1/energy_now
+    echo  "$(( 2500000*$capacity/100))" > $BATTERY_PATH/BAT2/charge_now
+  fi
+
+  # charge or discharge
+  if [[ $battery_status == Charging || $battery_status == Discharging ]]; then
+    echo  "5000000" > $BATTERY_PATH/BAT0/current_now
+    echo  "2500000" > $BATTERY_PATH/BAT1/power_now
+    echo        "0" > $BATTERY_PATH/BAT2/power_now
+  else
+    echo        "0" > $BATTERY_PATH/BAT0/power_now
+    echo        "0" > $BATTERY_PATH/BAT1/power_now
+    echo        "0" > $BATTERY_PATH/BAT2/power_now
+  fi
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnOSX() {
@@ -83,7 +98,7 @@ function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
   assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
-function testBatterySegmentIfBatteryIsAlmostFullWhileDischargingOnOSX() {
+function testBatterySegmentIfBatteryIsNormalWhileDischargingOnOSX() {
   local __P9K_OS='OSX' # Fake OSX
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; discharging; 3:57 remaining present: true"
@@ -91,7 +106,7 @@ function testBatterySegmentIfBatteryIsAlmostFullWhileDischargingOnOSX() {
   assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
-function testBatterySegmentIfBatteryIsAlmostFullWhileChargingOnOSX() {
+function testBatterySegmentIfBatteryIsNormalWhileChargingOnOSX() {
   local __P9K_OS='OSX' # Fake OSX
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; charging; 3:57 remaining present: true"
@@ -119,28 +134,28 @@ function testBatterySegmentIfBatteryIsLowWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Discharging"
 
-  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% (2:14) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "10" "Discharging"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}10%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %f%F{015}10%% (0:14) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "10" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}10%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %f%F{003}10%% (2:06) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {
@@ -150,28 +165,11 @@ function testBatterySegmentIfBatteryIsFullOnLinux() {
   assertEquals "%K{000} %F{002}🔋 %f%F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
-function testBatterySegmentIfBatteryIsNormalWithAcpiEnabledOnLinux() {
+function testBatterySegmentIfBatteryIsCalculatingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
-  makeBatterySay "50" "Discharging"
-  echo "echo 'Battery 0: Unknown, 50%\nBattery 1: Discharging, 50%, 01:38:54 remaining\n'" > ${FOLDER}/usr/bin/acpi
-  chmod +x ${FOLDER}/usr/bin/acpi
-  # For running on Mac, we need to mock date :(
-  [[ -f /usr/local/bin/gdate ]] && alias date=gdate
+  makeBatterySay "99" "Unknown"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}50%% (1:38) " "$(prompt_battery left 1 false ${FOLDER})"
-
-  unalias date &>/dev/null
-  return 0
-}
-
-function testBatterySegmentIfBatteryIsCalculatingWithAcpiEnabledOnLinux() {
-  local __P9K_OS='Linux' # Fake Linux
-  makeBatterySay "50" "Discharging"
-  # Todo: Include real acpi output!
-  echo "echo 'Battery 0: Discharging, 50%, rate remaining\nBattery 1: Unknown, 98%'" > ${FOLDER}/usr/bin/acpi
-  chmod +x ${FOLDER}/usr/bin/acpi
-
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}50%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %f%F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
This PR aims to replace `acpi` as a dependency for showing remaining charge and discharge time by using data from battery folders in `/sys/class/power_supply`.

I have only limited access to different hardware, so I'd appreciate it if somebody could test this code on different machines. Mocking tests won't help me here. If it should not work, please provide detailed information about the contents of folders in `/sys/class/power_supply`.

P.S.: I only added the code and didn't update the tests yet