### PR TITLE
[Bugfix] Ad hoc fix for `no matches found`

### DIFF
--- a/functions/autoload/__p9k_get_unique_path
+++ b/functions/autoload/__p9k_get_unique_path
@@ -28,7 +28,7 @@ for directory in ${paths[@]}; do
   test_dir=''
   for (( i=0; i < ${#directory}; i++ )); do
     test_dir+="${directory:$i:1}"
-    matching=("$cur_path"/"$test_dir"*/)
+    matching=("$cur_path"/"$test_dir"*/(N))
     if [[ ${#matching[@]} -eq 1 ]]; then
       break
     fi


### PR DESCRIPTION
This ignores `no matches found` error for handling decomposed UTF-8 encoding for non-ASCII character handling in macOS, by applying nullglob when matching directories.
Although this is does not _completely_ resolve the issue, it gracefully fails and simply show the full path for the directory with encoding problem—thus an ad hoc fix. 

Fixes #1067 