### PR TITLE
Fix error if git dir contains special characters

### DIFF
--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -136,7 +136,7 @@ function +vi-git-untracked() {
   # dump out if we're outside a git repository (which includes being in the .git folder)
   [[ $? != 0 || -z $repoTopLevel ]] && return
 
-  local untrackedFiles=$(command git ls-files --others --exclude-standard "${repoTopLevel}")
+  local untrackedFiles=$(command git ls-files --others --exclude-standard "'${repoTopLevel}'")
 
   if [[ -z $untrackedFiles && "$P9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" ]]; then
     untrackedFiles+=$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')


### PR DESCRIPTION
This fixes #1067 .
Directories with special characters in it need to be passed with quotes to `git rev-parse --show-toplevel`. 