### PR TITLE
[Bugfix] Update VIRTUAL_ENV_DISABLE_PROMPT value

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1648,7 +1648,7 @@ prompt_vi_mode() {
 # https://virtualenv.pypa.io/en/latest/
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n "$virtualenv_path" && "$VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
+  if [[ -n "$virtualenv_path" && -z "$VIRTUAL_ENV_DISABLE_PROMPT" ]]; then
     "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$(basename "$virtualenv_path")" 'PYTHON_ICON'
   fi
 }


### PR DESCRIPTION
Following a prezto update, the flag value of the VIRTUAL_ENV_DISABLE_PROMPT variable is now 12 (https://github.com/sorin-ionescu/prezto/blob/e9387a177e04b05dcf4f82e622615ddd32c558db/modules/python/init.zsh#L103).