### PR TITLE
Protect locale

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -21,8 +21,6 @@
 # - [Powerline-Patched Font](https://github.com/Lokaltog/powerline-fonts)
 ##
 
-# Set the right locale to protect special characters
-local LC_ALL="" LC_CTYPE="en_US.UTF-8"
 typeset -gAH __P9K_DATA
 typeset -gAH __P9K_ICONS
 
@@ -137,40 +135,44 @@ function p9k::register_segment() {
   [[ -z "${BOLD}" ]] || __P9K_DATA[${STATEFUL_NAME}_BD]=true
 }
 
-#                                                                                                                                
-p9k::register_icon "LEFT_SEGMENT_SEPARATOR"           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'
-#                                                                                                                                
-p9k::register_icon "RIGHT_SEGMENT_SEPARATOR"          $'\uE0B2'           $'\uE0B2'           $'\uE0B2'           $'\uE0B2'           $'\uE0B2'
-#                                                    Whitespace          Whitespace          Whitespace          Whitespace          Whitespace
-p9k::register_icon "LEFT_SEGMENT_END_SEPARATOR"       ' '                 ' '                 ' '                 ' '                 ' '
-#                                                                                                                                
-p9k::register_icon "LEFT_SUBSEGMENT_SEPARATOR"        $'\uE0B1'           $'\uE0B1'           $'\uE0B1'           $'\uE0B1'           $'\uE0B1'
-#                                                                                                                                
-p9k::register_icon "RIGHT_SUBSEGMENT_SEPARATOR"       $'\uE0B3'           $'\uE0B3'           $'\uE0B3'           $'\uE0B3'           $'\uE0B3'
-#                                                    ╭─                  ╭─                 ╭─                  ╭─                 ╭─
-p9k::register_icon "MULTILINE_FIRST_PROMPT_PREFIX"    $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'
-#                                                    ├─                 ├─                  ├─                 ├─                  ├─
-p9k::register_icon "MULTILINE_NEWLINE_PROMPT_PREFIX"  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'
-#                                                    ╰─                 ╰─                  ╰─                 ╰─                  ╰─
-p9k::register_icon "MULTILINE_LAST_PROMPT_PREFIX"     $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  #                                                                                                                                
+  p9k::register_icon "LEFT_SEGMENT_SEPARATOR"           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'           $'\uE0B0'
+  #                                                                                                                                
+  p9k::register_icon "RIGHT_SEGMENT_SEPARATOR"          $'\uE0B2'           $'\uE0B2'           $'\uE0B2'           $'\uE0B2'           $'\uE0B2'
+  #                                                    Whitespace          Whitespace          Whitespace          Whitespace          Whitespace
+  p9k::register_icon "LEFT_SEGMENT_END_SEPARATOR"       ' '                 ' '                 ' '                 ' '                 ' '
+  #                                                                                                                                
+  p9k::register_icon "LEFT_SUBSEGMENT_SEPARATOR"        $'\uE0B1'           $'\uE0B1'           $'\uE0B1'           $'\uE0B1'           $'\uE0B1'
+  #                                                                                                                                
+  p9k::register_icon "RIGHT_SUBSEGMENT_SEPARATOR"       $'\uE0B3'           $'\uE0B3'           $'\uE0B3'           $'\uE0B3'           $'\uE0B3'
+  #                                                    ╭─                  ╭─                 ╭─                  ╭─                 ╭─
+  p9k::register_icon "MULTILINE_FIRST_PROMPT_PREFIX"    $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'  $'\u256D'$'\u2500'
+  #                                                    ├─                 ├─                  ├─                 ├─                  ├─
+  p9k::register_icon "MULTILINE_NEWLINE_PROMPT_PREFIX"  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'  $'\u251C'$'\u2500'
+  #                                                    ╰─                 ╰─                  ╰─                 ╰─                  ╰─
+  p9k::register_icon "MULTILINE_LAST_PROMPT_PREFIX"     $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 ' $'\u2570'$'\u2500 '
 
-# Override the above icon settings with any user-defined variables.
-case ${P9K_MODE} in
-  'flat')
-    # Set the right locale to protect special characters
-    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
-    __P9K_ICONS[LEFT_SEGMENT_SEPARATOR]=''
-    __P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]=''
-    __P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]='|'
-    __P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]='|'
-  ;;
-  'compatible')
-    # Set the right locale to protect special characters
-    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
-    __P9K_ICONS[LEFT_SEGMENT_SEPARATOR]=$'\u2B80'                 # ⮀
-    __P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]=$'\u2B82'                # ⮂
-  ;;
-esac
+  # Override the above icon settings with any user-defined variables.
+  case ${P9K_MODE} in
+    'flat')
+      # Set the right locale to protect special characters
+      local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+      __P9K_ICONS[LEFT_SEGMENT_SEPARATOR]=''
+      __P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]=''
+      __P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]='|'
+      __P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]='|'
+    ;;
+    'compatible')
+      # Set the right locale to protect special characters
+      local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+      __P9K_ICONS[LEFT_SEGMENT_SEPARATOR]=$'\u2B80'                 # ⮀
+      __P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]=$'\u2B82'                # ⮂
+    ;;
+  esac
+}
 
 ################################################################
 # @description

--- a/segments/anaconda.p9k
+++ b/segments/anaconda.p9k
@@ -4,17 +4,21 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                      
-p9k::register_segment "ANACONDA" "" "blue" "$DEFAULT_COLOR" ''  $'\ue63c'  $'\ue63c'  '\u'${CODEPOINT_OF_DEVICONS_PYTHON}  $'\uE73C '
+() {
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                      
+  p9k::register_segment "ANACONDA" "" "blue" "$DEFAULT_COLOR" ''  $'\ue63c'  $'\ue63c'  '\u'${CODEPOINT_OF_DEVICONS_PYTHON}  $'\uE73C '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_ANACONDA_LEFT_DELIMITER "("
-p9k::set_default P9K_ANACONDA_RIGHT_DELIMITER ")"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_ANACONDA_LEFT_DELIMITER "("
+  p9k::set_default P9K_ANACONDA_RIGHT_DELIMITER ")"
+}
 
 ################################################################
 # @description

--- a/segments/aws.p9k
+++ b/segments/aws.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                        
-p9k::register_segment 'AWS' '' red white 'AWS:'  $'\uE895'  $'\uF270'  '\u'${CODEPOINT_OF_AWESOME_AMAZON}  $'\uF270'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                        
+  p9k::register_segment 'AWS' '' red white 'AWS:'  $'\uE895'  $'\uF270'  '\u'${CODEPOINT_OF_AWESOME_AMAZON}  $'\uF270'
+}
 
 ################################################################
 # @description

--- a/segments/aws_eb_env.p9k
+++ b/segments/aws_eb_env.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                 🌱            🌱           🌱                                                    
-p9k::register_segment "AWS_EB_ENV" "" black green $'\U1F331 '  $'\U1F331 '  $'\U1F331 '  '\u'$CODEPOINT_OF_AWESOME_DEVIANTART' '  $'\uF1BD '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                 🌱            🌱           🌱                                                    
+  p9k::register_segment "AWS_EB_ENV" "" black green $'\U1F331 '  $'\U1F331 '  $'\U1F331 '  '\u'$CODEPOINT_OF_AWESOME_DEVIANTART' '  $'\uF1BD '
+}
 
 ################################################################
 # @description

--- a/segments/background_jobs.p9k
+++ b/segments/background_jobs.p9k
@@ -4,12 +4,20 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                   ⚙                                                               
-p9k::register_segment 'BACKGROUND_JOBS' '' "yellow" "black" $'\u2699'  $'\uE82F '  $'\uF013 '  '\u'$CODEPOINT_OF_AWESOME_COG' '  $'\uF013 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                   ⚙                                                               
+  p9k::register_segment 'BACKGROUND_JOBS' '' "yellow" "black" $'\u2699'  $'\uE82F '  $'\uF013 '  '\u'$CODEPOINT_OF_AWESOME_COG' '  $'\uF013 '
+
+  p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE true
+  p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS false
+  p9k::set_default P9K_BACKGROUND_JOBS_EXPANDED false
+}
 
 __p9k_background_jobs() {
   # See https://unix.stackexchange.com/questions/68571/show-jobs-count-only-if-it-is-more-than-0
@@ -20,10 +28,6 @@ __p9k_background_jobs() {
 # initialize hooks
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd __p9k_background_jobs
-
-p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE true
-p9k::set_default P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS false
-p9k::set_default P9K_BACKGROUND_JOBS_EXPANDED false
 ################################################################
 # @description
 #   Displays the number of background jobs with an icon.

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -4,21 +4,25 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                🔋                    🔋                                                    
-p9k::register_segment "BATTERY" "LOW"           "${DEFAULT_COLOR}" "red"                        $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
-p9k::register_segment "BATTERY" "CHARGING"      "${DEFAULT_COLOR}" "yellow"                     $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
-p9k::register_segment "BATTERY" "CHARGED"       "${DEFAULT_COLOR}" "green"                      $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
-p9k::register_segment "BATTERY" "DISCONNECTED"  "${DEFAULT_COLOR}" "${DEFAULT_COLOR_INVERTED}"  $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                🔋                    🔋                                                    
+  p9k::register_segment "BATTERY" "LOW"           "${DEFAULT_COLOR}" "red"                        $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
+  p9k::register_segment "BATTERY" "CHARGING"      "${DEFAULT_COLOR}" "yellow"                     $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
+  p9k::register_segment "BATTERY" "CHARGED"       "${DEFAULT_COLOR}" "green"                      $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
+  p9k::register_segment "BATTERY" "DISCONNECTED"  "${DEFAULT_COLOR}" "${DEFAULT_COLOR_INVERTED}"  $'\U1F50B'  $'\uE894'  $'\U1F50B'  '\u'${CODEPOINT_OF_AWESOME_BATTERY_FULL}  $'\uF240 '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_BATTERY_LOW_THRESHOLD 10
-# Default behavior: Be verbose!
-p9k::set_default P9K_BATTERY_VERBOSE true
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_BATTERY_LOW_THRESHOLD 10
+  # Default behavior: Be verbose!
+  p9k::set_default P9K_BATTERY_VERBOSE true
+}
 
 ################################################################
 # @description

--- a/segments/chruby.p9k
+++ b/segments/chruby.p9k
@@ -4,17 +4,21 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                    
-p9k::register_segment 'CHRUBY' '' "red" "$DEFAULT_COLOR" ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF43B '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                    
+  p9k::register_segment 'CHRUBY' '' "red" "$DEFAULT_COLOR" ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF43B '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_CHRUBY_SHOW_VERSION true
-p9k::set_default P9K_CHRUBY_SHOW_ENGINE true
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_CHRUBY_SHOW_VERSION true
+  p9k::set_default P9K_CHRUBY_SHOW_ENGINE true
+}
 
 ################################################################
 # @description

--- a/segments/command_execution_time.p9k
+++ b/segments/command_execution_time.p9k
@@ -4,17 +4,21 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                    
-p9k::register_segment 'COMMAND_EXECUTION_TIME' '' "red" "yellow1" 'Dur'  $'\uE89C'  $'\uF253'  '\u'${CODEPOINT_OF_AWESOME_HOURGLASS_END}  $'\uF252'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                    
+  p9k::register_segment 'COMMAND_EXECUTION_TIME' '' "red" "yellow1" 'Dur'  $'\uE89C'  $'\uF253'  '\u'${CODEPOINT_OF_AWESOME_HOURGLASS_END}  $'\uF252'
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_COMMAND_EXECUTION_TIME_THRESHOLD 3
-p9k::set_default P9K_COMMAND_EXECUTION_TIME_PRECISION 2
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_COMMAND_EXECUTION_TIME_THRESHOLD 3
+  p9k::set_default P9K_COMMAND_EXECUTION_TIME_PRECISION 2
+}
 
 ################################################################
 # @description

--- a/segments/context.p9k
+++ b/segments/context.p9k
@@ -4,22 +4,26 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#
-p9k::register_segment 'CONTEXT' 'ROOT'        "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
-p9k::register_segment 'CONTEXT' 'SUDO'        "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
-p9k::register_segment 'CONTEXT' 'DEFAULT'     "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
-p9k::register_segment 'CONTEXT' 'REMOTE'      "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
-p9k::register_segment 'CONTEXT' 'REMOTE_SUDO' "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #
+  p9k::register_segment 'CONTEXT' 'ROOT'        "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
+  p9k::register_segment 'CONTEXT' 'SUDO'        "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
+  p9k::register_segment 'CONTEXT' 'DEFAULT'     "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
+  p9k::register_segment 'CONTEXT' 'REMOTE'      "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
+  p9k::register_segment 'CONTEXT' 'REMOTE_SUDO' "${DEFAULT_COLOR}" "yellow" ""  ""  ""  ""  ""  ""
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_CONTEXT_ALWAYS_SHOW false
-p9k::set_default P9K_CONTEXT_ALWAYS_SHOW_USER false
-p9k::set_default P9K_CONTEXT_TEMPLATE "%n@%m"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_CONTEXT_ALWAYS_SHOW false
+  p9k::set_default P9K_CONTEXT_ALWAYS_SHOW_USER false
+  p9k::set_default P9K_CONTEXT_TEMPLATE "%n@%m"
+}
 
 ################################################################
 # @description

--- a/segments/date.p9k
+++ b/segments/date.p9k
@@ -4,16 +4,20 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                         
-p9k::register_segment 'DATE' '' "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" ''  $'\uE184'  $'\uF073 '  '\u'$CODEPOINT_OF_AWESOME_CALENDAR' '  $'\uF073 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                         
+  p9k::register_segment 'DATE' '' "$DEFAULT_COLOR_INVERTED" "$DEFAULT_COLOR" ''  $'\uE184'  $'\uF073 '  '\u'$CODEPOINT_OF_AWESOME_CALENDAR' '  $'\uF073 '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_DATE_FORMAT "%D{%d.%m.%y}"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_DATE_FORMAT "%D{%d.%m.%y}"
+}
 
 ################################################################
 # @description

--- a/segments/detect_virt.p9k
+++ b/segments/detect_virt.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#
-p9k::register_segment 'DETECT_VIRT' '' "$DEFAULT_COLOR" "yellow" "" "" "" "" "" ""
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #
+  p9k::register_segment 'DETECT_VIRT' '' "$DEFAULT_COLOR" "yellow" "" "" "" "" "" ""
+}
 
 ################################################################
 # @description

--- a/segments/dir.p9k
+++ b/segments/dir.p9k
@@ -4,30 +4,35 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                     
-p9k::register_segment "DIR" 'DEFAULT'         "blue" "$DEFAULT_COLOR"   ''         $'\uE818'  $'\uF115'  '\u'${CODEPOINT_OF_AWESOME_FOLDER_O}     $'\uF115'
-#                                                                                                                                     
-p9k::register_segment "DIR" 'HOME'            "blue" "$DEFAULT_COLOR"   ''         $'\uE12C'  $'\uF015'  '\u'${CODEPOINT_OF_AWESOME_HOME}         $'\uF015'
-#                                                                                                                                     
-p9k::register_segment "DIR" 'HOME_SUBFOLDER'  "blue" "$DEFAULT_COLOR"   ''         $'\uE18D'  $'\uF07C'  '\u'${CODEPOINT_OF_AWESOME_FOLDER_OPEN}  $'\uF07C'
-#                                                                                                                                     
-p9k::register_segment "DIR" 'NOT_WRITABLE'    "blue" "$DEFAULT_COLOR"   $'\uE0A2'  $'\uE138'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}         $'\uF023'
-#                                                                                                                                   
-p9k::register_segment "DIR" 'ETC'             "blue" "$DEFAULT_COLOR"   $'\uE818'  $'\uF013'  $'\uF013'  '\u'${CODEPOINT_OF_AWESOME_COG}          $'\uF013'
+() {
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                     
+  p9k::register_segment "DIR" 'DEFAULT'         "blue" "$DEFAULT_COLOR"   ''         $'\uE818'  $'\uF115'  '\u'${CODEPOINT_OF_AWESOME_FOLDER_O}     $'\uF115'
+  #                                                                                                                                     
+  p9k::register_segment "DIR" 'HOME'            "blue" "$DEFAULT_COLOR"   ''         $'\uE12C'  $'\uF015'  '\u'${CODEPOINT_OF_AWESOME_HOME}         $'\uF015'
+  #                                                                                                                                     
+  p9k::register_segment "DIR" 'HOME_SUBFOLDER'  "blue" "$DEFAULT_COLOR"   ''         $'\uE18D'  $'\uF07C'  '\u'${CODEPOINT_OF_AWESOME_FOLDER_OPEN}  $'\uF07C'
+  #                                                                                                                                     
+  p9k::register_segment "DIR" 'NOT_WRITABLE'    "blue" "$DEFAULT_COLOR"   $'\uE0A2'  $'\uE138'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}         $'\uF023'
+  #                                                                                                                                   
+  p9k::register_segment "DIR" 'ETC'             "blue" "$DEFAULT_COLOR"   $'\uE818'  $'\uF013'  $'\uF013'  '\u'${CODEPOINT_OF_AWESOME_COG}          $'\uF013'
 
-p9k::set_default P9K_DIR_PATH_SEPARATOR "/"
-p9k::set_default P9K_DIR_HOME_FOLDER_ABBREVIATION "~"
-p9k::set_default P9K_DIR_PATH_HIGHLIGHT_BOLD false
-p9k::set_default P9K_DIR_PATH_ABSOLUTE false
-p9k::set_default P9K_DIR_SHORTEN_DELIMITER "\u2026"
-p9k::set_default P9K_DIR_SHORTEN_FOLDER_MARKER ".shorten_folder_marker"
-# Parse the 'name' from the package.json; if there are any problems, just
-# print the file path
-p9k::defined P9K_DIR_PACKAGE_FILES || P9K_DIR_PACKAGE_FILES=(package.json composer.json)
+  p9k::set_default P9K_DIR_PATH_SEPARATOR "/"
+  p9k::set_default P9K_DIR_HOME_FOLDER_ABBREVIATION "~"
+  p9k::set_default P9K_DIR_PATH_HIGHLIGHT_BOLD false
+  p9k::set_default P9K_DIR_PATH_ABSOLUTE false
+  p9k::set_default P9K_DIR_SHORTEN_DELIMITER "\u2026"
+  p9k::set_default P9K_DIR_SHORTEN_FOLDER_MARKER ".shorten_folder_marker"
+  # Parse the 'name' from the package.json; if there are any problems, just
+  # print the file path
+  p9k::defined P9K_DIR_PACKAGE_FILES || P9K_DIR_PACKAGE_FILES=(package.json composer.json)
+}
+
 ################################################################
 # @description
 #   Display information about the current working directory.

--- a/segments/dir_writable.p9k
+++ b/segments/dir_writable.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                              
-p9k::register_segment 'DIR_WRITABLE' 'FORBIDDEN' "red" "yellow1" $'\uE0A2'  $'\uE138'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                              
+  p9k::register_segment 'DIR_WRITABLE' 'FORBIDDEN' "red" "yellow1" $'\uE0A2'  $'\uE138'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
+}
 
 ################################################################
 # @description

--- a/segments/disk_usage.p9k
+++ b/segments/disk_usage.p9k
@@ -4,23 +4,27 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                                       
-p9k::register_segment "DISK_USAGE" "NORMAL"   "${DEFAULT_COLOR}"  "green1"            $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
-#                                                                                                                                                       
-p9k::register_segment "DISK_USAGE" "WARNING"  "yellow"            "${DEFAULT_COLOR}"  $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
-#                                                                                                                                                       
-p9k::register_segment "DISK_USAGE" "CRITICAL" "red"               "white"             $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                                       
+  p9k::register_segment "DISK_USAGE" "NORMAL"   "${DEFAULT_COLOR}"  "green1"            $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
+  #                                                                                                                                                       
+  p9k::register_segment "DISK_USAGE" "WARNING"  "yellow"            "${DEFAULT_COLOR}"  $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
+  #                                                                                                                                                       
+  p9k::register_segment "DISK_USAGE" "CRITICAL" "red"               "white"             $'hdd '  $'\uE1AE '  $'\uF0A0 '  '\u'$CODEPOINT_OF_AWESOME_HDD_O' '  $'\uF0A0'
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_DISK_USAGE_ONLY_WARNING false
-p9k::set_default P9K_DISK_USAGE_WARNING_LEVEL 90
-p9k::set_default P9K_DISK_USAGE_CRITICAL_LEVEL 95
-p9k::set_default P9K_DISK_USAGE_PATH "."
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_DISK_USAGE_ONLY_WARNING false
+  p9k::set_default P9K_DISK_USAGE_WARNING_LEVEL 90
+  p9k::set_default P9K_DISK_USAGE_CRITICAL_LEVEL 95
+  p9k::set_default P9K_DISK_USAGE_PATH "."
+}
 
 ################################################################
 # @description

--- a/segments/docker_machine.p9k
+++ b/segments/docker_machine.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                 
-p9k::register_segment "DOCKER_MACHINE" '' "magenta" "$DEFAULT_COLOR"  ''  $'\uE895'  $'\uF233'  '\u'${CODEPOINT_OF_AWESOME_SERVER}  $'\uF0AE'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                 
+  p9k::register_segment "DOCKER_MACHINE" '' "magenta" "$DEFAULT_COLOR"  ''  $'\uE895'  $'\uF233'  '\u'${CODEPOINT_OF_AWESOME_SERVER}  $'\uF0AE'
+}
 
 ################################################################
 # @description

--- a/segments/dropbox.p9k
+++ b/segments/dropbox.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                    
-p9k::register_segment "DROPBOX" '' 'white' 'blue' 'Dropbox'  $'\uF16B'  $'\uF16B'  '\u'${CODEPOINT_OF_AWESOME_DROPBOX}  $'\uF16B'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                    
+  p9k::register_segment "DROPBOX" '' 'white' 'blue' 'Dropbox'  $'\uF16B'  $'\uF16B'  '\u'${CODEPOINT_OF_AWESOME_DROPBOX}  $'\uF16B'
+}
 
 ################################################################
 # @description

--- a/segments/go_version.p9k
+++ b/segments/go_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                          
-p9k::register_segment "GO_VERSION" '' 'green' 'grey93' 'Go'  ''  ''  '\u'${CODEPOINT_OF_DEVICONS_GIT_PULL_REQUEST}  $'\uE626'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                          
+  p9k::register_segment "GO_VERSION" '' 'green' 'grey93' 'Go'  ''  ''  '\u'${CODEPOINT_OF_DEVICONS_GIT_PULL_REQUEST}  $'\uE626'
+}
 
 ################################################################
 # @description

--- a/segments/history.p9k
+++ b/segments/history.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                             
-p9k::register_segment "HISTORY" '' "grey50" "${DEFAULT_COLOR}"  ''  ''  $'\uE29A '  $'\uE29A '  $'\uE29A '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                             
+  p9k::register_segment "HISTORY" '' "grey50" "${DEFAULT_COLOR}"  ''  ''  $'\uE29A '  $'\uE29A '  $'\uE29A '
+}
 
 ################################################################
 # @description

--- a/segments/host.p9k
+++ b/segments/host.p9k
@@ -4,18 +4,22 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                     
-p9k::register_segment "HOST" "REMOTE" "yellow"           "${DEFAULT_COLOR}"  '(ssh)'  '(ssh)'  '(ssh)'    '(ssh)'   $'\uF489'
-#                                                                                                                  
-p9k::register_segment "HOST" "LOCAL"  "${DEFAULT_COLOR}" "yellow"            ''       ''       $'\uF67C'  $'\uF67C' $'\uF67C'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                     
+  p9k::register_segment "HOST" "REMOTE" "yellow"           "${DEFAULT_COLOR}"  '(ssh)'  '(ssh)'  '(ssh)'    '(ssh)'   $'\uF489'
+  #                                                                                                                  
+  p9k::register_segment "HOST" "LOCAL"  "${DEFAULT_COLOR}" "yellow"            ''       ''       $'\uF67C'  $'\uF67C' $'\uF67C'
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_HOST_TEMPLATE "%m"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_HOST_TEMPLATE "%m"
+}
 
 ################################################################
 # @description

--- a/segments/icons_test.p9k
+++ b/segments/icons_test.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#
-p9k::register_segment "ICONS_TEST" "" "${DEFAULT_COLOR_INVERTED}" "${DEFAULT_COLOR}"  "" "" "" "" ""
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #
+  p9k::register_segment "ICONS_TEST" "" "${DEFAULT_COLOR_INVERTED}" "${DEFAULT_COLOR}"  "" "" "" "" ""
+}
 
 ################################################################
 # @description

--- a/segments/ip.p9k
+++ b/segments/ip.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                 
-p9k::register_segment "IP" "" "cyan" "$DEFAULT_COLOR"  'IP'  $'\uE1AD'  $'\uF09E'  '\u'${CODEPOINT_OF_AWESOME_RSS}  $'\uF1EB'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                 
+  p9k::register_segment "IP" "" "cyan" "$DEFAULT_COLOR"  'IP'  $'\uE1AD'  $'\uF09E'  '\u'${CODEPOINT_OF_AWESOME_RSS}  $'\uF1EB'
+}
 
 ################################################################
 # @description

--- a/segments/java_version.p9k
+++ b/segments/java_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                  ☕         ☕         
-p9k::register_segment "JAVA_VERSION" "" "red" "white" 'Java'  ''  $'\u2615'  $'\u2615'  $'\uE256'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                  ☕         ☕         
+  p9k::register_segment "JAVA_VERSION" "" "red" "white" 'Java'  ''  $'\u2615'  $'\u2615'  $'\uE256'
+}
 
 ################################################################
 # @description

--- a/segments/kubecontext.p9k
+++ b/segments/kubecontext.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                        ⎈          ⎈         ⎈         ⎈         ⎈
-p9k::register_segment "KUBECONTEXT" "" "magenta" "white" $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                        ⎈          ⎈         ⎈         ⎈         ⎈
+  p9k::register_segment "KUBECONTEXT" "" "magenta" "white" $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'
+}
 
 ################################################################
 # @description

--- a/segments/laravel_version.p9k
+++ b/segments/laravel_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                            
-p9k::register_segment "LARAVEL_VERSION" "" "maroon" "white" 'Laravel'  ''  ''  ''  $'\uE73F'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                            
+  p9k::register_segment "LARAVEL_VERSION" "" "maroon" "white" 'Laravel'  ''  ''  ''  $'\uE73F'
+}
 
 ################################################################
 # @description

--- a/segments/load.p9k
+++ b/segments/load.p9k
@@ -4,18 +4,22 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                      
-p9k::register_segment "LOAD" "NORMAL"   "green"  "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
-p9k::register_segment "LOAD" "WARNING"  "yellow" "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
-p9k::register_segment "LOAD" "CRITICAL" "red"    "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                      
+  p9k::register_segment "LOAD" "NORMAL"   "green"  "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
+  p9k::register_segment "LOAD" "WARNING"  "yellow" "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
+  p9k::register_segment "LOAD" "CRITICAL" "red"    "${DEFAULT_COLOR}"  'L'  $'\uE190 '  $'\uF080 '  '\u'$CODEPOINT_OF_AWESOME_BAR_CHART' '  $'\uF080 '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_LOAD_WHICH 5
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_LOAD_WHICH 5
+}
 
 ################################################################
 # @description

--- a/segments/node_version.p9k
+++ b/segments/node_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                         ⬢         ⬢          ⬢          ⬢          
-p9k::register_segment "NODE_VERSION" "" "green" "white"  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                         ⬢         ⬢          ⬢          ⬢          
+  p9k::register_segment "NODE_VERSION" "" "green" "white"  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+}
 
 ################################################################
 # @description

--- a/segments/nodeenv.p9k
+++ b/segments/nodeenv.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                  ⬢          ⬢          ⬢          ⬢          
-p9k::register_segment "NODEENV" "" "black" "green" $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                  ⬢          ⬢          ⬢          ⬢          
+  p9k::register_segment "NODEENV" "" "black" "green" $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+}
 
 ################################################################
 # @description

--- a/segments/nvm.p9k
+++ b/segments/nvm.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment icon
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                  ⬢         ⬢          ⬢          ⬢          
-p9k::register_segment "NVM" "" "magenta" "black"  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment icon
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                  ⬢         ⬢          ⬢          ⬢          
+  p9k::register_segment "NVM" "" "magenta" "black"  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\u2B22'  $'\uE617 '
+}
 
 ################################################################
 # @description

--- a/segments/openfoam.p9k
+++ b/segments/openfoam.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#
-p9k::register_segment "OPENFOAM" "" "yellow" "${DEFAULT_COLOR}"  ''  ''  ''  ''  ''
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #
+  p9k::register_segment "OPENFOAM" "" "yellow" "${DEFAULT_COLOR}"  ''  ''  ''  ''  ''
+}
 
 ################################################################
 # @description

--- a/segments/os_icon.p9k
+++ b/segments/os_icon.p9k
@@ -4,64 +4,68 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment icon
-# Parameters:
-#   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-case "$__P9K_OS" in
-  #                                                                                                                             
-  "OSX")      p9k::register_segment "OS_ICON" "" "black" "white" 'OSX'  $'\uE26E'    $'\uF179'    '\u'${CODEPOINT_OF_AWESOME_APPLE}  $'\uF179' ;;
-  #                                                                                                                             
-  "Windows")  p9k::register_segment "OS_ICON" "" "black" "white" 'WIN'  $'\uE26F'    $'\uF17A'    $'\uF17A'                        $'\uF17A' ;;
-  #                                                                      😈           😈           😈                                
-  "BSD")      p9k::register_segment "OS_ICON" "" "black" "white" 'BSD'  $'\U1F608 '  $'\U1F608 '  $'\U1F608 '                      $'\uF30c ' ;;
-#  OpenBSD) ;;
-#  DragonFly) ;;
-  "Linux")
-    case "$__P9K_OS_ID" in
-      #                                                                                                                                                                          
-      "arch")                  p9k::register_segment "OS_ICON" "" "black" "white" 'Arc'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF303' ;;
-      #                                                                                                                                                                          
-      "debian")                p9k::register_segment "OS_ICON" "" "black" "white" 'Deb'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uE77D' ;;
-      #                                                                                                                                                                          
-      "ubuntu")                p9k::register_segment "OS_ICON" "" "black" "white" 'Ubu'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF31B' ;;
-      #                                                                                                                                                                          
-      "elementary")            p9k::register_segment "OS_ICON" "" "black" "white" 'Elm'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF309' ;;
-      #                                                                                                                                                                          
-      "fedora")                p9k::register_segment "OS_ICON" "" "black" "white" 'Fed'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30A' ;;
-      #                                                                                                                                                                          
-      "rhel")                  p9k::register_segment "OS_ICON" "" "black" "white" 'Rhe'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uE7BB' ;;
-      #                                                                                                                                                                          
-      "coreos")                p9k::register_segment "OS_ICON" "" "black" "white" 'Cor'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF305' ;;
-      #                                                                                                                                                                          
-      "gentoo")                p9k::register_segment "OS_ICON" "" "black" "white" 'Gen'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30D' ;;
-      #                                                                                                                                                                          
-      "mageia")                p9k::register_segment "OS_ICON" "" "black" "white" 'Mag'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF310' ;;
-      #                                                                                                                                                                          
-      "centos")                p9k::register_segment "OS_ICON" "" "black" "white" 'Cen'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF304' ;;
-      #                                                                                                                                                                          
-      "opensuse"|"tumbleweed") p9k::register_segment "OS_ICON" "" "black" "white" 'OSu'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF314' ;;
-      #                                                                                                                                                                          
-      "sabayon")               p9k::register_segment "OS_ICON" "" "black" "white" 'Sab'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF317' ;;
-      #                                                                                                                                                                          
-      "slackware")             p9k::register_segment "OS_ICON" "" "black" "white" 'Sla'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF318' ;;
-      #                                                                                                                                                                          
-      "linuxmint")             p9k::register_segment "OS_ICON" "" "black" "white" 'LMi'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30E' ;;
-      #                                                                                                                                                                          
-      *)                       p9k::register_segment "OS_ICON" "" "black" "white" 'Lx'   $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF17C' ;;
-    esac
-  ;;
-  #                                                                                                                                
-  "Android") p9k::register_segment "OS_ICON" "" "black" "white"  'And'  $'\uE270'    $'\uE17B'   $'\uF17B'                           $'\uF17B'
-  ;;
-  #                                                                      🌞                                                         
-  "Solaris") p9k::register_segment "OS_ICON" "" "black" "white"  'Sun'  $'\U1F31E '  $'\uF185 '  '\u'$CODEPOINT_OF_AWESOME_SUN_O' '  $'\uF185 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment icon
+  # Parameters:
+  #   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  case "$__P9K_OS" in
+    #                                                                                                                             
+    "OSX")      p9k::register_segment "OS_ICON" "" "black" "white" 'OSX'  $'\uE26E'    $'\uF179'    '\u'${CODEPOINT_OF_AWESOME_APPLE}  $'\uF179' ;;
+    #                                                                                                                             
+    "Windows")  p9k::register_segment "OS_ICON" "" "black" "white" 'WIN'  $'\uE26F'    $'\uF17A'    $'\uF17A'                        $'\uF17A' ;;
+    #                                                                      😈           😈           😈                                
+    "BSD")      p9k::register_segment "OS_ICON" "" "black" "white" 'BSD'  $'\U1F608 '  $'\U1F608 '  $'\U1F608 '                      $'\uF30c ' ;;
+  #  OpenBSD) ;;
+  #  DragonFly) ;;
+    "Linux")
+      case "$__P9K_OS_ID" in
+        #                                                                                                                                                                          
+        "arch")                  p9k::register_segment "OS_ICON" "" "black" "white" 'Arc'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF303' ;;
+        #                                                                                                                                                                          
+        "debian")                p9k::register_segment "OS_ICON" "" "black" "white" 'Deb'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uE77D' ;;
+        #                                                                                                                                                                          
+        "ubuntu")                p9k::register_segment "OS_ICON" "" "black" "white" 'Ubu'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF31B' ;;
+        #                                                                                                                                                                          
+        "elementary")            p9k::register_segment "OS_ICON" "" "black" "white" 'Elm'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF309' ;;
+        #                                                                                                                                                                          
+        "fedora")                p9k::register_segment "OS_ICON" "" "black" "white" 'Fed'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30A' ;;
+        #                                                                                                                                                                          
+        "rhel")                  p9k::register_segment "OS_ICON" "" "black" "white" 'Rhe'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uE7BB' ;;
+        #                                                                                                                                                                          
+        "coreos")                p9k::register_segment "OS_ICON" "" "black" "white" 'Cor'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF305' ;;
+        #                                                                                                                                                                          
+        "gentoo")                p9k::register_segment "OS_ICON" "" "black" "white" 'Gen'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30D' ;;
+        #                                                                                                                                                                          
+        "mageia")                p9k::register_segment "OS_ICON" "" "black" "white" 'Mag'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF310' ;;
+        #                                                                                                                                                                          
+        "centos")                p9k::register_segment "OS_ICON" "" "black" "white" 'Cen'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF304' ;;
+        #                                                                                                                                                                          
+        "opensuse"|"tumbleweed") p9k::register_segment "OS_ICON" "" "black" "white" 'OSu'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF314' ;;
+        #                                                                                                                                                                          
+        "sabayon")               p9k::register_segment "OS_ICON" "" "black" "white" 'Sab'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF317' ;;
+        #                                                                                                                                                                          
+        "slackware")             p9k::register_segment "OS_ICON" "" "black" "white" 'Sla'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF318' ;;
+        #                                                                                                                                                                          
+        "linuxmint")             p9k::register_segment "OS_ICON" "" "black" "white" 'LMi'  $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF30E' ;;
+        #                                                                                                                                                                          
+        *)                       p9k::register_segment "OS_ICON" "" "black" "white" 'Lx'   $'\uE271'      $'\uF17C'      '\u'$CODEPOINT_OF_AWESOME_LINUX                              $'\uF17C' ;;
+      esac
     ;;
-  *)
-    p9k::register_segment "OS_ICON" "" "black" "white"  ''  ''  ''  ''  ''
-    OS=''
+    #                                                                                                                                
+    "Android") p9k::register_segment "OS_ICON" "" "black" "white"  'And'  $'\uE270'    $'\uE17B'   $'\uF17B'                           $'\uF17B'
     ;;
-esac
+    #                                                                      🌞                                                         
+    "Solaris") p9k::register_segment "OS_ICON" "" "black" "white"  'Sun'  $'\U1F31E '  $'\uF185 '  '\u'$CODEPOINT_OF_AWESOME_SUN_O' '  $'\uF185 '
+      ;;
+    *)
+      p9k::register_segment "OS_ICON" "" "black" "white"  ''  ''  ''  ''  ''
+      OS=''
+      ;;
+  esac
+}
 
 ################################################################
 # @description

--- a/segments/php_version.p9k
+++ b/segments/php_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                              
-p9k::register_segment "PHP_VERSION" "" "fuchsia" "grey93"  'PHP'  $'\uF457'  $'\uF457'  $'\uF457'  $'\uE73D'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                              
+  p9k::register_segment "PHP_VERSION" "" "fuchsia" "grey93"  'PHP'  $'\uF457'  $'\uF457'  $'\uF457'  $'\uE73D'
+}
 
 ################################################################
 # @description

--- a/segments/public_ip.p9k
+++ b/segments/public_ip.p9k
@@ -4,30 +4,34 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                               
-p9k::register_segment "PUBLIC_IP" "" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED"  ''  ''  ''  '\u'${CODEPOINT_OF_AWESOME_GLOBE}  $'\uF0AC'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                               
+  p9k::register_segment "PUBLIC_IP" "" "$DEFAULT_COLOR" "$DEFAULT_COLOR_INVERTED"  ''  ''  ''  '\u'${CODEPOINT_OF_AWESOME_GLOBE}  $'\uF0AC'
 
-################################################################
-# Register segment icon
-# Parameters:
-#   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                            
-p9k::register_icon "VPN_ICON"  '(vpn)'  '(vpn)'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
+  ################################################################
+  # Register segment icon
+  # Parameters:
+  #   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                            
+  p9k::register_icon "VPN_ICON"  '(vpn)'  '(vpn)'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
+
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_PUBLIC_IP_TIMEOUT "00"
+  p9k::set_default P9K_PUBLIC_IP_NONE ""
+  p9k::set_default P9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
+  p9k::set_default P9K_PUBLIC_IP_HOST "http://ident.me"
+  p9k::defined P9K_PUBLIC_IP_METHODS || P9K_PUBLIC_IP_METHODS=(dig curl wget)
+}
 
 # On macOS, stat is in /usr/bin/stat. However, if gnu utils are installed, this won't work.
 [[ $(which stat) == "/usr/bin/stat" ]] && local stat_version="OSX"
-
-################################################################
-# Register segment default values
-p9k::set_default P9K_PUBLIC_IP_TIMEOUT "00"
-p9k::set_default P9K_PUBLIC_IP_NONE ""
-p9k::set_default P9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
-p9k::set_default P9K_PUBLIC_IP_HOST "http://ident.me"
-p9k::defined P9K_PUBLIC_IP_METHODS || P9K_PUBLIC_IP_METHODS=(dig curl wget)
 
 ################################################################
 # Public IP segment

--- a/segments/pyenv.p9k
+++ b/segments/pyenv.p9k
@@ -4,16 +4,20 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                               🐍          
-p9k::register_segment "PYENV" "" "blue" "$DEFAULT_COLOR" ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                               🐍          
+  p9k::register_segment "PYENV" "" "blue" "$DEFAULT_COLOR" ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_PYENV_PROMPT_ALWAYS_SHOW false
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_PYENV_PROMPT_ALWAYS_SHOW false
+}
 
 ################################################################
 # @description

--- a/segments/ram.p9k
+++ b/segments/ram.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                            
-p9k::register_segment "RAM" "" "yellow" "$DEFAULT_COLOR"  'RAM'  $'\uE1E2 '  $'\uF0E4'  '\u'${CODEPOINT_OF_AWESOME_DASHBOARD}  $'\uF0E4'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                            
+  p9k::register_segment "RAM" "" "yellow" "$DEFAULT_COLOR"  'RAM'  $'\uE1E2 '  $'\uF0E4'  '\u'${CODEPOINT_OF_AWESOME_DASHBOARD}  $'\uF0E4'
+}
 
 ################################################################
 # @description

--- a/segments/rbenv.p9k
+++ b/segments/rbenv.p9k
@@ -4,16 +4,20 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                      
-p9k::register_segment "RBENV" "" "red" "${DEFAULT_COLOR}"  ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF219 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                      
+  p9k::register_segment "RBENV" "" "red" "${DEFAULT_COLOR}"  ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF219 '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_RBENV_ALWAYS false
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_RBENV_ALWAYS false
+}
 
 ################################################################
 # @description

--- a/segments/root_indicator.p9k
+++ b/segments/root_indicator.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                       ⚡                                                              
-p9k::register_segment "ROOT_INDICATOR" "" "${DEFAULT_COLOR}" "yellow"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}  $'\uF0E7'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                       ⚡                                                              
+  p9k::register_segment "ROOT_INDICATOR" "" "${DEFAULT_COLOR}" "yellow"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}  $'\uF0E7'
+}
 
 ################################################################
 # @description

--- a/segments/rust_version.p9k
+++ b/segments/rust_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                               
-p9k::register_segment "RUST_VERSION" "" "darkorange" "$DEFAULT_COLOR"  'Rust'  ''  $'\uE6A8'  $'\uE6A8'  $'\uE7A8 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                               
+  p9k::register_segment "RUST_VERSION" "" "darkorange" "$DEFAULT_COLOR"  'Rust'  ''  $'\uE6A8'  $'\uE6A8'  $'\uE7A8 '
+}
 
 ################################################################
 # @description

--- a/segments/rvm.p9k
+++ b/segments/rvm.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                       
-p9k::register_segment "RVM" "" "grey35" "${DEFAULT_COLOR}"  ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF219 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                       
+  p9k::register_segment "RVM" "" "grey35" "${DEFAULT_COLOR}"  ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_RUBY' '  $'\uF219 '
+}
 
 ################################################################
 # @description

--- a/segments/ssh.p9k
+++ b/segments/ssh.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                
-p9k::register_segment "SSH" "" "${DEFAULT_COLOR}" "yellow"  '(ssh)'  '(ssh)'  '(ssh)'  '(ssh)'  $'\uF489'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                
+  p9k::register_segment "SSH" "" "${DEFAULT_COLOR}" "yellow"  '(ssh)'  '(ssh)'  '(ssh)'  '(ssh)'  $'\uF489'
+}
 
 ################################################################
 # @description

--- a/segments/stack_project.p9k
+++ b/segments/stack_project.p9k
@@ -25,12 +25,12 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_stack_project() {
-    local haskellstack_version=$(stack --version 2>/dev/null)
-    # Check for both a global Stack installation and a stack.yaml files (in current or parent directories)
-    if [[ "${haskellstack_version}" =~ "([0-9.]+)" ]]; then
-        local stackyaml_file_search=$(__p9k_upsearch "stack.yaml")
-        if [[ "${stackyaml_file_search}" != "$HOME" && "${stackyaml_file_search}" != "/" ]]; then
-            p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "Stack"
-        fi
+  local haskellstack_version=$(stack --version 2>/dev/null)
+  # Check for both a global Stack installation and a stack.yaml files (in current or parent directories)
+  if [[ "${haskellstack_version}" =~ "([0-9.]+)" ]]; then
+    local stackyaml_file_search=$(__p9k_upsearch "stack.yaml")
+    if [[ "${stackyaml_file_search}" != "$HOME" && "${stackyaml_file_search}" != "/" ]]; then
+      p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "Stack"
     fi
+  fi
 }

--- a/segments/stack_project.p9k
+++ b/segments/stack_project.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  foreground  background  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                    
-p9k::register_segment "STACK_PROJECT" "" "purple3" "white" $'\u03BB='  $'\u03BB='  $'\u03BB='  $'\u03BB='  $'\uE777'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  foreground  background  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                    
+  p9k::register_segment "STACK_PROJECT" "" "purple3" "white" $'\u03BB='  $'\u03BB='  $'\u03BB='  $'\u03BB='  $'\uE777'
+}
 
 ################################################################
 # @description

--- a/segments/status.p9k
+++ b/segments/status.p9k
@@ -4,30 +4,34 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                      ✔         ✔          ✔                                            
-p9k::register_segment "STATUS" "OK"       "$DEFAULT_COLOR" "green"    $'\u2714'  $'\u2714'  $'\u2714'  '\u'${CODEPOINT_OF_AWESOME_CHECK}  $'\uF00C'
-#                                                                      ✘          ✘         ✘                                             
-p9k::register_segment "STATUS" "ERROR"    "$DEFAULT_COLOR" "red"      $'\u2718'  $'\u2718'  $'\u2718'  '\u'${CODEPOINT_OF_AWESOME_TIMES}  $'\uF00D'
-#                                                                      ↵         ↵         ↵          ↵                                 ↵
-p9k::register_segment "STATUS" "ERROR_CR" "red"            "yellow1"  $'\u21B5'  $'\u21B5'  $'\u21B5'  $'\u21B5'                          $'\u21B5'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                      ✔         ✔          ✔                                            
+  p9k::register_segment "STATUS" "OK"       "$DEFAULT_COLOR" "green"    $'\u2714'  $'\u2714'  $'\u2714'  '\u'${CODEPOINT_OF_AWESOME_CHECK}  $'\uF00C'
+  #                                                                      ✘          ✘         ✘                                             
+  p9k::register_segment "STATUS" "ERROR"    "$DEFAULT_COLOR" "red"      $'\u2718'  $'\u2718'  $'\u2718'  '\u'${CODEPOINT_OF_AWESOME_TIMES}  $'\uF00D'
+  #                                                                      ↵         ↵         ↵          ↵                                 ↵
+  p9k::register_segment "STATUS" "ERROR_CR" "red"            "yellow1"  $'\u21B5'  $'\u21B5'  $'\u21B5'  $'\u21B5'                          $'\u21B5'
 
-################################################################
-# Register segment default values
-#
-# Status: When an error occur, return the error code, or a cross icon if option is set
-# Display an ok icon when no error occur, or hide the segment if option is set to false
-#
-p9k::set_default P9K_STATUS_CROSS false
-p9k::set_default P9K_STATUS_HIDE_SIGNAME false
-p9k::set_default P9K_STATUS_OK true
-p9k::set_default P9K_STATUS_SHOW_PIPESTATUS true
-# old options, retro compatibility
-p9k::set_default P9K_STATUS_OK_IN_NON_VERBOSE false
-p9k::set_default P9K_STATUS_VERBOSE true
+  ################################################################
+  # Register segment default values
+  #
+  # Status: When an error occur, return the error code, or a cross icon if option is set
+  # Display an ok icon when no error occur, or hide the segment if option is set to false
+  #
+  p9k::set_default P9K_STATUS_CROSS false
+  p9k::set_default P9K_STATUS_HIDE_SIGNAME false
+  p9k::set_default P9K_STATUS_OK true
+  p9k::set_default P9K_STATUS_SHOW_PIPESTATUS true
+  # old options, retro compatibility
+  p9k::set_default P9K_STATUS_OK_IN_NON_VERBOSE false
+  p9k::set_default P9K_STATUS_VERBOSE true
+}
 
 exit_code_or_status() {
   local ec=$1

--- a/segments/swap.p9k
+++ b/segments/swap.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                           
-p9k::register_segment "SWAP" "" "yellow" "$DEFAULT_COLOR"  'SWP'  $'\uE87D'  $'\uF0E4'  '\u'${CODEPOINT_OF_AWESOME_DASHBOARD}  $'\uF464'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                           
+  p9k::register_segment "SWAP" "" "yellow" "$DEFAULT_COLOR"  'SWP'  $'\uE87D'  $'\uF0E4'  '\u'${CODEPOINT_OF_AWESOME_DASHBOARD}  $'\uF464'
+}
 
 ################################################################
 # @description

--- a/segments/swift_version.p9k
+++ b/segments/swift_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                      
-p9k::register_segment "SWIFT_VERSION" "" "magenta" "white"  'Swift'  ''  ''  $'\uE655'  $'\uE755'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                      
+  p9k::register_segment "SWIFT_VERSION" "" "magenta" "white"  'Swift'  ''  ''  $'\uE655'  $'\uE755'
+}
 
 ################################################################
 # @description

--- a/segments/symfony2_version.p9k
+++ b/segments/symfony2_version.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                 
-p9k::register_segment "SYMFONY2_VERSION" "" "grey35" "${DEFAULT_COLOR}"  'SF'  'SF'  'SF'  'SF'  $'\uE757'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                 
+  p9k::register_segment "SYMFONY2_VERSION" "" "grey35" "${DEFAULT_COLOR}"  'SF'  'SF'  'SF'  'SF'  $'\uE757'
+}
 
 ################################################################
 # @description

--- a/segments/test_stats.p9k
+++ b/segments/test_stats.p9k
@@ -8,14 +8,18 @@
 #   for the rspec_stats.p9k and symfony_tests segments.
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                
-p9k::register_segment "TEST_STATS" "GOOD" "cyan"   "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
-p9k::register_segment "TEST_STATS" "AVG"  "yellow" "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
-p9k::register_segment "TEST_STATS" "BAD"  "red"    "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                
+  p9k::register_segment "TEST_STATS" "GOOD" "cyan"   "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
+  p9k::register_segment "TEST_STATS" "AVG"  "yellow" "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
+  p9k::register_segment "TEST_STATS" "BAD"  "red"    "${DEFAULT_COLOR}"   ''  $'\uE891'  $'\uF291'  '\u'${CODEPOINT_OF_AWESOME_BUG}  $'\uF188'
+}
 
 ################################################################
 # @description

--- a/segments/time.p9k
+++ b/segments/time.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                            
-p9k::register_segment "TIME" "" "${DEFAULT_COLOR_INVERTED}" "${DEFAULT_COLOR}"  ''  $'\uE12E'  $'\uF017 '  $'\uF017 '  $'\uF017 '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                            
+  p9k::register_segment "TIME" "" "${DEFAULT_COLOR_INVERTED}" "${DEFAULT_COLOR}"  ''  $'\uE12E'  $'\uF017 '  $'\uF017 '  $'\uF017 '
+}
 
 ################################################################
 # @description

--- a/segments/todo.p9k
+++ b/segments/todo.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                             ☑          ☑          ☑                                                   
-p9k::register_segment "TODO" "" "grey50" "${DEFAULT_COLOR}"  $'\u2611'  $'\u2611'  $'\u2611'  '\u'${CODEPOINT_OF_AWESOME_CHECK_SQUARE_O}  $'\uF046'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                             ☑          ☑          ☑                                                   
+  p9k::register_segment "TODO" "" "grey50" "${DEFAULT_COLOR}"  $'\u2611'  $'\u2611'  $'\u2611'  '\u'${CODEPOINT_OF_AWESOME_CHECK_SQUARE_O}  $'\uF046'
+}
 
 ################################################################
 # @description

--- a/segments/user.p9k
+++ b/segments/user.p9k
@@ -4,26 +4,30 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                                            
-p9k::register_segment "USER" "DEFAULT"     "yellow" "${DEFAULT_COLOR}"  ''         ''         $'\uF2C0'  '\u'${CODEPOINT_OF_AWESOME_USER_O}  $'\uF2C0'
-#                                                                        ⚡                                                                
-p9k::register_segment "USER" "ROOT"        "yellow" "${DEFAULT_COLOR}"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}    $'\uE614 '
-#                                                                                                                                         
-p9k::register_segment "USER" "SUDO"        "yellow" "${DEFAULT_COLOR}"  $'\uE0A2'  $'\uF09C'  $'\uF09C'  '\u'${CODEPOINT_OF_AWESOME_UNLOCK}  $'\uF09C'
-#                                                                                                                                            
-p9k::register_segment "USER" "REMOTE"      "yellow" "${DEFAULT_COLOR}"  ''         ''         $'\uF2C0'  '\u'${CODEPOINT_OF_AWESOME_USER_O}  $'\uF2C0'
-#                                                                                                                                         
-p9k::register_segment "USER" "REMOTE_SUDO" "yellow" "${DEFAULT_COLOR}"  $'\uE0A2'  $'\uF09C'  $'\uF09C'  '\u'${CODEPOINT_OF_AWESOME_UNLOCK}  $'\uF09C'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                                            
+  p9k::register_segment "USER" "DEFAULT"     "yellow" "${DEFAULT_COLOR}"  ''         ''         $'\uF2C0'  '\u'${CODEPOINT_OF_AWESOME_USER_O}  $'\uF2C0'
+  #                                                                        ⚡                                                                
+  p9k::register_segment "USER" "ROOT"        "yellow" "${DEFAULT_COLOR}"  $'\u26A1'  $'\uE801'  $'\uF201'  '\u'${CODEPOINT_OF_OCTICONS_ZAP}    $'\uE614 '
+  #                                                                                                                                         
+  p9k::register_segment "USER" "SUDO"        "yellow" "${DEFAULT_COLOR}"  $'\uE0A2'  $'\uF09C'  $'\uF09C'  '\u'${CODEPOINT_OF_AWESOME_UNLOCK}  $'\uF09C'
+  #                                                                                                                                            
+  p9k::register_segment "USER" "REMOTE"      "yellow" "${DEFAULT_COLOR}"  ''         ''         $'\uF2C0'  '\u'${CODEPOINT_OF_AWESOME_USER_O}  $'\uF2C0'
+  #                                                                                                                                         
+  p9k::register_segment "USER" "REMOTE_SUDO" "yellow" "${DEFAULT_COLOR}"  $'\uE0A2'  $'\uF09C'  $'\uF09C'  '\u'${CODEPOINT_OF_AWESOME_UNLOCK}  $'\uF09C'
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_USER_ALWAYS_SHOW false
-p9k::set_default P9K_USER_ALWAYS_SHOW_USER false
-p9k::set_default P9K_USER_TEMPLATE "%n"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_USER_ALWAYS_SHOW false
+  p9k::set_default P9K_USER_ALWAYS_SHOW_USER false
+  p9k::set_default P9K_USER_TEMPLATE "%n"
+}
 
 ################################################################
 # @description

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -64,65 +64,69 @@
 # Initialize all the required VCS_INFO hooks / helper functions
 ################################################################
 
-################################################################
-# Register segment helper icons
-# Parameters:
-#   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                          ●                                                                                  
-p9k::register_icon "VCS_UNSTAGED"          $'\u25CF'   $'\uE17C'   $'\uF06A'   '\u'${CODEPOINT_OF_AWESOME_EXCLAMATION_CIRCLE}    $'\uF06A'
-#                                          ✚                                                                                  
-p9k::register_icon "VCS_STAGED"            $'\u271A'   $'\uE168'   $'\uF055'   '\u'${CODEPOINT_OF_AWESOME_PLUS_CIRCLE}           $'\uF055'
-#                                          ⍟                                                                                  
-p9k::register_icon "VCS_STASH"             $'\u235F'   $'\uE133 '  $'\uF01C '  '\u'${CODEPOINT_OF_AWESOME_INBOX}' '              $'\uF01C '
-#                                          ↓                                                                                  
-p9k::register_icon "VCS_INCOMING_CHANGES"  $'\u2193'   $'\uE131 '  $'\uF01A '  '\u'${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_DOWN}' '  $'\uF01A '
-#                                          ↑                                                                                  
-p9k::register_icon "VCS_OUTGOING_CHANGES"  $'\u2191'   $'\uE132 '  $'\uF01B '  '\u'${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_UP}' '    $'\uF01B '
-#                                                                                                                             
-p9k::register_icon "VCS_TAG"               ''          $'\uE817 '  $'\uF217 '  '\u'${CODEPOINT_OF_AWESOME_TAG}' '                $'\uF02B '
-#                                          ☿                                                                                  
-p9k::register_icon "VCS_BOOKMARK"          $'\u263F'   $'\uE87B'   $'\uF27B'   '\u'${CODEPOINT_OF_OCTICONS_BOOKMARK}             $'\uF461 '
-#                                                                                                                             
-p9k::register_icon "VCS_COMMIT"            ''          $'\uE821 '  $'\uF221 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_COMMIT}' '        $'\uE729 '
-#                                                                                                                             
-p9k::register_icon "VCS_CLOBBERED_FOLDER"  ''          $'\uE818'   $'\uF115'   '\u'${CODEPOINT_OF_AWESOME_FOLDER_O}              $'\uF115'
-#                                          ✘           ✘           ✘                                                             
-p9k::register_icon "VCS_ERROR"             $'\u2718'   $'\u2718'   $'\u2718'   '\u'${CODEPOINT_OF_AWESOME_TIMES}                 $'\uF00D'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment helper icons
+  # Parameters:
+  #   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                          ●                                                                                  
+  p9k::register_icon "VCS_UNSTAGED"          $'\u25CF'   $'\uE17C'   $'\uF06A'   '\u'${CODEPOINT_OF_AWESOME_EXCLAMATION_CIRCLE}    $'\uF06A'
+  #                                          ✚                                                                                  
+  p9k::register_icon "VCS_STAGED"            $'\u271A'   $'\uE168'   $'\uF055'   '\u'${CODEPOINT_OF_AWESOME_PLUS_CIRCLE}           $'\uF055'
+  #                                          ⍟                                                                                  
+  p9k::register_icon "VCS_STASH"             $'\u235F'   $'\uE133 '  $'\uF01C '  '\u'${CODEPOINT_OF_AWESOME_INBOX}' '              $'\uF01C '
+  #                                          ↓                                                                                  
+  p9k::register_icon "VCS_INCOMING_CHANGES"  $'\u2193'   $'\uE131 '  $'\uF01A '  '\u'${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_DOWN}' '  $'\uF01A '
+  #                                          ↑                                                                                  
+  p9k::register_icon "VCS_OUTGOING_CHANGES"  $'\u2191'   $'\uE132 '  $'\uF01B '  '\u'${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_UP}' '    $'\uF01B '
+  #                                                                                                                             
+  p9k::register_icon "VCS_TAG"               ''          $'\uE817 '  $'\uF217 '  '\u'${CODEPOINT_OF_AWESOME_TAG}' '                $'\uF02B '
+  #                                          ☿                                                                                  
+  p9k::register_icon "VCS_BOOKMARK"          $'\u263F'   $'\uE87B'   $'\uF27B'   '\u'${CODEPOINT_OF_OCTICONS_BOOKMARK}             $'\uF461 '
+  #                                                                                                                             
+  p9k::register_icon "VCS_COMMIT"            ''          $'\uE821 '  $'\uF221 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_COMMIT}' '        $'\uE729 '
+  #                                                                                                                             
+  p9k::register_icon "VCS_CLOBBERED_FOLDER"  ''          $'\uE818'   $'\uF115'   '\u'${CODEPOINT_OF_AWESOME_FOLDER_O}              $'\uF115'
+  #                                          ✘           ✘           ✘                                                             
+  p9k::register_icon "VCS_ERROR"             $'\u2718'   $'\u2718'   $'\u2718'   '\u'${CODEPOINT_OF_AWESOME_TIMES}                 $'\uF00D'
 
-# Hide branch icon if user wants it hidden
-if [[ "${P9K_VCS_HIDE_BRANCH_ICON}" != true ]]; then
-  if [[ ${P9K_MODE} != 'compatible' ]]; then
-    #                                                                                                                         
-    p9k::register_icon "VCS_BRANCH"        $'\uE0A0 '  $'\uE220 '  $'\uF126 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_BRANCH}' '        $'\uF126 '
-  else
-    #                                                                                                                         
-    p9k::register_icon "VCS_BRANCH"        "@ "        $'\uE220 '  $'\uF126 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_BRANCH}' '        $'\uF126 '
+  # Hide branch icon if user wants it hidden
+  if [[ "${P9K_VCS_HIDE_BRANCH_ICON}" != true ]]; then
+    if [[ ${P9K_MODE} != 'compatible' ]]; then
+      #                                                                                                                         
+      p9k::register_icon "VCS_BRANCH"        $'\uE0A0 '  $'\uE220 '  $'\uF126 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_BRANCH}' '        $'\uF126 '
+    else
+      #                                                                                                                         
+      p9k::register_icon "VCS_BRANCH"        "@ "        $'\uE220 '  $'\uF126 '  '\u'${CODEPOINT_OF_OCTICONS_GIT_BRANCH}' '        $'\uF126 '
+    fi
   fi
-fi
 
-#                                          →           →          →                                                            
-p9k::register_icon "VCS_REMOTE_BRANCH"     $'\u2192'   $'\u2192'   $'\u2192'   '\u'${CODEPOINT_OF_OCTICONS_REPO_PUSH}            $'\uE728 '
-#                                                                                                                             
-p9k::register_icon "VCS_GIT"               ''          $'\uE20E '  $'\uF1D3 '  '\u'${CODEPOINT_OF_AWESOME_GIT}' '                $'\uF1D3 '
-#                                                                                                                              
-p9k::register_icon "VCS_GIT_GITHUB"        ''          $'\uE20E '  $'\uF113 '  '\u'${CODEPOINT_OF_AWESOME_GITHUB_ALT}' '         $'\uF113 '
-#                                                                                                                              
-p9k::register_icon "VCS_GIT_BITBUCKET"     ''          $'\uE20E '  $'\uF171 '  '\u'${CODEPOINT_OF_AWESOME_BITBUCKET}' '          $'\uE703 '
-#                                                                                                                              
-p9k::register_icon "VCS_GIT_GITLAB"        ''          $'\uE20E '  $'\uF296 '  '\u'${CODEPOINT_OF_AWESOME_GITLAB}' '             $'\uF296 '
-#                                                                                                                             
-p9k::register_icon "VCS_HG"                ''          $'\uE1C3 '  $'\uF0C3 '  '\u'${CODEPOINT_OF_AWESOME_FLASK}' '              $'\uF0C3 '
-#                                                                                                                                
-p9k::register_icon "VCS_SVN"               ''          '(svn) '    '(svn) '    '(svn) '                                          $'\uE72D '
+  #                                          →           →          →                                                            
+  p9k::register_icon "VCS_REMOTE_BRANCH"     $'\u2192'   $'\u2192'   $'\u2192'   '\u'${CODEPOINT_OF_OCTICONS_REPO_PUSH}            $'\uE728 '
+  #                                                                                                                             
+  p9k::register_icon "VCS_GIT"               ''          $'\uE20E '  $'\uF1D3 '  '\u'${CODEPOINT_OF_AWESOME_GIT}' '                $'\uF1D3 '
+  #                                                                                                                              
+  p9k::register_icon "VCS_GIT_GITHUB"        ''          $'\uE20E '  $'\uF113 '  '\u'${CODEPOINT_OF_AWESOME_GITHUB_ALT}' '         $'\uF113 '
+  #                                                                                                                              
+  p9k::register_icon "VCS_GIT_BITBUCKET"     ''          $'\uE20E '  $'\uF171 '  '\u'${CODEPOINT_OF_AWESOME_BITBUCKET}' '          $'\uE703 '
+  #                                                                                                                              
+  p9k::register_icon "VCS_GIT_GITLAB"        ''          $'\uE20E '  $'\uF296 '  '\u'${CODEPOINT_OF_AWESOME_GITLAB}' '             $'\uF296 '
+  #                                                                                                                             
+  p9k::register_icon "VCS_HG"                ''          $'\uE1C3 '  $'\uF0C3 '  '\u'${CODEPOINT_OF_AWESOME_FLASK}' '              $'\uF0C3 '
+  #                                                                                                                                
+  p9k::register_icon "VCS_SVN"               ''          '(svn) '    '(svn) '    '(svn) '                                          $'\uE72D '
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_VCS_ACTIONFORMAT_FOREGROUND "red"
-p9k::set_default P9K_VCS_HIDE_TAGS false
-p9k::set_default P9K_VCS_INTERNAL_HASH_LENGTH "8" # Default: Just display the first 8 characters of our changeset-ID.
-p9k::set_default P9K_VCS_DIR_SHORTEN_DELIMITER $'\U2026'
-p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
-p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_VCS_ACTIONFORMAT_FOREGROUND "red"
+  p9k::set_default P9K_VCS_HIDE_TAGS false
+  p9k::set_default P9K_VCS_INTERNAL_HASH_LENGTH "8" # Default: Just display the first 8 characters of our changeset-ID.
+  p9k::set_default P9K_VCS_DIR_SHORTEN_DELIMITER $'\U2026'
+  p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
+  p9k::set_default P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH false
+}
 
 function +vi-git-untracked() {
   [[ -z "${vcs_comm[gitdir]}" || "${vcs_comm[gitdir]}" == "." ]] && return

--- a/segments/vi_mode.p9k
+++ b/segments/vi_mode.p9k
@@ -4,21 +4,25 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-p9k::register_segment  "VI_MODE" "NORMAL" "${DEFAULT_COLOR}" "white"  ''  ''  ''  ''  ''
-p9k::register_segment  "VI_MODE" "INSERT" "${DEFAULT_COLOR}" "blue"   ''  ''  ''  ''  ''
-p9k::register_segment  "VI_MODE" "SEARCH" "${DEFAULT_COLOR}" "purple" ''  ''  ''  ''  ''
-p9k::register_segment  "VI_MODE" "VISUAL" "${DEFAULT_COLOR}" "orange" ''  ''  ''  ''  ''
+() {
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  p9k::register_segment  "VI_MODE" "NORMAL" "${DEFAULT_COLOR}" "white"  ''  ''  ''  ''  ''
+  p9k::register_segment  "VI_MODE" "INSERT" "${DEFAULT_COLOR}" "blue"   ''  ''  ''  ''  ''
+  p9k::register_segment  "VI_MODE" "SEARCH" "${DEFAULT_COLOR}" "purple" ''  ''  ''  ''  ''
+  p9k::register_segment  "VI_MODE" "VISUAL" "${DEFAULT_COLOR}" "orange" ''  ''  ''  ''  ''
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_VI_MODE_NORMAL_STRING 'NORMAL'
-p9k::set_default P9K_VI_MODE_INSERT_STRING 'INSERT'
-p9k::set_default P9K_VI_MODE_SEARCH_STRING 'SEARCH'
-p9k::set_default P9K_VI_MODE_VISUAL_STRING 'VISUAL'
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_VI_MODE_NORMAL_STRING 'NORMAL'
+  p9k::set_default P9K_VI_MODE_INSERT_STRING 'INSERT'
+  p9k::set_default P9K_VI_MODE_SEARCH_STRING 'SEARCH'
+  p9k::set_default P9K_VI_MODE_VISUAL_STRING 'VISUAL'
+}
 
 ###############################################################
 # Vi Mode: show editing mode (NORMAL|INSERT)

--- a/segments/virtualenv.p9k
+++ b/segments/virtualenv.p9k
@@ -4,12 +4,16 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                 🐍          
-p9k::register_segment "VIRTUALENV" "" "blue" "${DEFAULT_COLOR}"  ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C '
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                 🐍          
+  p9k::register_segment "VIRTUALENV" "" "blue" "${DEFAULT_COLOR}"  ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C '
+}
 
 ################################################################
 # @description

--- a/segments/vpn_ip.p9k
+++ b/segments/vpn_ip.p9k
@@ -4,16 +4,20 @@
 # @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
 ##
 
-################################################################
-# Register segment
-# Parameters:
-#   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-#                                                                                                                  
-p9k::register_segment "VPN_IP" "" "cyan" "${DEFAULT_COLOR}"  '(vpn)'  '(vpn)'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                  
+  p9k::register_segment "VPN_IP" "" "cyan" "${DEFAULT_COLOR}"  '(vpn)'  '(vpn)'  $'\uF023'  '\u'${CODEPOINT_OF_AWESOME_LOCK}  $'\uF023'
 
-################################################################
-# Register segment default values
-p9k::set_default P9K_VPN_IP_INTERFACE "tun"
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_VPN_IP_INTERFACE "tun"
+}
 
 ################################################################
 # @description

--- a/test/functions/icons.spec
+++ b/test/functions/icons.spec
@@ -6,70 +6,61 @@ setopt shwordsplit
 SHUNIT_PARENT=$0
 
 function setUp() {
-    # Store old value for LC_CTYPE
-    _OLD_LC_CTYPE="${LC_CTYPE}"
-    # Reset actual LC_CTYPE
-    unset LC_CTYPE
-
-    # Store old P9K mode
-    _OLD_P9K_MODE="${P9K_MODE}"
     source functions/utilities.zsh
 }
 
-function tearDown() {
-    # Restore LC_CTYPE
-    LC_CTYPE="${_OLD_LC_CTYPE}"
-
-    # Restore old P9K mode
-    P9K_MODE="${_OLD_P9K_MODE}"
-}
-
-function testLcCtypeIsSetCorrectlyInDefaultMode() {
-  P9K_MODE="default"
+function testLcCtypeIsNotOverwrittenInDefaultMode() {
+  local P9K_MODE="default"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
-function testLcCtypeIsSetCorrectlyInAwesomePatchedMode() {
-  P9K_MODE="awesome-patched"
+function testLcCtypeIsNotOverwrittenInAwesomePatchedMode() {
+  local P9K_MODE="awesome-patched"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
-function testLcCtypeIsSetCorrectlyInAwesomeFontconfigMode() {
-  P9K_MODE="awesome-fontconfig"
+function testLcCtypeIsNotOverwrittenInAwesomeFontconfigMode() {
+  local P9K_MODE="awesome-fontconfig"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
-function testLcCtypeIsSetCorrectlyInNerdfontFontconfigMode() {
-  P9K_MODE="nerdfont-fontconfig"
+function testLcCtypeIsNotOverwrittenInNerdfontFontconfigMode() {
+  local P9K_MODE="nerdfont-fontconfig"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
-function testLcCtypeIsSetCorrectlyInFlatMode() {
-  P9K_MODE="flat"
+function testLcCtypeIsNotOverwrittenInFlatMode() {
+  local P9K_MODE="flat"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
-function testLcCtypeIsSetCorrectlyInCompatibleMode() {
-  P9K_MODE="compatible"
+function testLcCtypeIsNotOverwrittenInCompatibleMode() {
+  local P9K_MODE="compatible"
+  local LC_CTYPE="my-locale"
   # Load Powerlevel9k
   source functions/icons.zsh
 
-  assertEquals 'en_US.UTF-8' "${LC_CTYPE}"
+  assertEquals 'my-locale' "${LC_CTYPE}"
 }
 
 # Go through all icons defined in default mode, and
@@ -77,7 +68,7 @@ function testLcCtypeIsSetCorrectlyInCompatibleMode() {
 function testAllIconsAreDefinedLikeInDefaultMode() {
   # Always compare against this mode
   local _P9K_TEST_MODE="default"
-  P9K_MODE="${_P9K_TEST_MODE}"
+  local P9K_MODE="${_P9K_TEST_MODE}"
   source functions/icons.zsh
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
@@ -86,7 +77,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "awesome-patched" mode
-  P9K_MODE="awesome-patched"
+  local P9K_MODE="awesome-patched"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -105,7 +96,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   done
 
   # Switch to "awesome-fontconfig" mode
-  P9K_MODE="awesome-fontconfig"
+  local P9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -114,7 +105,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   done
 
   # Switch to "nerdfont-fontconfig" mode
-  P9K_MODE="nerdfont-fontconfig"
+  local P9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -123,7 +114,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   done
 
   # Switch to "flat" mode
-  P9K_MODE="flat"
+  local P9K_MODE="flat"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -132,7 +123,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
   done
 
   # Switch to "compatible" mode
-  P9K_MODE="compatible"
+  local P9K_MODE="compatible"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -149,7 +140,7 @@ function testAllIconsAreDefinedLikeInDefaultMode() {
 function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   # Always compare against this mode
   local _P9K_TEST_MODE="awesome-patched"
-  P9K_MODE="$_P9K_TEST_MODE"
+  local P9K_MODE="$_P9K_TEST_MODE"
   source functions/icons.zsh
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
@@ -158,7 +149,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
-  P9K_MODE="default"
+  local P9K_MODE="default"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -177,7 +168,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   done
 
   # Switch to "awesome-fontconfig" mode
-  P9K_MODE="awesome-fontconfig"
+  local P9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -186,7 +177,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   done
 
   # Switch to "nerdfont-fontconfig" mode
-  P9K_MODE="nerdfont-fontconfig"
+  local P9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -195,7 +186,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   done
 
   # Switch to "flat" mode
-  P9K_MODE="flat"
+  local P9K_MODE="flat"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -204,7 +195,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
   done
 
   # Switch to "compatible" mode
-  P9K_MODE="compatible"
+  local P9K_MODE="compatible"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -221,7 +212,7 @@ function testAllIconsAreDefinedLikeInAwesomePatchedMode() {
 function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   # Always compare against this mode
   local _P9K_TEST_MODE="awesome-fontconfig"
-  P9K_MODE="$_P9K_TEST_MODE"
+  local P9K_MODE="$_P9K_TEST_MODE"
   source functions/icons.zsh
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
@@ -230,7 +221,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
-  P9K_MODE="default"
+  local P9K_MODE="default"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -249,7 +240,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   done
 
   # Switch to "awesome-patched" mode
-  P9K_MODE="awesome-patched"
+  local P9K_MODE="awesome-patched"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -258,7 +249,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   done
 
   # Switch to "nerdfont-fontconfig" mode
-  P9K_MODE="nerdfont-fontconfig"
+  local P9K_MODE="nerdfont-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -267,7 +258,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   done
 
   # Switch to "flat" mode
-  P9K_MODE="flat"
+  local P9K_MODE="flat"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -276,7 +267,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
   done
 
   # Switch to "compatible" mode
-  P9K_MODE="compatible"
+  local P9K_MODE="compatible"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -293,7 +284,7 @@ function testAllIconsAreDefinedLikeInAwesomeFontconfigMode() {
 function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   # Always compare against this mode
   local _P9K_TEST_MODE="nerdfont-fontconfig"
-  P9K_MODE="$_P9K_TEST_MODE"
+  local P9K_MODE="$_P9K_TEST_MODE"
   source functions/icons.zsh
   # _ICONS_UNDER_TEST is an array of just the keys of $icons.
   # We later check via (r) "subscript" flag that our key
@@ -302,7 +293,7 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   _ICONS_UNDER_TEST=(${(k)icons[@]})
 
   # Switch to "default" mode
-  P9K_MODE="default"
+  local P9K_MODE="default"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -321,7 +312,7 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   done
 
   # Switch to "awesome-patched" mode
-  P9K_MODE="awesome-patched"
+  local P9K_MODE="awesome-patched"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -330,7 +321,7 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   done
 
   # Switch to "awesome-fontconfig" mode
-  P9K_MODE="awesome-fontconfig"
+  local P9K_MODE="awesome-fontconfig"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -339,7 +330,7 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   done
 
   # Switch to "flat" mode
-  P9K_MODE="flat"
+  local P9K_MODE="flat"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})
@@ -348,7 +339,7 @@ function testAllIconsAreDefinedLikeInNerdfontFontconfigMode() {
   done
 
   # Switch to "compatible" mode
-  P9K_MODE="compatible"
+  local P9K_MODE="compatible"
   source functions/icons.zsh
   typeset -ah current_icons
   current_icons=(${(k)icons[@]})


### PR DESCRIPTION
This protects the users locale. Before, we always set `LC_CTYPE` to `en_us.utf8`. Now we do that only internally. I had to wrap all occurrences of icons with a anonymous wrapper function to create scope so that `local` works correctly. I also moved all calls to `p9k::set_default` into that function, because they may contain icons as well (see dir segment).