### PR TITLE
Improve truncate_with_package_name strategy

### DIFF
--- a/segments/dir.p9k
+++ b/segments/dir.p9k
@@ -121,22 +121,12 @@ prompt_dir() {
         fi
       ;;
       truncate_with_package_name)
-        local name repo_path package_path current_dir zero
-
-        package_path=${PWD:A}
-        # Get the path of the Git repo, which should have the package.json file
-        if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == "true" ]]; then
-          # Get path from the root of the git repository to the current dir
-          local gitPath=$(git rev-parse --show-prefix)
-          # Remove trailing slash from git path, so that we can
-          # remove that git path from the pwd.
-          gitPath=${gitPath%/}
-          package_path=${PWD%%$gitPath}
-          # Remove trailing slash
-          package_path=${package_path%/}
-        elif [[ $(git rev-parse --is-inside-git-dir 2> /dev/null) == "true" ]]; then
-          package_path=${PWD%%/.git*}
-        fi
+        # Search for the folder marker in the parent directories and
+        # buildup a pattern that is removed from the current path
+        # later on.
+        local -a markedFolders
+        markedFolders=( $(__p9k_upsearch "(${(j:|:)P9K_DIR_PACKAGE_FILES})") )
+        local package_path="${markedFolders[1]}"
 
         # Replace the shortest possible match of the marked folder from
         # the current path. Remove the amount of characters up to the


### PR DESCRIPTION
The `truncate_with_package_name` shortening strategy now makes use of `__p9k_upsearch`. So now the current directory must not be inside a git checkout any more.