### PR TITLE
[Enhancement] Custom symbols for start/end edge segments instead of squares, custom whitespace control 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ without affecting the icon color.
 
 You can also change the battery icon automatically depending on the battery
 level. This will override the default battery icon. In order to do this, you
-need to define the `POWERLEVEL9k_BATTERY_STAGES` variable.
+need to define the `P9k_BATTERY_STAGES` variable.
 
 
 | Variable                      | Default Value | Description                                                   |

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -343,3 +343,76 @@ function __p9k_print_deprecation_var_warning() {
     fi
   done
 }
+
+###############################################################
+# @description
+#   Takes a list of variable names and returns the value of the 
+#   the first defined one, even if it's an empty string. Useful
+#   for cases when users can define variables that should take 
+#   priority even if they are empty.
+# @args
+#   $1 optional flag '-n' as first argument will make function to 
+#   return variable name instead of it's value.
+#   $* List of variable names.
+# @returns
+#   First defined variable value, or it's name if '-n' is passed.
+##
+function p9k::find_first_defined() {
+  local returnName
+  while [ $# -ne 0 ]; do
+    if [[ "$1" == "-n" ]]; then 
+      returnName=true
+    elif [[ ! -z "${(P)1+x}" ]]; then 
+      [[ -n $returnName ]] && echo "$1" || echo "${(P)1}"
+      break
+    fi
+    shift
+  done
+}
+
+###############################################################
+# @description
+#   Takes a list of variable names and returns the value of the 
+#   the first non empty one. 
+# @args
+#   $1 optional flag '-n' as first argument will make function to 
+#   return variable name instead of it's value.
+#   $* List of variable names.
+# @returns
+#   First non empty variable value, or it's name if '-n' is passed.
+##
+function p9k::find_first_non_empty() {
+  local returnName
+  while [ $# -ne 0 ]; do
+    if [[ "$1" == "-n" ]]; then 
+      returnName=true
+    elif [[ -n "${(P)1}" ]]; then 
+      [[ -n $returnName ]] && echo "$1" || echo "${(P)1}"
+      break
+    fi
+    shift
+  done
+}
+
+###############################################################
+# @description
+#   Joins supplied strings with specified separator.
+# @args
+#   $1 The separator to join strings with
+#   $* List of string to join.
+# @returns
+#   A joined string.
+##
+p9k::join_by() { 
+  local separator="$1"; 
+  local sep=""; 
+  shift; 
+  local result=""
+  for str in $@; do 
+    if [[ -n $str ]]; then
+      result="${result}${sep}${str}"
+      sep="${separator}"
+    fi
+  done
+  echo "$result"
+}

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -52,7 +52,8 @@ function __p9k_detect_os() {
     FreeBSD | OpenBSD | DragonFly) __P9K_OS='BSD' ;;
     Linux)
       __P9K_OS='Linux'
-      [[ ${(f)"$((</etc/os-release) 2>/dev/null)"} =~ "ID=([A-Za-z]+)" ]] && __P9K_OS_ID="${match[1]}"
+      local os_release=$((</etc/os-release) 2>/dev/null)
+      [[ ${(f)os_release} =~ "ID=([A-Za-z]+)" ]] && __P9K_OS_ID="${match[1]}"
       case $(uname -o 2>/dev/null) in
         Android) __P9K_OS='Android' ;;
       esac

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -54,31 +54,49 @@ function __p9k_left_prompt_segment() {
   local joined=false
   [[ "${3}" == "true" ]] \
       && __p9k_segment_should_be_joined ${current_index} ${last_left_element_index} "$P9K_LEFT_PROMPT_ELEMENTS" && joined=true
+  local content
   # Support for bold segment
-  [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
+  [[ -n ${4} ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
 
+  local ws=$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
+  local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_LEFT_WHITESPACE \
+    P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS ws)
+  local right_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
+    P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS ws)
+
   if [[ ${CURRENT_BG} != 'NONE' ]]; then # not first segment
     if [[ "$bg" != "$CURRENT_BG" ]]; then # background colors are different
       echo -n "$bg%F${CURRENT_BG#%K}"
-      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}$left_ws"
     else # background colors are the same
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment. This should have enough contrast.
-      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]}$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]}$left_ws"
     fi
   else # First segment
-    echo -n "${bg}$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS"
+
+    # Custom symbol for left side of the first segment and 
+    # custom white space that follows it
+    local first_symbol=""
+    local first_ws=$left_ws
+    if [[ -n "$P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL" ]]; then
+      first_symbol="%K{$CURRENT_BG}%F${bg#%K}${P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL}"
+      first_ws=$(p9k::find_first_defined P9K_LEFT_PROMPT_FIRST_SEGMENT_START_WHITESPACE first_ws)
+    fi
+
+    echo -n "${first_symbol}${bg}$first_ws"
   fi
 
-  # Print the visual identifier
-  [[ ${SEGMENT_ICON} != "" ]] && echo -n "$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}${P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS}%f${fg}" || echo -n "${fg}"
-  # Print the content of the segment, if there is any
-  [[ -n "${content}" ]] && echo -n "${content}${P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS}"
+  # Print the visual identifier and content if any
+  local visual_identifier
+  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
+  [[ -n "${content}" ]] && content="${fg}${content}"
+  echo -n "$(p9k::join_by "${ws}" "${visual_identifier}" "${content}")${right_ws}"
 
   CURRENT_BG=$bg
   last_left_element_index=$current_index
@@ -103,6 +121,7 @@ function __p9k_left_prompt_end() {
 CURRENT_RIGHT_BG='NONE'
 
 p9k::set_default last_right_element_index 1
+p9k::set_default last_right_element_stateful_name ""
 p9k::set_default P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS " "
 ################################################################
 # @description
@@ -126,13 +145,21 @@ function __p9k_right_prompt_segment() {
   [[ "${3}" == "true" ]] && __p9k_segment_should_be_joined ${current_index} ${last_right_element_index} "$P9K_RIGHT_PROMPT_ELEMENTS" && joined=true
   local content
   # Support for bold segment
-  [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
+  [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
 
+  local ws=$P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS
+  local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
+    P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS ws )
+  local right_ws=$(p9k::find_first_defined P9K_${last_right_element_stateful_name}_RIGHT_WHITESPACE \
+    P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS ws )
+
+
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
+  [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "$right_ws" # print right whitespace of prev segment
   if [[ ${joined} == false ]] || [[ ${CURRENT_RIGHT_BG} == 'NONE' ]]; then
     if [[ "$bg" != "$CURRENT_RIGHT_BG" ]]; then
       # Use the new BG color for the foreground with separator
@@ -147,22 +174,27 @@ function __p9k_right_prompt_segment() {
 
   echo -n "${bg}${fg}"
 
-  if [[ ${(L)P9K_RPROMPT_ICON_LEFT} == "true" ]]; then # Visual identifier before content
-    # Print the visual identifier
-    echo -n "${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
-    # Print segment content if there is any
-    [[ -n "${content}" ]] && echo -n "${content}${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
-  else
+  local visual_identifier
+  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}"
+
+  # if [[ ${(L)P9K_RPROMPT_ICON_LEFT} == "true" ]]; then # Visual identifier before content
+  #   echo -n "${left_ws}"
+  #   # Print the visual identifier if there is any
+  #   [[ -n "${visual_identifier}" ]] && echo -n "${visual_identifier}${ws}"
+  #   # Print segment content if there is any
+  #   [[ -n "${content}" ]] && echo -n "${content}${right_ws}"
+  # else
     # Print whitespace only if segment is not joined or first right segment
-    [[ ${joined} == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
-    # Print segment content if there is any
-    [[ -n "${content}" ]] && echo -n "${content}${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
-    # Print the visual identifier
-    echo -n "$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}${P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS}"
-  fi
+    [[ ${joined} == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${left_ws}"
+    # Print segment content and icon, if any
+    [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
+      && echo -n "$(p9k::join_by "${ws}" "${content}" "${visual_identifier}")" \
+      || echo -n "$(p9k::join_by "${ws}" "${visual_identifier}" "${content}")"
+  # fi
 
   CURRENT_RIGHT_BG=$bg
   last_right_element_index=$current_index
+  last_right_element_stateful_name=${STATEFUL_NAME}
 }
 
 ################################################################
@@ -305,6 +337,17 @@ function __p9k_build_right_prompt() {
 
     index=$((index + 1))
   done
+
+  # last whitespace with last segments right symbol, if any
+  local last_symbol
+  local last_ws=$(p9k::find_first_defined P9K_${last_right_element_stateful_name}_RIGHT_WHITESPACE \
+    P9K_RIGHT_PROMPT_LAST_SEGMENT_END_WHITESPACE P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
+  if p9k::defined "P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL"; then
+    last_symbol="%K{none}%F${CURRENT_RIGHT_BG#%K}${P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL}"
+  fi
+
+  echo -n "${last_ws}${last_symbol}"
+
 }
 
 ###############################################################

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -62,11 +62,12 @@ function __p9k_left_prompt_segment() {
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
 
-  local ws=$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
   local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_LEFT_WHITESPACE \
-    P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS ws)
+    P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS)
+  local middle_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_MIDDLE_WHITESPACE \
+    P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS )
   local right_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
-    P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS ws)
+    P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS)
 
   if [[ ${CURRENT_BG} != 'NONE' ]]; then # not first segment
     if [[ "$bg" != "$CURRENT_BG" ]]; then # background colors are different
@@ -96,7 +97,7 @@ function __p9k_left_prompt_segment() {
   local visual_identifier
   [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
   [[ -n "${content}" ]] && content="${fg}${content}"
-  echo -n "$(p9k::join_by "${ws}" "${visual_identifier}" "${content}")${right_ws}"
+  echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${content}")${right_ws}"
 
   CURRENT_BG=$bg
   last_left_element_index=$current_index
@@ -151,12 +152,12 @@ function __p9k_right_prompt_segment() {
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
 
-  local ws=$P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS
   local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
-    P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS ws )
+    P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
+  local middle_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_MIDDLE_WHITESPACE \
+    P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
   local right_ws=$(p9k::find_first_defined P9K_${last_right_element_stateful_name}_RIGHT_WHITESPACE \
-    P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS ws )
-
+    P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
   [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "$right_ws" # print right whitespace of prev segment
@@ -177,20 +178,12 @@ function __p9k_right_prompt_segment() {
   local visual_identifier
   [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
 
-  # if [[ ${(L)P9K_RPROMPT_ICON_LEFT} == "true" ]]; then # Visual identifier before content
-  #   echo -n "${left_ws}"
-  #   # Print the visual identifier if there is any
-  #   [[ -n "${visual_identifier}" ]] && echo -n "${visual_identifier}${ws}"
-  #   # Print segment content if there is any
-  #   [[ -n "${content}" ]] && echo -n "${content}${right_ws}"
-  # else
-    # Print whitespace only if segment is not joined or first right segment
-    [[ ${joined} == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${left_ws}"
-    # Print segment content and icon, if any
-    [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
-      && echo -n "$(p9k::join_by "${ws}" "${content}" "${visual_identifier}")" \
-      || echo -n "$(p9k::join_by "${ws}" "${visual_identifier}" "${content}")"
-  # fi
+  # Print whitespace only if segment is not joined or first right segment
+  [[ ${joined} == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${left_ws}"
+  # Print segment content and icon, if any
+  [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
+    && echo -n "$(p9k::join_by "${middle_ws}" "${content}" "${visual_identifier}")" \
+    || echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${content}")"
 
   CURRENT_RIGHT_BG=$bg
   last_right_element_index=$current_index
@@ -327,8 +320,7 @@ function __p9k_build_right_prompt() {
     # Remove joined information in direct calls
     element="${element%_joined}"
 
-    # Check if it is a custom command, otherwise interpet it as
-    # a prompt.
+    # Check if it is a custom command, otherwise interpet it as a prompt.
     if [[ $element[0,7] =~ "custom_" ]]; then
       "__p9k_prompt_custom" "right" "$index" ${joined} $element[8,-1]
     else
@@ -341,7 +333,7 @@ function __p9k_build_right_prompt() {
   # last whitespace with last segments right symbol, if any
   local last_symbol
   local last_ws=$(p9k::find_first_defined P9K_${last_right_element_stateful_name}_RIGHT_WHITESPACE \
-    P9K_RIGHT_PROMPT_LAST_SEGMENT_END_WHITESPACE P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
+    P9K_RIGHT_PROMPT_LAST_SEGMENT_END_WHITESPACE P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
   if p9k::defined "P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL"; then
     last_symbol="%K{none}%F${CURRENT_RIGHT_BG#%K}${P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL}"
   fi

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -175,7 +175,7 @@ function __p9k_right_prompt_segment() {
   echo -n "${bg}${fg}"
 
   local visual_identifier
-  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}"
+  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
 
   # if [[ ${(L)P9K_RPROMPT_ICON_LEFT} == "true" ]]; then # Visual identifier before content
   #   echo -n "${left_ws}"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -36,6 +36,7 @@ CURRENT_BG='NONE'
 
 p9k::set_default last_left_element_index 1
 p9k::set_default P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS " "
+p9k::set_default P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS " "
 ################################################################
 # @description
 #   Construct a left prompt segment
@@ -65,7 +66,7 @@ function __p9k_left_prompt_segment() {
   local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_LEFT_WHITESPACE \
     P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS)
   local middle_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_MIDDLE_WHITESPACE \
-    P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS )
+    P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS  )
   local right_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
     P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS)
 
@@ -124,6 +125,7 @@ CURRENT_RIGHT_BG='NONE'
 p9k::set_default last_right_element_index 1
 p9k::set_default last_right_element_stateful_name ""
 p9k::set_default P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS " "
+p9k::set_default P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS " "
 ################################################################
 # @description
 #   Construct a right prompt segment
@@ -152,10 +154,10 @@ function __p9k_right_prompt_segment() {
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
 
-  local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_RIGHT_WHITESPACE \
+  local left_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_LEFT_WHITESPACE \
     P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
   local middle_ws=$(p9k::find_first_defined P9K_${STATEFUL_NAME}_MIDDLE_WHITESPACE \
-    P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
+    P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS )
   local right_ws=$(p9k::find_first_defined P9K_${last_right_element_stateful_name}_RIGHT_WHITESPACE \
     P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
 

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -160,7 +160,7 @@ function __p9k_right_prompt_segment() {
   [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "${right_ws}" # print right whitespace of prev segment
   if [[ ${joined} == false ]] || [[ ${CURRENT_RIGHT_BG} == 'NONE' ]]; then
     if [[ "${bg}" != "${CURRENT_RIGHT_BG}" ]]; then
-      # Use the new BG color for the foreground with separator
+      # Use the new BG color for the foreground with separator 
       echo -n "%F${bg#%K}${__P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]}"
     else
       # Middle segment with same color as previous segment

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -70,27 +70,27 @@ function __p9k_left_prompt_segment() {
     P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS)
 
   if [[ ${CURRENT_BG} != 'NONE' ]]; then # not first segment
-    if [[ "$bg" != "$CURRENT_BG" ]]; then # background colors are different
-      echo -n "$bg%F${CURRENT_BG#%K}"
-      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}$left_ws"
+    if [[ "${bg}" != "${CURRENT_BG}" ]]; then # background colors are different
+      echo -n "${bg}%F${CURRENT_BG#%K}"
+      [[ ${joined} == false ]] && echo -n "$__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]${left_ws}"
     else # background colors are the same
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment. This should have enough contrast.
-      [[ ${joined} == false ]] && echo -n "${__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]}$left_ws"
+      [[ ${joined} == false ]] && echo -n "$__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]${left_ws}"
     fi
   else # First segment
 
     # Custom symbol for left side of the first segment and 
     # custom white space that follows it
     local first_symbol=""
-    local first_ws=$left_ws
+    local first_ws=${left_ws}
     if [[ -n "$P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL" ]]; then
-      first_symbol="%K{$CURRENT_BG}%F${bg#%K}${P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL}"
+      first_symbol="%K{${CURRENT_BG}}%F${bg#%K}$P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL"
       first_ws=$(p9k::find_first_defined P9K_LEFT_PROMPT_FIRST_SEGMENT_START_WHITESPACE first_ws)
     fi
 
-    echo -n "${first_symbol}${bg}$first_ws"
+    echo -n "${first_symbol}${bg}${first_ws}"
   fi
 
   # Print the visual identifier and content if any
@@ -160,16 +160,16 @@ function __p9k_right_prompt_segment() {
     P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS )
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
-  [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "$right_ws" # print right whitespace of prev segment
+  [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "${right_ws}" # print right whitespace of prev segment
   if [[ ${joined} == false ]] || [[ ${CURRENT_RIGHT_BG} == 'NONE' ]]; then
-    if [[ "$bg" != "$CURRENT_RIGHT_BG" ]]; then
+    if [[ "${bg}" != "${CURRENT_RIGHT_BG}" ]]; then
       # Use the new BG color for the foreground with separator
       echo -n "%F${bg#%K}${__P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]}"
     else
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment. This should have enough contrast.
-      echo -n "$fg${__P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]}"
+      echo -n "${fg}${__P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]}"
     fi
   fi
 
@@ -179,14 +179,14 @@ function __p9k_right_prompt_segment() {
   [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
 
   # Print whitespace only if segment is not joined or first right segment
-  [[ ${joined} == false ]] || [[ "$CURRENT_RIGHT_BG" == "NONE" ]] && echo -n "${left_ws}"
+  [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && echo -n "${left_ws}"
   # Print segment content and icon, if any
   [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
     && echo -n "$(p9k::join_by "${middle_ws}" "${content}" "${visual_identifier}")" \
-    || echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${content}")"
+    || echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${fg}${content}")" 
 
-  CURRENT_RIGHT_BG=$bg
-  last_right_element_index=$current_index
+  CURRENT_RIGHT_BG=${bg}
+  last_right_element_index=${current_index}
   last_right_element_stateful_name=${STATEFUL_NAME}
 }
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -163,7 +163,7 @@ deprecated_variables=(
   'P9K_CHANGESET_HASH_LENGTH'         'P9K_VCS_CHANGESET_HASH_LENGTH'
   # vi_mode segment
   'P9K_VI_INSERT_MODE_STRING'         'P9K_VI_MODE_INSERT_STRING'
-  'P9K_VI_COMMAND_MODE_STRING'        'P9K_VI_MODE_COMMAND_STRING'
+  'P9K_VI_COMMAND_MODE_STRING'        'P9K_VI_MODE_NORMAL_STRING'
   'P9K_VI_VISUAL_MODE_STRING'         'P9K_VI_MODE_VISUAL_STRING'
 )
 __p9k_print_deprecation_var_warning deprecated_variables

--- a/segments/vi_mode.p9k
+++ b/segments/vi_mode.p9k
@@ -42,7 +42,7 @@ p9k::set_default P9K_VI_MODE_VISUAL_STRING 'VISUAL'
 prompt_vi_mode() {
   local current_state
   typeset -gAH vi_states
-  case "${KEYMAP}" in
+  case "${VIM_MODE_KEYMAP:-$KEYMAP}" in
     vicmd)        current_state="NORMAL" ;;
     vivis)        current_state="VISUAL" ;;
     main|viins|*) current_state="INSERT" ;;
@@ -64,16 +64,16 @@ function rebuild_vi_mode {
         printf '%s' ${terminfo[smkx]}
       fi
       local current_state
-      case "${KEYMAP}" in
+      case "${VIM_MODE_KEYMAP:-$KEYMAP}" in
         vicmd)
-          [[ -z "${P9K_VI_COMMAND_MODE_STRING}" ]] && return
+          [[ -z "${P9K_VI_MODE_NORMAL_STRING}" ]] && return
           current_state="NORMAL"
           ;;
         vivis)
           current_state="VISUAL"
           ;;
         main|viins|*)
-          [[ -z "$P9K_VI_INSERT_MODE_STRING" ]] && return
+          [[ -z "${P9K_VI_MODE_INSERT_STRING}" ]] && return
           current_state="INSERT"
           ;;
       esac
@@ -174,12 +174,12 @@ cursorShape() {
 function zle-line-init {
   case $P9K_GENERATOR in
     zsh-async)
-      rebuild_vi_mode "${KEYMAP}"
+      rebuild_vi_mode "${VIM_MODE_KEYMAP:-$KEYMAP}"
     ;;
   esac
   # change cursor shape
   if [[ $P9K_CURSOR_SHAPE ]]; then
-    case ${KEYMAP} in
+    case "${VIM_MODE_KEYMAP:-$KEYMAP}" in
       vicmd)      cursorShape ${P9K_CURSOR_SHAPE_NORMAL};;
       viins|main) cursorShape ${P9K_CURSOR_SHAPE_INSERT};;
       vivis)      cursorShape ${P9K_CURSOR_SHAPE_VISUAL};;
@@ -190,7 +190,7 @@ function zle-line-init {
 
 ###############################################################
 function zle-line-finish {
-  #rebuild_vi_mode "${KEYMAP}"
+  #rebuild_vi_mode "${VIM_MODE_KEYMAP:-$KEYMAP}"
   if [[ $P9K_CURSOR_SHAPE ]]; then
     cursorShape ${P9K_CURSOR_SHAPE_DEFAULT}
   fi
@@ -200,7 +200,7 @@ function zle-line-finish {
 function zle-keymap-select {
   case $P9K_GENERATOR in
     zsh-async)
-      rebuild_vi_mode "${KEYMAP}"
+      rebuild_vi_mode "${VIM_MODE_KEYMAP:-$KEYMAP}"
     ;;
     *)
       # About .reset-prompt see:
@@ -212,7 +212,7 @@ function zle-keymap-select {
   esac
   # change cursor shape
   if [[ $P9K_CURSOR_SHAPE ]]; then
-    case ${KEYMAP} in
+    case "${VIM_MODE_KEYMAP:-$KEYMAP}" in
       vicmd)      cursorShape ${P9K_CURSOR_SHAPE_NORMAL};;
       viins|main) cursorShape ${P9K_CURSOR_SHAPE_INSERT};;
       vivis)      cursorShape ${P9K_CURSOR_SHAPE_VISUAL};;

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -17,7 +17,7 @@ function testDynamicColoringOfSegmentsWork() {
   local P9K_DATE_BACKGROUND='red'
   source segments/date.p9k
 
-  assertEquals "%K{001} %F{000}date-icon %f%F{000}%D{%d.%m.%y} %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}date-icon%f %F{000}%D{%d.%m.%y} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDynamicColoringOfVisualIdentifiersWork() {
@@ -26,7 +26,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
   local P9K_DATE_ICON_COLOR='green'
   source segments/date.p9k
 
-  assertEquals "%K{015} %F{002}date-icon %f%F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{002}date-icon%f %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
@@ -37,7 +37,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
   local P9K_DATE_BACKGROUND='yellow'
   source segments/date.p9k
 
-  assertEquals "%K{003} %F{002}date-icon %f%F{001}%D{%d.%m.%y} %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{002}date-icon%f %F{001}%D{%d.%m.%y} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingOfStatefulSegment() {
@@ -49,7 +49,7 @@ function testColorOverridingOfStatefulSegment() {
   local SSH_CLIENT="x"
   source segments/host.p9k
 
-  assertEquals "%K{001} %F{002}ssh-icon %f%F{002}%m %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{002}ssh-icon%f %F{002}%m %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingOfCustomSegment() {
@@ -60,7 +60,7 @@ function testColorOverridingOfCustomSegment() {
   local P9K_CUSTOM_WORLD_FOREGROUND='red'
   local P9K_CUSTOM_WORLD_BACKGROUND='red'
 
-  assertEquals "%K{001} %F{002}CW %f%F{001}world %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{002}CW%f %F{001}world %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -102,7 +102,7 @@ function testLeftJoiningBuiltinSegmentWorks() {
   alias php="echo PHP 1.2.3 "
   source segments/php_version.p9k
 
-  assertEquals "%K{013} %F{255}PHP %f%F{255}1.2.3 %F{255}PHP %f%F{255}1.2.3 %k%F{013}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{013} %F{255}PHP%f %F{255}1.2.3 %F{255}PHP%f %F{255}1.2.3 %k%F{013}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }
@@ -118,7 +118,7 @@ function testRightNormalSegmentsShouldNotBeJoined() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %F{000}%K{015}%F{000} world2 %F{000} %F{000}%K{015}%F{000} world4 %F{000} %F{000}%K{015}%F{000} world6 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world2 %F{000}%K{015}%F{000} world4 %F{000}%K{015}%F{000} world6 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightJoinedSegments() {
@@ -128,7 +128,7 @@ function testRightJoinedSegments() {
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %K{015}%F{000}world2 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightTransitiveJoinedSegments() {
@@ -139,7 +139,7 @@ function testRightTransitiveJoinedSegments() {
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %K{015}%F{000}world2 %F{000} %K{015}%F{000}world3 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 %K{015}%F{000}world3 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightTransitiveJoiningWithConditionalJoinedSegment() {
@@ -151,7 +151,7 @@ function testRightTransitiveJoiningWithConditionalJoinedSegment() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %K{015}%F{000}world2 %F{000} %K{015}%F{000}world4 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 %K{015}%F{000}world4 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithConditionalPredecessor() {
@@ -162,7 +162,7 @@ function testRightPromotingSegmentWithConditionalPredecessor() {
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %F{000}%K{015}%F{000} world3 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world3 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
@@ -174,7 +174,7 @@ function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %F{000}%K{015}%F{000} world4 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world4 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
@@ -188,7 +188,7 @@ function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000} %F{000}%K{015}%F{000} world4 %F{000} %K{015}%F{000}world6 %F{000} " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world4 %K{015}%F{000}world6 " "$(__p9k_build_right_prompt)"
 }
 
 function testRightJoiningBuiltinSegmentWorks() {
@@ -198,8 +198,7 @@ function testRightJoiningBuiltinSegmentWorks() {
   alias php="echo PHP 1.2.3"
   source segments/php_version.p9k
 
-  #assertEquals "%F{013}%K{013}%F{255} PHP 1.2.3 %f%K{013}%F{255}PHP 1.2.3 %F{000} " "$(__p9k_build_right_prompt)"
-  assertEquals "%F{013}%K{013}%F{255} 1.2.3 %F{255}PHP %K{013}%F{255}1.2.3 %F{255}PHP " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{013}%K{013}%F{255} 1.2.3 %F{255}PHP%f %K{013}%F{255}1.2.3 %F{255}PHP%f " "$(__p9k_build_right_prompt)"
 
   unalias php
 }

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -240,7 +240,7 @@ function testCustomWhitespaceWithIconOnLeft() {
   local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
 
   __p9k_prepare_prompts
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[R]_world1_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[R]_world3_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[R]_%F{000}world1_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[R]_%F{000}world3_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 }
 
 # !!! keep this last test in this file !!!

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -11,7 +11,7 @@ function setUp() {
   source powerlevel9k.zsh-theme
 }
 
-stripEsc() {
+function stripEsc() {
   local clean_string="" escape_found=false
   for (( i = 0; i < ${#1}; i++ )); do
     case ${1[i]}; in
@@ -39,7 +39,7 @@ function testSegmentOnRightSide() {
   __p9k_prepare_prompts
 
   local _actual=$(stripEsc "${(e)RPROMPT}")
-  assertEquals "%f%b%k%F{015}%K{015}%F{000} world1 %F{000} %F{000}%K{015}%F{000} world2 %F{000} %{<Esc>00m%" "${_actual}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world2 %{<Esc>00m%" "${_actual}"
 }
 
 function testDisablingRightPrompt() {
@@ -81,7 +81,7 @@ function testRightPromptOnSameLine() {
   __p9k_prepare_prompts
 
   local _actual=$(stripEsc "${(e)RPROMPT}")
-  assertEquals "%{<Esc>1A%}%f%b%k%F{015}%K{015}%F{000} world1 %F{000} %{<Esc>00m%}%{<Esc>1B%" "${_actual}"
+  assertEquals "%{<Esc>1A%}%f%b%k%F{015}%K{015}%F{000} world1 %{<Esc>00m%}%{<Esc>1B%" "${_actual}"
 }
 
 function testPrefixingFirstLineOnLeftPrompt() {
@@ -112,7 +112,70 @@ function testPrefixingSecondLineOnLeftPrompt() {
 
   local nl=$'\n'
   assertEquals "╭─%f%b%k%K{015} %F{000}world1 %k%F{015}%f ${nl}XXX" "${(e)PROMPT}"
+}
 
+function testCustomStartEndSymbolsOnEdgeSegments() {
+  # Reset RPROMPT, so a running P9K does not interfere with the test
+  local PROMPT=
+  local RPROMPT=
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  local P9K_CUSTOM_WORLD1='echo world1'
+  local P9K_CUSTOM_WORLD2='echo world2'
+
+  local P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL="_[_"
+  local P9K_LEFT_PROMPT_FIRST_SEGMENT_START_WHITESPACE="_A_"
+  local P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL="_]_"
+  local P9K_RIGHT_PROMPT_LAST_SEGMENT_END_WHITESPACE="_B_"
+
+  __p9k_prepare_prompts
+
+  assertEquals "%f%b%k%K{NONE}%F{015}_[_%K{015}_A_%F{000}world1  %F{000}world2 %k%F{015}%f " "${(e)PROMPT}"
+  local _right=$(stripEsc "${(e)RPROMPT}")
+  assertEquals "%f%b%k%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world2_B_%K{none}%F{015}_]_%{<Esc>00m%" "${_right}"
+}
+
+function testCustomWhitespaceOfSegments() {
+  # Reset RPROMPT, so a running P9K does not interfere with the test
+  local PROMPT=
+  local RPROMPT=
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  local P9K_CUSTOM_WORLD1='echo world1'
+  local P9K_CUSTOM_WORLD1_ICON='{1}'
+  local P9K_CUSTOM_WORLD2='echo world1'
+  local P9K_CUSTOM_WORLD3='echo world3'
+
+  local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_A_"
+  local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_B_"
+  local P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS="_C_"
+  local P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS="_D_"
+  local P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS="_E_"
+  local P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS="_F_"
+
+  local P9K_CUSTOM_WORLD1_RIGHT_WHITESPACE="_G_"
+  local P9K_CUSTOM_WORLD3_LEFT_WHITESPACE="_H_"
+
+  __p9k_prepare_prompts
+
+  assertEquals "%f%b%k%K{015}_C_%F{000}{1}_A_%F{000}world1_G__C_%F{000}world1_D__H_%F{000}world3_D_%k%F{015}%f " "${(e)PROMPT}"
+  local _right=$(stripEsc "${(e)RPROMPT}")
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_world1_B_%F{000}{1}_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+  
+  local P9K_RPROMPT_ICON_LEFT=true
+
+  __p9k_prepare_prompts
+  _right=$(stripEsc "${(e)RPROMPT}")
+  
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_%F{000}{1}_B_world1_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+}
+
+# !!! keep this last test in this file !!!
+test_unfunction_stripEsc() {
   unfunction stripEsc
 }
 

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -152,11 +152,15 @@ function testCustomWhitespaceOfSegments() {
   local P9K_CUSTOM_WORLD3_ICON='{3}'
 
   local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_[L]_"
+  local P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS="_[M]_"
+
   local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
+  local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[M]_"
+
 
   __p9k_prepare_prompts
-  assertEquals "%f%b%k%K{015}_[L]_%F{000}{1}%f_[L]_%F{000}world1_[L]__[L]_%F{000}world2_[L]__[L]_%F{000}{3}%f_[L]_%F{000}world3_[L]_%k%F{015}%f " "${(e)PROMPT}"
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_world1_[R]_%F{000}{1}%f_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_world3_[R]_%F{000}{3}%f_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+  assertEquals "%f%b%k%K{015}_[L]_%F{000}{1}%f_[M]_%F{000}world1_[L]__[L]_%F{000}world2_[L]__[L]_%F{000}{3}%f_[M]_%F{000}world3_[L]_%k%F{015}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_world1_[M]_%F{000}{1}%f_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_world3_[M]_%F{000}{3}%f_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 
 }
 
@@ -216,7 +220,7 @@ function testCustomWhitespaceOfCustomSegments() {
 
     __p9k_prepare_prompts
   assertEquals "%f%b%k%K{015}_[L1]_%F{000}{1}%f_[M1]_%F{000}world1_[R1]__[L2]_%F{000}world2_[R2]__[L3]_%F{000}{3}%f_[M3]_%F{000}world3_[R3]_%k%F{015}%f " "${(e)PROMPT}"
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R1]_world1_[M1]_%F{000}{1}%f_[R1]_%F{000}%K{015}%F{000}_[R2]_world2_[R2]_%F{000}%K{015}%F{000}_[R3]_world3_[M3]_%F{000}{3}%f_[R3]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[L1]_world1_[M1]_%F{000}{1}%f_[R1]_%F{000}%K{015}%F{000}_[L2]_world2_[R2]_%F{000}%K{015}%F{000}_[L3]_world3_[M3]_%F{000}{3}%f_[R3]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 
 }
 
@@ -236,11 +240,11 @@ function testCustomWhitespaceWithIconOnLeft() {
   
   local P9K_RPROMPT_ICON_LEFT=true
   
-  local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_[L]_"
+  local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[M]_"
   local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
 
   __p9k_prepare_prompts
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[R]_%F{000}world1_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[R]_%F{000}world3_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[M]_%F{000}world1_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[M]_%F{000}world3_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 }
 
 # !!! keep this last test in this file !!!

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -147,31 +147,100 @@ function testCustomWhitespaceOfSegments() {
   P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
-  local P9K_CUSTOM_WORLD2='echo world1'
+  local P9K_CUSTOM_WORLD2='echo world2'
   local P9K_CUSTOM_WORLD3='echo world3'
+  local P9K_CUSTOM_WORLD3_ICON='{3}'
 
-  local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_A_"
-  local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_B_"
-  local P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS="_C_"
-  local P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS="_D_"
-  local P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS="_E_"
-  local P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS="_F_"
-
-  local P9K_CUSTOM_WORLD1_RIGHT_WHITESPACE="_G_"
-  local P9K_CUSTOM_WORLD3_LEFT_WHITESPACE="_H_"
+  local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_[L]_"
+  local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
 
   __p9k_prepare_prompts
+  assertEquals "%f%b%k%K{015}_[L]_%F{000}{1}%f_[L]_%F{000}world1_[L]__[L]_%F{000}world2_[L]__[L]_%F{000}{3}%f_[L]_%F{000}world3_[L]_%k%F{015}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_world1_[R]_%F{000}{1}%f_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_world3_[R]_%F{000}{3}%f_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 
-  assertEquals "%f%b%k%K{015}_C_%F{000}{1}%f_A_%F{000}world1_G__C_%F{000}world1_D__H_%F{000}world3_D_%k%F{015}%f " "${(e)PROMPT}"
-  local _right=$(stripEsc "${(e)RPROMPT}")
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_world1_B_%F{000}{1}%f_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+}
+
+function testCustomWhitespaceOfLeftAndRightSegments() {
+  # Reset RPROMPT, so a running P9K does not interfere with the test
+  local PROMPT=
+  local RPROMPT=
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  local P9K_CUSTOM_WORLD1='echo world1'
+  local P9K_CUSTOM_WORLD1_ICON='{1}'
+  local P9K_CUSTOM_WORLD2='echo world2'
+  local P9K_CUSTOM_WORLD3='echo world3'
+  local P9K_CUSTOM_WORLD3_ICON='{3}'
+  
+  local P9K_LEFT_WHITESPACE_OF_LEFT_SEGMENTS="_[LL]_"
+  local P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS="_[LM]_"
+  local P9K_RIGHT_WHITESPACE_OF_LEFT_SEGMENTS="_[LR]_"
+
+  local P9K_LEFT_WHITESPACE_OF_RIGHT_SEGMENTS="_[RL]_"
+  local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[RM]_"
+  local P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS="_[RR]_"
+
+    __p9k_prepare_prompts
+  assertEquals "%f%b%k%K{015}_[LL]_%F{000}{1}%f_[LM]_%F{000}world1_[LR]__[LL]_%F{000}world2_[LR]__[LL]_%F{000}{3}%f_[LM]_%F{000}world3_[LR]_%k%F{015}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[RL]_world1_[RM]_%F{000}{1}%f_[RR]_%F{000}%K{015}%F{000}_[RL]_world2_[RR]_%F{000}%K{015}%F{000}_[RL]_world3_[RM]_%F{000}{3}%f_[RR]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+
+}
+
+function testCustomWhitespaceOfCustomSegments() {
+  # Reset RPROMPT, so a running P9K does not interfere with the test
+  local PROMPT=
+  local RPROMPT=
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  local P9K_CUSTOM_WORLD1='echo world1'
+  local P9K_CUSTOM_WORLD1_ICON='{1}'
+  local P9K_CUSTOM_WORLD2='echo world2'
+  local P9K_CUSTOM_WORLD3='echo world3'
+  local P9K_CUSTOM_WORLD3_ICON='{3}'
+  
+  local P9K_CUSTOM_WORLD1_LEFT_WHITESPACE="_[L1]_"
+  local P9K_CUSTOM_WORLD1_MIDDLE_WHITESPACE="_[M1]_"
+  local P9K_CUSTOM_WORLD1_RIGHT_WHITESPACE="_[R1]_"
+
+  local P9K_CUSTOM_WORLD2_LEFT_WHITESPACE="_[L2]_"
+  local P9K_CUSTOM_WORLD2_MIDDLE_WHITESPACE="_[M2]_"
+  local P9K_CUSTOM_WORLD2_RIGHT_WHITESPACE="_[R2]_"
+
+  local P9K_CUSTOM_WORLD3_LEFT_WHITESPACE="_[L3]_"
+  local P9K_CUSTOM_WORLD3_MIDDLE_WHITESPACE="_[M3]_"
+  local P9K_CUSTOM_WORLD3_RIGHT_WHITESPACE="_[R3]_"
+
+    __p9k_prepare_prompts
+  assertEquals "%f%b%k%K{015}_[L1]_%F{000}{1}%f_[M1]_%F{000}world1_[R1]__[L2]_%F{000}world2_[R2]__[L3]_%F{000}{3}%f_[M3]_%F{000}world3_[R3]_%k%F{015}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R1]_world1_[M1]_%F{000}{1}%f_[R1]_%F{000}%K{015}%F{000}_[R2]_world2_[R2]_%F{000}%K{015}%F{000}_[R3]_world3_[M3]_%F{000}{3}%f_[R3]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
+
+}
+
+function testCustomWhitespaceWithIconOnLeft() {
+  # Reset RPROMPT, so a running P9K does not interfere with the test
+  local PROMPT=
+  local RPROMPT=
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  local P9K_CUSTOM_WORLD1='echo world1'
+  local P9K_CUSTOM_WORLD1_ICON='{1}'
+  local P9K_CUSTOM_WORLD2='echo world2'
+  local P9K_CUSTOM_WORLD3='echo world3'
+  local P9K_CUSTOM_WORLD3_ICON='{3}'
   
   local P9K_RPROMPT_ICON_LEFT=true
+  
+  local P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS="_[L]_"
+  local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
 
   __p9k_prepare_prompts
-  _right=$(stripEsc "${(e)RPROMPT}")
-  
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_%F{000}{1}%f_B_world1_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[R]_world1_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[R]_world3_[R]_%{<Esc>00m%" "$(stripEsc "${(e)RPROMPT}")"
 }
 
 # !!! keep this last test in this file !!!

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -162,16 +162,16 @@ function testCustomWhitespaceOfSegments() {
 
   __p9k_prepare_prompts
 
-  assertEquals "%f%b%k%K{015}_C_%F{000}{1}_A_%F{000}world1_G__C_%F{000}world1_D__H_%F{000}world3_D_%k%F{015}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%K{015}_C_%F{000}{1}%f_A_%F{000}world1_G__C_%F{000}world1_D__H_%F{000}world3_D_%k%F{015}%f " "${(e)PROMPT}"
   local _right=$(stripEsc "${(e)RPROMPT}")
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_world1_B_%F{000}{1}_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_world1_B_%F{000}{1}%f_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
   
   local P9K_RPROMPT_ICON_LEFT=true
 
   __p9k_prepare_prompts
   _right=$(stripEsc "${(e)RPROMPT}")
   
-  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_%F{000}{1}_B_world1_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
+  assertEquals "%f%b%k%F{015}%K{015}%F{000}_G_%F{000}{1}%f_B_world1_G_%F{000}%K{015}%F{000}_E_world1_F_%F{000}%K{015}%F{000}_E_world3_B_%{<Esc>00m%" "${_right}"
 }
 
 # !!! keep this last test in this file !!!

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -19,7 +19,7 @@ function testOverwritingIconsWork() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %f%F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}icon-here%f %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
@@ -29,7 +29,7 @@ function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %f%F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}icon-here%f %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
@@ -39,7 +39,7 @@ function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}icon-here " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}icon-here%f " "$(__p9k_build_right_prompt)"
 }
 
 function testVisualIdentifierPrintsNothingIfNotAvailable() {
@@ -58,7 +58,7 @@ function testVisualIdentifierWorksWithUnicodeIcon() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='\u2714'
 
-  assertEquals "%K{015} %F{000}✔ %f%F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}✔%f %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -67,7 +67,7 @@ function testGetRelevantItemDoesNotReturnNotFoundItems() {
   local callback='[[ "$item" == "d" ]] && echo "found"'
 
   local result=$(p9k::get_relevant_item "$list" "$callback")
-  assertEquals '' ''
+  assertEquals '' '' # whats this ?
 
   unset list
 }
@@ -219,6 +219,45 @@ function testUpsearchWithFileGlobs() {
 
   cd "${OLDPWD}"
   rm -fr "/tmp/p9k-test"
+}
+
+function testFindingFirstDefinedOrNonEmptyVariableNyName() {
+  local var1=""
+  local var2="some value"
+
+  local result=
+
+  assertEquals "$(p9k::find_first_defined var0 var1 var2)" "" # var1 value
+  assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var1" # var1 name
+
+  assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "some value" # var2 value
+  assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var2" # var2 name
+
+  local var0=""
+  assertEquals "$(p9k::find_first_defined var0 var1 var2)" "" # var1 value
+  assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var0" # var1 name
+  var0="other value"
+  assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "other value" # var2 value
+  assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var0" # var2 name
+
+  function internal() {
+    local var0="qwe"
+    assertEquals "$(p9k::find_first_defined var0 var1 var2)" "qwe" # var1 value
+    assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var0" # var1 name
+    assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "qwe" # var2 value
+    assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var0" # var2 name
+  }
+
+  internal
+
+}
+
+function testJoiningStrings() {
+
+  assertEquals "$(p9k::join_by _ hello there)" "hello_there"
+  assertEquals "$(p9k::join_by '-' one two three)" "one-two-three"
+  assertEquals "$(p9k::join_by '-' "" two three)" "two-three"
+
 }
 
 source shunit2/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -72,7 +72,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{004} %F{002}icon-here %f%F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{002}icon-here%f %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -92,7 +92,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{003} %F{002}icon-here %f%F{001}/tmp %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{002}icon-here%f %F{001}/tmp %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -109,7 +109,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{004} %F{000}icon-here %f%F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here%f %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   # rm -fr ~/$testFolder
@@ -126,9 +126,23 @@ function testNewlineOnRpromptCanBeDisabled() {
   local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 
   __p9k_prepare_prompts
-  #             ╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [30m [00m[1B
-  assertEquals '╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [30m [00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
 
+  #               ╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [00m[1B
+  local expected='╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [00m[1B'
+  local _real="$(print -P ${PROMPT}${RPROMPT})"
+
+  # use this to debug output with special escape sequences
+  # new lines for escape codes that move output one line above
+  # set -vx;
+  # echo "\n__1__\n"
+  # echo "\n__${expected}__\n"
+  # echo "\n__2__\n"
+  # echo "\n__${_real}__\n"
+  # echo "\n__3__\n"
+  # set +vx;
+
+  assertEquals "$expected" "$_real"
+  
 }
 
 source shunit2/shunit2

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -36,7 +36,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPathIsSet() {
   CONDA_ENV_PATH=/tmp
   unset CONDA_PREFIX
 
-  assertEquals "%K{004} %F{000}icon-here %f%F{000}(tmp) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here%f %F{000}(tmp) %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
@@ -50,7 +50,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
   unset CONDA_ENV_PATH
   local CONDA_PREFIX="test"
 
-  assertEquals "%K{004} %F{000}icon-here %f%F{000}(test) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here%f %F{000}(test) %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAnacondaSegmentWorks() {
@@ -64,7 +64,7 @@ function testAnacondaSegmentWorks() {
   local CONDA_ENV_PATH=/tmp
   local CONDA_PREFIX="test"
 
-  assertEquals "%K{004} %F{000}icon-here %f%F{000}(tmptest) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here%f %F{000}(tmptest) %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/aws_eb_env.spec
+++ b/test/segments/aws_eb_env.spec
@@ -32,7 +32,7 @@ function testAwsEbEnvSegmentWorksIfElasticBeanstalkEnvironmentIsSet() {
   echo "test:\n    environment: test" > /tmp/powerlevel9k-test/.elasticbeanstalk/config.yml
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{000} %F{002}🌱  %f%F{002}test %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}🌱 %f %F{002}test %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   rm -fr /tmp/powerlevel9k-test
   cd -
@@ -53,7 +53,7 @@ function testAwsEbEnvSegmentWorksIfElasticBeanstalkEnvironmentIsSetInParentDirec
   echo "test:\n    environment: test" > /tmp/powerlevel9k-test/.elasticbeanstalk/config.yml
   cd /tmp/powerlevel9k-test/1/12/123/1234/12345
 
-  assertEquals "%K{000} %F{002}🌱  %f%F{002}test %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}🌱 %f %F{002}test %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   rm -fr /tmp/powerlevel9k-test
   cd -

--- a/test/segments/background_jobs.spec
+++ b/test/segments/background_jobs.spec
@@ -33,7 +33,7 @@ function testBackgroundJobsSegmentVerboseAlwaysPrintsZeroWithoutBackgroundJobs()
   # Load Powerlevel9k
   source segments/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %f%F{000}0 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙%f %F{000}0 %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
@@ -45,7 +45,7 @@ function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
 
   # Load Powerlevel9k
   source segments/background_jobs.p9k
-  assertEquals "%K{003} %F{000}⚙ %f%F{000}%k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙%f %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
@@ -58,7 +58,7 @@ function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
   # Load Powerlevel9k
   source segments/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %f%F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙%f %F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWithVerboseMode() {
@@ -71,7 +71,7 @@ function testBackgroundJobsSegmentWithVerboseMode() {
     # Load Powerlevel9k
     source segments/background_jobs.p9k
 
-    assertEquals "%K{003} %F{000}⚙ %f%F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{003} %F{000}⚙%f %F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithExpandedMode() {
@@ -85,7 +85,7 @@ function testBackgroundJobsSegmentWorksWithExpandedMode() {
   # Load Powerlevel9k
   source segments/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %f%F{000}1r 2s %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙%f %F{000}1r 2s %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -89,7 +89,7 @@ function testBatterySegmentIfBatteryIsLowWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; discharging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋%f %F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
@@ -97,7 +97,7 @@ function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; charging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋%f %F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnOSX() {
@@ -105,7 +105,7 @@ function testBatterySegmentIfBatteryIsNormalWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; discharging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnOSX() {
@@ -113,7 +113,7 @@ function testBatterySegmentIfBatteryIsNormalWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; charging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋%f %F{003}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnOSX() {
@@ -121,7 +121,7 @@ function testBatterySegmentIfBatteryIsFullOnOSX() {
   makeBatterySay "Now drawing from 'AC Power'
  -InternalBattery-0 (id=1234567)	99%; charged; 0:00 remaining present: true"
 
-  assertEquals "%K{000} %F{002}🔋 %f%F{002}99%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}🔋%f %F{002}99%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnOSX() {
@@ -129,49 +129,49 @@ function testBatterySegmentIfBatteryIsCalculatingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	99%; discharging; (no estimate) present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Discharging"
 
-  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋%f %F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}4%% (2:14) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋%f %F{003}4%% (2:14) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Discharging"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% (2:17) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}98%% (2:17) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}98%% (0:02) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋%f %F{003}98%% (0:02) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "100" "Full"
 
-  assertEquals "%K{000} %F{002}🔋 %f%F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}🔋%f %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "99" "Unknown"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -151,7 +151,7 @@ function testBatterySegmentIfBatteryIsLowWhileUnknownOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Unknown"
 
-  assertEquals "%K{000} %F{001}🔋 %f%F{001}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋%f %F{001}4%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
@@ -172,7 +172,7 @@ function testBatterySegmentIfBatteryIsNormalWhileUnknownOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Unknown"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {
@@ -186,14 +186,14 @@ function testBatterySegmentIfBatteryNearlyFullButNotChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Unknown" "0"
 
-  assertEquals "%K{000} %F{015}🔋 %f%F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋%f %F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "99" "Charging" "0"
 
-  assertEquals "%K{000} %F{003}🔋 %f%F{003}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋%f %F{003}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -31,7 +31,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   local _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}2.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}2.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeSetToZero() {
@@ -40,7 +40,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   local _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}0.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}0.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeChanged() {
@@ -50,7 +50,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=4
   local _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}0.0001 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}0.0001 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeSetToZero() {
@@ -59,7 +59,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=0
   local _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() {
@@ -67,7 +67,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() 
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local _P9K_COMMAND_DURATION=180
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}03:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}03:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
@@ -75,7 +75,7 @@ function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local _P9K_COMMAND_DURATION=7200
 
-  assertEquals "%K{001} %F{226}Dur %f%F{226}02:00:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur%f %F{226}02:00:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/custom.spec
+++ b/test/segments/custom.spec
@@ -55,7 +55,7 @@ function testSettingVisualIdentifierForCustomSegment() {
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_ICON="hw"
 
-  assertEquals "%K{015} %F{000}hw %f%F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}hw%f %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testSettingVisualIdentifierForegroundColorForCustomSegment() {
@@ -65,7 +65,7 @@ function testSettingVisualIdentifierForegroundColorForCustomSegment() {
   local P9K_CUSTOM_WORLD_ICON="hw"
   local P9K_CUSTOM_WORLD_ICON_COLOR="red"
 
-  assertEquals "%K{015} %F{001}hw %f%F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{001}hw%f %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -426,7 +426,7 @@ function testHomeFolderDetectionWorks() {
   source segments/dir.p9k
 
   cd ~
-  assertEquals "%K{004} %F{000}home-icon %f%F{000}~ %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}home-icon%f %F{000}~ %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -441,7 +441,7 @@ function testHomeSubfolderDetectionWorks() {
   local FOLDER=~/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{004} %F{000}sub-icon %f%F{000}~/powerlevel9k-test %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}sub-icon%f %F{000}~/powerlevel9k-test %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -457,7 +457,7 @@ function testOtherFolderDetectionWorks() {
   local FOLDER=/tmp/powerlevel9k-test
   mkdir $FOLDER
   cd $FOLDER
-  assertEquals "%K{004} %F{000}folder-icon %f%F{000}/tmp/powerlevel9k-test %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon%f %F{000}/tmp/powerlevel9k-test %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $FOLDER
@@ -515,7 +515,7 @@ function testOmittingFirstCharacterWorks() {
 
   cd /tmp
 
-  assertEquals "%K{004} %F{000}folder-icon %f%F{000}tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon%f %F{000}tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -532,7 +532,7 @@ function testOmittingFirstCharacterWorksWithChangingPathSeparator() {
   mkdir -p /tmp/powerlevel9k-test/1/2
   cd /tmp/powerlevel9k-test/1/2
 
-  assertEquals "%K{004} %F{000}folder-icon %f%F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}folder-icon%f %F{000}tmpxXxpowerlevel9k-testxXx1xXx2 %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test

--- a/test/segments/disk_usage.spec
+++ b/test/segments/disk_usage.spec
@@ -40,7 +40,7 @@ function testDiskUsageSegmentWhenDiskIsAlmostFull() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{001} %F{015}hdd  %f%F{015}97%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}hdd %f %F{015}97%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -56,7 +56,7 @@ function testDiskUsageSegmentWhenDiskIsVeryFull() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{003} %F{000}hdd  %f%F{000}94%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd %f %F{000}94%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -72,7 +72,7 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{000} %F{046}hdd  %f%F{046}4%% %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{046}hdd %f %F{046}4%% %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -105,7 +105,7 @@ function testDiskUsageSegmentWarningLevelCouldBeAdjusted() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{003} %F{000}hdd  %f%F{000}11%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd %f %F{000}11%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -123,7 +123,7 @@ function testDiskUsageSegmentCriticalLevelCouldBeAdjusted() {
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{001} %F{015}hdd  %f%F{015}11%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}hdd %f %F{015}11%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -42,7 +42,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{002} %F{255}Go %f%F{255}go1.5.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{255}Go%f %F{255}go1.5.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_GO_ICON
   unset PWD

--- a/test/segments/ip.spec
+++ b/test/segments/ip.spec
@@ -65,7 +65,7 @@ function testIpSegmentWorksOnOsxWithNoInterfaceSpecified() {
 
   local __P9K_OS='OSX' # Fake OSX
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unalias ipconfig
   unalias networksetup
@@ -118,7 +118,7 @@ function testIpSegmentWorksOnOsxWithMultipleInterfacesSpecified() {
 
   local __P9K_OS='OSX' # Fake OSX
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unfunction ipconfig
   unalias networksetup
@@ -132,7 +132,7 @@ function testIpSegmentWorksOnOsxWithInterfaceSpecified() {
 
   local __P9K_OS='OSX' # Fake OSX
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}1.2.3.4 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unalias ipconfig
 }
@@ -160,7 +160,7 @@ function testIpSegmentWorksOnLinuxWithNoInterfaceSpecified() {
 
   local __P9K_OS='Linux' # Fake Linux
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unfunction ip
 }
@@ -193,7 +193,7 @@ function testIpSegmentWorksOnLinuxWithMultipleInterfacesSpecified() {
 
   local __P9K_OS='Linux' # Fake Linux
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unfunction ip
 }
@@ -210,7 +210,7 @@ inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
 
   local __P9K_OS='Linux' # Fake Linux
 
-  assertEquals "%K{006} %F{000}IP %f%F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{006} %F{000}IP%f %F{000}10.0.2.15 %k%F{006}%f " "$(__p9k_build_left_prompt)"
 
   unfunction ip
 }

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -71,7 +71,7 @@ function testKubeContext() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{005} %F{015}⎈ %f%F{015}minikube/default %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{015}⎈%f %F{015}minikube/default %k%F{005}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -81,7 +81,7 @@ function testKubeContextOtherNamespace() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{005} %F{015}⎈ %f%F{015}minikube/kube-system %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{015}⎈%f %F{015}minikube/kube-system %k%F{005}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -33,7 +33,7 @@ function testLaravelVersionSegment() {
   P9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
   source segments/laravel_version.p9k
 
-  assertEquals "%K{001} %F{015}x %f%F{015}5.4.23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}x%f %F{015}5.4.23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
   unalias php
 }
 

--- a/test/segments/load.spec
+++ b/test/segments/load.spec
@@ -43,7 +43,7 @@ function testLoadSegmentWorksOnOsx() {
 
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{002} %F{000}L %f%F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L%f %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -63,7 +63,7 @@ function testLoadSegmentWorksOnBsd() {
 
   local __P9K_OS="BSD" # Fake BSD
 
-  assertEquals "%K{002} %F{000}L %f%F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L%f %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -78,7 +78,7 @@ function testLoadSegmentWorksOnLinux() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{002} %F{000}L %f%F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L%f %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -96,7 +96,7 @@ function testLoadSegmentNormalState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{002} %F{000}L %f%F{000}1.00 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L%f %F{000}1.00 " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -114,7 +114,7 @@ function testLoadSegmentWarningState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}L %f%F{000}2.01 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}L%f %F{000}2.01 " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -132,7 +132,7 @@ function testLoadSegmentCriticalState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{001} %F{000}L %f%F{000}2.81 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{001} %F{000}L%f %F{000}2.81 " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }

--- a/test/segments/node_version.spec
+++ b/test/segments/node_version.spec
@@ -30,7 +30,7 @@ function testNodeVersionSegmentWorks() {
     echo "v1.2.3"
   }
 
-  assertEquals "%K{002} %F{015}⬢ %f%F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{015}⬢%f %F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   unfunction node
 }

--- a/test/segments/nodeenv.spec
+++ b/test/segments/nodeenv.spec
@@ -65,7 +65,7 @@ function testNodeenvSegmentPrintsAtLeastNodeEnvWithoutNode() {
   alias node="nonode 2>/dev/null"
   NODE_VIRTUAL_ENV="node-env"
 
-  assertEquals "%K{000} %F{002}⬢ %f%F{002}[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}⬢%f %F{002}[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset NODE_VIRTUAL_ENV
   unalias node
@@ -79,7 +79,7 @@ function testNodeenvSegmentWorks() {
   }
   NODE_VIRTUAL_ENV="node-env"
 
-  assertEquals "%K{000} %F{002}⬢ %f%F{002}v1.2.3[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}⬢%f %F{002}v1.2.3[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction node
   unset NODE_VIRTUAL_ENV

--- a/test/segments/nvm.spec
+++ b/test/segments/nvm.spec
@@ -48,7 +48,7 @@ function testNvmSegmentWorksWithoutHavingADefaultAlias() {
     [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v1.4.0'
   }
 
-  assertEquals "%K{005} %F{000}⬢ %f%F{000}4.6.0 %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{000}⬢%f %F{000}4.6.0 %k%F{005}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {

--- a/test/segments/php_version.spec
+++ b/test/segments/php_version.spec
@@ -31,7 +31,7 @@ Copyright (c) 1997-2016 The PHP Group
 Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
 '"
 
-  assertEquals "%K{013} %F{255}PHP %f%F{255}5.6.27 %k%F{013}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{013} %F{255}PHP%f %F{255}5.6.27 %k%F{013}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }

--- a/test/segments/ram.spec
+++ b/test/segments/ram.spec
@@ -38,7 +38,7 @@ Pages inactive:                         1313411.
 
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{003} %F{000}RAM %f%F{000}6.15G " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM%f %F{000}6.15G " "$(prompt_ram left 1 false ${FOLDER})"
 
   unalias vm_stat
 }
@@ -49,7 +49,7 @@ function testRamSegmentWorksOnBsd() {
 
   local __P9K_OS="BSD" # Fake BSD
 
-  assertEquals "%K{003} %F{000}RAM %f%F{000}0.29M " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM%f %F{000}0.29M " "$(prompt_ram left 1 false ${FOLDER})"
   return 0
 }
 
@@ -59,7 +59,7 @@ function testRamSegmentWorksOnLinux() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}RAM %f%F{000}0.29G " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM%f %F{000}0.29G " "$(prompt_ram left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -34,7 +34,7 @@ function testRust() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{000}Rust %f%F{000}0.4.1a-alpha %k%F{208}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{208} %F{000}Rust%f %F{000}0.4.1a-alpha %k%F{208}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testRustPrintsNothingIfRustIsNotAvailable() {

--- a/test/segments/ssh.spec
+++ b/test/segments/ssh.spec
@@ -35,7 +35,7 @@ function testSshSegmentWorksIfOnlySshClientIsSet() {
   SSH_CLIENT='ssh-client'
   unset SSH_TTY
 
-  assertEquals "%K{000} %F{003}ssh-icon %f%F{003}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_CLIENT
 }
@@ -50,7 +50,7 @@ function testSshSegmentWorksIfOnlySshTtyIsSet() {
   SSH_TTY='ssh-tty'
   unset SSH_CLIENT
 
-  assertEquals "%K{000} %F{003}ssh-icon %f%F{003}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_TTY
 }
@@ -65,7 +65,7 @@ function testSshSegmentWorksIfAllNecessaryVariablesAreSet() {
   SSH_CLIENT='ssh-client'
   SSH_TTY='ssh-tty'
 
-  assertEquals "%K{000} %F{003}ssh-icon %f%F{003}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon%f %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_TTY
   unset SSH_CLIENT

--- a/test/segments/stack_project.spec
+++ b/test/segments/stack_project.spec
@@ -60,7 +60,7 @@ function testStackProjectSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(stack_project)
 
-  assertEquals "%K{056} %F{015}λ= %f%F{015}Stack %k%F{056}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{056} %F{015}λ=%f %F{015}Stack %k%F{056}%f " "$(__p9k_build_left_prompt)"
 
   unalias stack
 }

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -32,7 +32,7 @@ function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
   local P9K_STATUS_HIDE_SIGNAME=true
   local P9K_LEFT_PROMPT_ELEMENTS=(status)
 
-  assertEquals "%K{000} %F{002}✔ %f%F{002}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}✔%f %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusInGeneralErrorCase() {
@@ -41,7 +41,7 @@ function testStatusInGeneralErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_SHOW_PIPESTATUS=false
 
-  assertEquals "%K{001} %F{226}↵ %f%F{226}1 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵%f %F{226}1 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testPipestatusInErrorCase() {
@@ -51,7 +51,7 @@ function testPipestatusInErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_SHOW_PIPESTATUS=true
 
-  assertEquals "%K{001} %F{226}↵ %f%F{226}0|0|1|0 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵%f %F{226}0|0|1|0 %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusCrossWinsOverVerbose() {
@@ -61,7 +61,7 @@ function testStatusCrossWinsOverVerbose() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_CROSS=true
 
-  assertEquals "%K{000} %F{001}✘ %f%F{001}%k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{001}✘%f %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusShowsSignalNameInErrorCase() {
@@ -71,7 +71,7 @@ function testStatusShowsSignalNameInErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_HIDE_SIGNAME=false
 
-  assertEquals "%K{001} %F{226}↵ %f%F{226}SIGILL(4) %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵%f %F{226}SIGILL(4) %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusSegmentIntegrated() {
@@ -80,7 +80,7 @@ function testStatusSegmentIntegrated() {
 
   false; __p9k_prepare_prompts
 
-  assertEquals "%f%b%k%K{000} %F{001}✘ %f%F{001}%k%F{000}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%K{000} %F{001}✘%f %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/shunit2

--- a/test/segments/swap.spec
+++ b/test/segments/swap.spec
@@ -36,7 +36,7 @@ function testSwapSegmentWorksOnOsx() {
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{003} %F{000}SWP %f%F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}SWP%f %F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -52,7 +52,7 @@ function testSwapSegmentWorksOnLinux() {
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}SWP %f%F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}SWP%f %F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/test/segments/swift_version.spec
+++ b/test/segments/swift_version.spec
@@ -47,7 +47,7 @@ function testSwiftSegmentWorks() {
     echo "Apple Swift version 3.0.1 (swiftlang-800.0.58.6 clang-800.0.42.1)\nTarget: x86_64-apple-macosx10.9"
   }
 
-  assertEquals "%K{005} %F{015}Swift %f%F{015}3.0.1 %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{015}Swift%f %F{015}3.0.1 %k%F{005}%f " "$(__p9k_build_left_prompt)"
 
   unfunction swift
 }

--- a/test/segments/symfony_version.spec
+++ b/test/segments/symfony_version.spec
@@ -79,7 +79,7 @@ function testSymfonyVersionSegmentWorks() {
     echo "Symfony version 3.1.4 - app/dev/debug"
   }
 
-  assertEquals "%K{240} %F{000}SF %f%F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{240} %F{000}SF%f %F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
 
   unfunction php
 }
@@ -98,7 +98,7 @@ function testSymfonyVersionSegmentWorksInNestedFolder() {
   mkdir -p src/P9K/AppBundle
   cd src/P9K/AppBundle
 
-  assertEquals "%K{240} %F{000}SF %f%F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{240} %F{000}SF%f %F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
 
   unfunction php
 }

--- a/test/segments/todo.spec
+++ b/test/segments/todo.spec
@@ -53,7 +53,7 @@ function testTodoSegmentWorksAsExpected() {
   echo 'echo "TODO: 34 of 100 tasks shown";' >> ${FOLDER}/bin/todo.sh
   chmod +x ${FOLDER}/bin/todo.sh
 
-  assertEquals "%K{244} %F{000}☑ %f%F{000}100 %k%F{244}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{244} %F{000}☑%f %F{000}100 %k%F{244}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/vagrant.spec
+++ b/test/segments/vagrant.spec
@@ -59,7 +59,7 @@ function testVagrantSegmentSaysVmIsDownIfVirtualboxIsNotAvailableButVagrantFolde
   local PATH=/bin:/usr/bin
   mockVagrantFolder "some-id"
 
-  assertEquals "%K{001} %F{000}V %f%F{000}DOWN %K{015}%F{001} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V%f %F{000}DOWN %K{015}%F{001} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsUp() {
@@ -69,7 +69,7 @@ function testVagrantSegmentWorksIfVmIsUp() {
   mockVBoxManage "${vagrantId}"
   mockVagrantFolder "${vagrantId}"
 
-  assertEquals "%K{002} %F{000}V %f%F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V%f %F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsDown() {
@@ -79,7 +79,7 @@ function testVagrantSegmentWorksIfVmIsDown() {
   mockVBoxManage "${vagrantId}"
   mockVagrantFolder "another-vm-id"
 
-  assertEquals "%K{001} %F{000}V %f%F{000}DOWN %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V%f %F{000}DOWN %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsUpFromWithinSubdir() {
@@ -92,7 +92,7 @@ function testVagrantSegmentWorksIfVmIsUpFromWithinSubdir() {
   mkdir -p "subfolder/1/2/3"
   cd subfolder/1/2/3
 
-  assertEquals "%K{002} %F{000}V %f%F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V%f %F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWithChangedString() {
@@ -102,11 +102,11 @@ function testVagrantSegmentWithChangedString() {
   mockVagrantFolder "${vagrantId}"
 
   local P9K_VAGRANT_DOWN="Nope"
-  assertEquals "%K{001} %F{000}V %f%F{000}Nope %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V%f %F{000}Nope %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   mockVBoxManage "${vagrantId}"
   local P9K_VAGRANT_UP="Yep"
-  assertEquals "%K{002} %F{000}V %f%F{000}Yep %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V%f %F{000}Yep %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -102,7 +102,7 @@ function testColorOverridingForUntrackedStateWorks() {
 
   touch testfile
 
-  assertEquals "%K{003} %F{006}? %f%F{006} master ? %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{006}?%f %F{006} master ? %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitIconWorks() {
@@ -110,7 +110,7 @@ function testGitIconWorks() {
   local P9K_VCS_GIT_ICON='Git-icon'
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{002} %F{000}Git-icon %f%F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}Git-icon%f %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitlabIconWorks() {
@@ -123,7 +123,7 @@ function testGitlabIconWorks() {
   # sufficient to show the GitLab-specific icon.
   git remote add origin https://gitlab.com/dritter/gitlab-test-project.git
 
-  assertEquals "%K{002} %F{000}GL-icon %f%F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GL-icon%f %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBitbucketIconWorks() {
@@ -136,7 +136,7 @@ function testBitbucketIconWorks() {
   # sufficient to show the BitBucket-specific icon.
   git remote add origin https://dritter@bitbucket.org/dritter/dr-test.git
 
-  assertEquals "%K{002} %F{000}BB-icon %f%F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}BB-icon%f %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitHubIconWorks() {
@@ -149,7 +149,7 @@ function testGitHubIconWorks() {
   # sufficient to show the GitHub-specific icon.
   git remote add origin https://github.com/dritter/test.git
 
-  assertEquals "%K{002} %F{000}GH-icon %f%F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GH-icon%f %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testUntrackedFilesIconWorks() {
@@ -160,7 +160,7 @@ function testUntrackedFilesIconWorks() {
   # Create untracked file
   touch "i-am-untracked.txt"
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStagedFilesIconWorks() {
@@ -353,10 +353,10 @@ function testBranchNameTruncatingShortenLength() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_LENGTH=3
-  assertEquals "%K{002} %F{000}? %f%F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -376,11 +376,11 @@ function testBranchNameTruncatingMinLength() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_MIN_LENGTH=7
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -400,11 +400,11 @@ function testBranchNameTruncatingShortenStrategy() {
   git init 1>/dev/null
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %f%F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_STRATEGY="truncate_middle"
 
-  assertEquals "%K{002} %F{000}? %f%F{000} mas…ter ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} mas…ter ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -485,7 +485,7 @@ function testGitDirClobber() {
   # so for git this is a repo inside another repo.
   cd vcs-test2
 
-  assertEquals "%K{001} %F{000}✘  /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}✘ /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   unset GIT_DIR
@@ -518,7 +518,7 @@ function testDetectingUntrackedFilesInSubmodulesWork() {
 
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
@@ -544,7 +544,7 @@ function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
 
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectingUntrackedFilesInNestedSubmodulesWork() {
@@ -587,7 +587,7 @@ function testDetectingUntrackedFilesInNestedSubmodulesWork() {
 
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
@@ -610,7 +610,7 @@ function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
 
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 
-  assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}?%f %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -414,6 +414,7 @@ function testRemoteBranchNameIdenticalToTag() {
   # This tests the fix from #941
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   echo "test" > test.txt
   git add test.txt 1>/dev/null
@@ -440,6 +441,7 @@ function testAlwaysShowRemoteBranch() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
   local P9K_VCS_HIDE_TAGS='true'
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   echo "test" > test.txt
   git add . 1>/dev/null
@@ -460,6 +462,8 @@ function testGitDirClobber() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
   local P9K_VCS_HIDE_TAGS='true'
+  local P9K_VCS_CLOBBERED_FOLDER_ICON="clob"
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   echo "xxx" > xxx.txt
   git add . 1>/dev/null
@@ -485,7 +489,7 @@ function testGitDirClobber() {
   # so for git this is a repo inside another repo.
   cd vcs-test2
 
-  assertEquals "%K{001} %F{000}✘ /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}✘ clob /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   unset GIT_DIR

--- a/test/segments/vcs_hg.spec
+++ b/test/segments/vcs_hg.spec
@@ -192,7 +192,7 @@ function testMercurialIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs.p9k
 
-  assertEquals "%K{002} %F{000}HG-icon %f%F{000} default %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}HG-icon%f %F{000} default %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBookmarkIconWorks() {


### PR DESCRIPTION
Hi, this may look like a big change but it's really two files, the rest rest are minor adjustments to the test cases.

I wanted to achieve this look, so I added ability to specify symbols for left and right edges of prompts instead of default whitespace with square bg. I could've added it to first line prefix but then it wouldn't be colored.

![screen shot 2018-11-17 at 7 50 59 pm](https://user-images.githubusercontent.com/5442968/48664129-d4c3bf80-eaa2-11e8-9391-fc913ba7fcb9.png)

While playing with style symbols I realized that I needed to control right and left whitespace of segments separately, so I added ws control for all cases, left/right prompt, left/right side of default or custom segment, and a middle one between the icon and the content.
Using some symbols adds too much space, but removing ws altogether makes it to cramped or overlapped. 

![screen shot 2018-11-17 at 8 15 41 pm](https://user-images.githubusercontent.com/5442968/48664363-38032100-eaa6-11e8-8186-edab384ac636.png)
![screen shot 2018-11-17 at 8 15 53 pm](https://user-images.githubusercontent.com/5442968/48664369-3df90200-eaa6-11e8-913c-6e1ae6732145.png)
![screen shot 2018-11-17 at 8 16 26 pm](https://user-images.githubusercontent.com/5442968/48664371-40f3f280-eaa6-11e8-9493-5a8a041d0fbe.png)
![screen shot 2018-11-17 at 8 16 35 pm](https://user-images.githubusercontent.com/5442968/48664372-43564c80-eaa6-11e8-9515-e8998e95d5cc.png)

Here is an example of the left prompt where ws present only on the left (except first seg) and in the middle.

![screen shot 2018-11-17 at 7 52 09 pm](https://user-images.githubusercontent.com/5442968/48664227-333d6d80-eaa4-11e8-9370-3bd285dba1d2.png)
![screen shot 2018-11-17 at 8 09 31 pm](https://user-images.githubusercontent.com/5442968/48664271-b8288700-eaa4-11e8-96a2-9004c2da3244.png)

Looks more compact and cleaner. No extra whitespace and no icon overlapping. And now it is 
 possible to remove whitespace between the icon and the content. Works in single and multi line mode, and there's more ways to mix and match styles now. You can make right prompt more compact to be more out of the way.

![screen shot 2018-11-17 at 9 08 25 pm](https://user-images.githubusercontent.com/5442968/48664809-2a9d6500-eaad-11e8-975d-7a6e3c6b9ef9.png)

In total I've added three new methods to utilities.zsh and modified/refactored three methods in default.p9k. The rest of changes files are new specs and fixes to existing specs where color codes and whitespace just moved around a bit, no structural changes. I covered all new utilities and functionality with test cases.

Short summary:
- refactored variables a bit to make sure that variables that do not have visible content stay empty (do not include escape codes)
- added utility for finding defined value to make it possible to easily specify variable override order
- added custom left symbol for first segment of PROMPT (with custom ws) and same for last segment of RPROMPT
- wrapped parts in isolated vars, allowed me to remove some extra if cases, make code more compact
- added whitespace controll for each segment for left, right and middle

Everything is optional and doesn't change anything if vars are not defined.

Examples of the new config variables can be seen in `test/core/prompt.spec`.

All tests are passing locally. Docker didn't work for me, after starting it I try to enter into `p9k` dir and it just hogs cpu and hangs. TravisCI passed all test except for zsh v5.2 and lower there was one error in git test of extra whitespace before the dir path. [travis report](https://travis-ci.org/n1kk/powerlevel9k/builds/456391244)
```
testGitDirClobber
ASSERT:expected:<%K{001} %F{000}✘ /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f > but was:<%K{001} %F{000}✘  /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f >
```

Hope this is a nice addition to customization control and stylizing.

I can write some docs for this, I just need to know where exactly to do it.
