### PR TITLE
[New Segment] Added Reminder segment

### DIFF
--- a/segments/reminder.p9k
+++ b/segments/reminder.p9k
@@ -1,0 +1,71 @@
+# vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+################################################################
+# @title powerlevel9k Segment - Reminder
+# @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
+##
+
+################################################################
+# Register segment
+# Parameters:
+#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+#                                                                                                                             
+p9k::register_segment 'REMINDER' '' green "$DEFAULT_COLOR" '!!' ''   $'\UF0A4 '   '\u'"${CODEPOINT_OF_AWESOME_HAND_O_RIGHT}"   $'\UF0A4'
+
+################################################################
+# @description
+#   Display the reminder icon/text for the current time interval.
+##
+# @args
+#   $1 string Alignment - left | right
+#   $2 integer Segment index
+#   $3 boolean Whether the segment should be joined
+##
+prompt_reminder() {
+	typeset -AH __lookup
+  __lookup=(
+    "sun" 0
+    "mon" 1
+    "tue" 2
+    "wed" 3
+    "thu" 4
+    "fri" 5
+    "sat" 6
+  )
+	local dow=$( date +"%w" )
+	local now=$( date +"%H%M" )
+  local segment_content=""
+	local separator=""
+	for rule in $P9K_REMINDER_RULES; do
+		echo $rule | while read date_exp time_exp icon; do
+			time_exp=$( echo "$time_exp" | sed -e "s/[:]//g" )
+			local match=false
+			case "$date_exp" in
+				'*')
+					match=true
+					;;
+
+				???-???)
+					d=("${(@s/-/)date_exp}")
+					start_day=$__lookup[$d[1]]
+					end_day=$__lookup[$d[2]]
+					[[ ( $dow -ge $start_day ) && ( $dow -le $end_day ) ]] && match=true
+					;;
+
+				???)
+					start_day=$__lookup[$date_exp]
+					[[ $dow -eq $start_day ]] && match=true
+					;;
+			esac
+			if ( ! $match ) break;
+			t=("${(@s/-/)time_exp}")
+			match=false
+			[[ ( $now -ge $t[1] ) && ( $now -le $t[2] ) ]] && match=true
+			if ( ! $match ) break;
+			segment_content="${segment_content}${separator}${icon}"
+			separator=${P9K_REMINDER_SEPARATOR:-"┊"}
+		done
+	done
+  if ! [ -z "${segment_content}" ]; then
+    p9k::prepare_segment "$0" "" "$1" "$2" "$3" "${segment_content}"
+  fi
+}


### PR DESCRIPTION
#### Reminder segment
A reminder segment named "reminder" that evaluates the current time against an array of reminders and display the associated icon(s).
 
#### Description
Given a P9K_REMINDER_RULES array of strings (day, time, and icons separated by space), evaluate the current time of day against the array and output the appropriate icon(s).

P9K_REMINDER_RULES=(
	"mon-sat 08:30-10:00 $P9K_REMINDER_HOT_BEVERAGE"
	"sun 10:00-18:00 $P9K_REMINDER_TEACUP_WITHOUT_HANDLE"
	"* 20:30-23:59 $P9K_REMINDER_SLEEPING_FACE"
	"* 21:30-23:59 $P9K_REMINDER_PERSON_IN_BED"
)

![reminder-screenshot](https://user-images.githubusercontent.com/1375277/48569658-f3ba2a00-e8c7-11e8-9127-3824b9a857fe.png)

#### Questions
It'd be great if you can have a look and suggest what unit tests might be necessary.
