### PR TITLE
Speedup VCS Segment 4

### DIFF
--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -129,17 +129,34 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
-  [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return
+  [[ -z "${vcs_comm[gitdir]}" ]] && return
 
-  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
+  # If we are in a repos root folder, vcs_comm[gitdir] yields ".git".
+  # Inside the .git dir itself (and not a subdir of it) the variable
+  # yields ".". In any other case (either a subdirectory of .git or
+  # the repo itself), the value of vcs_comm[gitdir] is the absolute
+  # path to the .git directory.
+  # Therefore we can step up a directory, if we are inside the .git
+  # folder. And in any other case, use the parent directory of the
+  # gitdir.
+  local repoDir="."
+  # Getting the parent dir of the current dir "." is still ".", so
+  # is is safe to do this always.
+  [[ "${vcs_comm[gitdir]}" != ".git" ]] && repoDir="${vcs_comm[gitdir]:h}"
+  [[ "${vcs_comm[gitdir]}" == "." ]] && repoDir=".."
+
+  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(cd ${repoDir} && command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
-  elif [[ "$(command git ls-files --others --exclude-standard)" != "" ]]; then
+  elif [[ "$(cd ${repoDir} && command git ls-files --others --exclude-standard)" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
   else
     VCS_WORKDIR_HALF_DIRTY=false
   fi
+  # If we are in any other directory than the repo root, we want
+  # to go back a directory.
+  [[ "${vcs_comm[gitdir]}" != ".git" ]] && cd - >/dev/null
 }
 
 function +vi-git-aheadbehind() {

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -129,34 +129,20 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
-  [[ -z "${vcs_comm[gitdir]}" ]] && return
+  [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return
 
-  # If we are in a repos root folder, vcs_comm[gitdir] yields ".git".
-  # Inside the .git dir itself (and not a subdir of it) the variable
-  # yields ".". In any other case (either a subdirectory of .git or
-  # the repo itself), the value of vcs_comm[gitdir] is the absolute
-  # path to the .git directory.
-  # Therefore we can step up a directory, if we are inside the .git
-  # folder. And in any other case, use the parent directory of the
-  # gitdir.
-  local repoDir="."
-  # Getting the parent dir of the current dir "." is still ".", so
-  # is is safe to do this always.
-  [[ "${vcs_comm[gitdir]}" != ".git" ]] && repoDir="${vcs_comm[gitdir]:h}"
-  [[ "${vcs_comm[gitdir]}" == "." ]] && repoDir=".."
+  # If we are in a .git folder, do not check for untracked files.
+  [[ "${PWD:A}" =~ "\.git/" ]] && return
 
-  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(cd ${repoDir} && command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
+  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
-  elif [[ "$(cd ${repoDir} && command git ls-files --others --exclude-standard)" != "" ]]; then
+  elif [[ "$(command git ls-files --others --exclude-standard)" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
   else
     VCS_WORKDIR_HALF_DIRTY=false
   fi
-  # If we are in any other directory than the repo root, we want
-  # to go back a directory.
-  [[ "${vcs_comm[gitdir]}" != ".git" ]] && cd - >/dev/null
 }
 
 function +vi-git-aheadbehind() {

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -134,10 +134,24 @@ function +vi-git-untracked() {
   # If we are in a .git folder, do not check for untracked files.
   [[ "${PWD:A}" =~ "\.git/" ]] && return
 
+  # If we are in a repos root folder, vcs_comm[gitdir] yields ".git".
+  # Inside the .git dir itself (and not a subdir of it) the variable
+  # yields ".". In any other case (either a subdirectory of .git or
+  # the repo itself), the value of vcs_comm[gitdir] is the absolute
+  # path to the .git directory.
+  # Therefore we can step up a directory, if we are inside the .git
+  # folder. And in any other case, use the parent directory of the
+  # gitdir.
+  local repoDir="."
+  # Getting the parent dir of the current dir "." is still ".", so
+  # is is safe to do this always.
+  [[ "${vcs_comm[gitdir]}" != ".git" ]] && repoDir="${vcs_comm[gitdir]:A:h}"
+  [[ "${vcs_comm[gitdir]}" == "." ]] && repoDir="${PWD:A:h}"
+
   if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
-  elif [[ "$(command git ls-files --others --exclude-standard)" != "" ]]; then
+  elif [[ "$(command git ls-files --others --exclude-standard "${repoDir}")" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true
   else

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -129,6 +129,8 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
+  [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return
+
   if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
     hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
     VCS_WORKDIR_HALF_DIRTY=true

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -244,11 +244,9 @@ function +vi-git-tagname() {
 # Show count of stashed changes
 # Port from https://github.com/whiteinge/dotfiles/blob/5dfd08d30f7f2749cfc60bc55564c6ea239624d9/.zsh_shouse_prompt#L268
 function +vi-git-stash() {
-  local -a stashes
-
-  if [[ -s "${vcs_comm[gitdir]}/refs/stash" ]] ; then
-    stashes=$(command git stash list 2>/dev/null | wc -l)
-    hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${stashes// /}"
+  if [[ -s "${vcs_comm[gitdir]}/logs/refs/stash" ]] ; then
+    local -a stashes=( "${(@f)"$(<${vcs_comm[gitdir]}/logs/refs/stash)"}" )
+    hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${#stashes}"
   fi
 }
 

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -590,4 +590,27 @@ function testDetectingUntrackedFilesInNestedSubmodulesWork() {
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
+function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
+  unset P9K_VCS_UNTRACKED_BACKGROUND
+
+  mkdir clean-folder
+  touch clean-folder/file.txt
+
+  mkdir dirty-folder
+  touch dirty-folder/file.txt
+
+  git add . 2>/dev/null
+  git commit -m "Initial commit" >/dev/null
+
+  touch dirty-folder/new-file.txt
+  cd clean-folder
+
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
This PR changes the way how stashes are counted. Previously the stashes were counted via `git stash list | wc -l`, now they are counted without invoking `wc` or even `git`.

Secondly this fixes an issue with the untracked files: That code worked only within the current directory. So if you have untracked files in your repo root and change into a clean subdir, you never saw the untracked icon. This is now fixed.

Talking in speed:
`time ( repeat 10; do; prompt_vcs "left" 1 false > /dev/null; done;)` in my P9K dev repo with 65 stashes:
**1,57s user 1,68s system 85% cpu 3,804 total**
Old segment from `next` (5200a1ba2274e5383f2207caecc5d8b3c0e9c242):
**2,32s user 2,58s system 83% cpu 5,864 total**

@Erowlin could you double check the speed improvements?