### PR TITLE
[Enhancement] A setting to hide stashed changes count for git

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ customization is provided via:
 |`P9K_VCS_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
 |`P9K_VCS_SHOW_SUBMODULE_DIRTY`|`true`|Set to `false` to not reflect submodule status in the top-level repository prompt.|
 |`P9K_VCS_HIDE_TAGS`|`false`|Set to `true` to stop tags being displayed in the segment.|
+|`P9K_VCS_HIDE_STASHES`|`false`|Set to `true` to stop count of stashed changes being displayed in the segment.|
 |`P9K_VCS_GIT_HOOKS`|`(vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)`|Layout of the segment for git repositories.|
 |`P9K_VCS_HG_HOOKS`|`(vcs-detect-changes)`|Layout of the segment for Mercurial repositories.|
 |`P9K_VCS_SVN_HOOKS`|`(vcs-detect-changes svn-detect-changes)`|Layout of the segment for SVN repositories.|

--- a/segments/vcs.p9k
+++ b/segments/vcs.p9k
@@ -122,6 +122,7 @@
   # Register segment default values
   p9k::set_default P9K_VCS_ACTIONFORMAT_FOREGROUND "red"
   p9k::set_default P9K_VCS_HIDE_TAGS false
+  p9k::set_default P9K_VCS_HIDE_STASHES false
   p9k::set_default P9K_VCS_INTERNAL_HASH_LENGTH "8" # Default: Just display the first 8 characters of our changeset-ID.
   p9k::set_default P9K_VCS_DIR_SHORTEN_DELIMITER $'\U2026'
   p9k::set_default P9K_VCS_SHOW_SUBMODULE_DIRTY true
@@ -249,12 +250,15 @@ function +vi-git-tagname() {
   fi
 }
 
+p9k::set_default P9K_VCS_HIDE_STASHES false
 # Show count of stashed changes
 # Port from https://github.com/whiteinge/dotfiles/blob/5dfd08d30f7f2749cfc60bc55564c6ea239624d9/.zsh_shouse_prompt#L268
 function +vi-git-stash() {
-  if [[ -s "${vcs_comm[gitdir]}/logs/refs/stash" ]] ; then
-    local -a stashes=( "${(@f)"$(<${vcs_comm[gitdir]}/logs/refs/stash)"}" )
-    hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${#stashes}"
+  if [[ "$P9K_VCS_HIDE_STASHES" == "false" ]]; then
+    if [[ -s "${vcs_comm[gitdir]}/logs/refs/stash" ]] ; then
+      local -a stashes=( "${(@f)"$(<${vcs_comm[gitdir]}/logs/refs/stash)"}" )
+      hook_com[misc]+=" ${__P9K_ICONS[VCS_STASH]}${#stashes}"
+    fi
   fi
 }
 


### PR DESCRIPTION
#### Description
Added a setting `P9K_VCS_HIDE_STASHES` that allows to hide git stashed changes count.
Its default value is `false`.

Here is how status without stashed changes count looks like:
![image](https://user-images.githubusercontent.com/3943804/49683377-cfbbc400-fad4-11e8-8274-b1365ca0e963.png)


