### PR TITLE
Enable colors on Travis

### DIFF
--- a/test/suite.spec
+++ b/test/suite.spec
@@ -1,6 +1,8 @@
 #!/usr/bin/env zsh
 #vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
 
+export SHUNIT_COLOR="always"
+
 local failed=false
 local P9K_IGNORE_VAR_WARNING=true
 


### PR DESCRIPTION
shUnit is capable of outputting ANSI-Colors. By default shUnit detects the coloring capabilities of the terminal automatically. This seems to fail for travis. This PR enforces colored output.