### PR TITLE
[Bugfix] Fix errors emitted by VCS segment's untracked file check when in a submodule

### DIFF
--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -125,6 +125,8 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
+  [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return
+
   # get the root for the current repo or submodule
   local repoTopLevel="$(command git rev-parse --show-toplevel 2> /dev/null)"
   # dump out if we're outside a git repository (which includes being in the .git folder)

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -122,10 +122,6 @@ p9k::set_default P9K_VCS_HIDE_TAGS false
 p9k::set_default P9K_VCS_INTERNAL_HASH_LENGTH "8" # Default: Just display the first 8 characters of our changeset-ID.
 p9k::set_default P9K_VCS_DIR_SHORTEN_DELIMITER $'\U2026'
 p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
-
-################################################################
-# Register segment helper default values
-p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY false
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -134,7 +134,7 @@ function +vi-git-untracked() {
 
   local untrackedFiles=$(command git ls-files --others --exclude-standard "${repoTopLevel}")
 
-  if [[ -z $untrackedFiles && "$P9K_VCS_SHOW_SUBMODULE_DIRTY" != "false" ]]; then
+  if [[ -z $untrackedFiles && "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" ]]; then
     untrackedFiles+=$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')
   fi
 

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -125,34 +125,21 @@ p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
 p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
-  [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return
+  # get the root for the current repo or submodule
+  local repoTopLevel="$(git rev-parse --show-toplevel 2> /dev/null)"
+  # dump out if we're outside a git repository (which includes being in the .git folder)
+  [[ $? != 0 || -z $repoTopLevel ]] && return
 
-  # If we are in a .git folder, do not check for untracked files.
-  [[ "${PWD:A}" =~ "\.git/" ]] && return
+  local untrackedFiles=$(command git ls-files --others --exclude-standard "${repoTopLevel}")
 
-  # If we are in a repos root folder, vcs_comm[gitdir] yields ".git".
-  # Inside the .git dir itself (and not a subdir of it) the variable
-  # yields ".". In any other case (either a subdirectory of .git or
-  # the repo itself), the value of vcs_comm[gitdir] is the absolute
-  # path to the .git directory.
-  # Therefore we can step up a directory, if we are inside the .git
-  # folder. And in any other case, use the parent directory of the
-  # gitdir.
-  local repoDir="."
-  # Getting the parent dir of the current dir "." is still ".", so
-  # is is safe to do this always.
-  [[ "${vcs_comm[gitdir]}" != ".git" ]] && repoDir="${vcs_comm[gitdir]:A:h}"
-  [[ "${vcs_comm[gitdir]}" == "." ]] && repoDir="${PWD:A:h}"
-
-  if [[ "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" && "$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')" != "" ]]; then
-    hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
-    VCS_WORKDIR_HALF_DIRTY=true
-  elif [[ "$(command git ls-files --others --exclude-standard "${repoDir}")" != "" ]]; then
-    hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
-    VCS_WORKDIR_HALF_DIRTY=true
-  else
-    VCS_WORKDIR_HALF_DIRTY=false
+  if [[ -z $untrackedFiles && "$P9K_VCS_SHOW_SUBMODULE_DIRTY" != "false" ]]; then
+    untrackedFiles+=$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')
   fi
+
+  [[ -z $untrackedFiles ]] && return
+
+  hook_com[unstaged]+=" ${__P9K_ICONS[VCS_UNTRACKED]}"
+  VCS_WORKDIR_HALF_DIRTY=true
 }
 
 function +vi-git-aheadbehind() {

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -126,7 +126,7 @@ p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
 
 function +vi-git-untracked() {
   # get the root for the current repo or submodule
-  local repoTopLevel="$(git rev-parse --show-toplevel 2> /dev/null)"
+  local repoTopLevel="$(command git rev-parse --show-toplevel 2> /dev/null)"
   # dump out if we're outside a git repository (which includes being in the .git folder)
   [[ $? != 0 || -z $repoTopLevel ]] && return
 

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -613,4 +613,32 @@ function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
+function testGitSubmoduleWorks() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
+  unset P9K_VCS_UNTRACKED_BACKGROUND
+
+  mkdir ../submodule
+  cd ../submodule
+  git init 1>/dev/null
+  touch "i-am-tracked.txt"
+  git add . 1>/dev/null && git commit -m "Initial Commit" 1>/dev/null
+
+  local submodulePath="${PWD}"
+
+  cd -
+  git submodule add "${submodulePath}" 2>/dev/null
+  git commit -m "Add submodule" 1>/dev/null
+
+  cd submodule
+
+  source "${P9K_HOME}/powerlevel9k.zsh-theme"
+
+  local result="$(__p9k_build_left_prompt 2>&1)"
+  [[ "$result" =~ ".*(is outside repository)+" ]] && return 1
+
+  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$result"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
* Unify two "default values" sections to be consistent with other segments, and resolve double-set `P9K_VCS_SHOW_SUBMODULE_DIRTY` default in favor of the current documentation.
* Fix fatal errors emitted when the CWD is inside a submodule's tree.
* Modify logic so that the `VCS_WORKDIR_HALF_DIRTY` status reflects the untracked file state from the *current repo down* instead of always going back to the highest-level repo.
* Modify flow to skip the check completely if the CWD is the local `.git` folder (it's not considered to be a part of the working tree).
* Optimize the routine a bit by skipping the recursive submodule check if the `VCS_WORKDIR_HALF_DIRTY` status can be established by the presence of untracked files in the current repo's tree.