### PR TITLE
Get rid of absolute versions for Dockerfiles

### DIFF
--- a/docker/base-4.3.11/Dockerfile
+++ b/docker/base-4.3.11/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   yum install -y \
   curl \
   git \
-  zsh \
+  zsh-4.3.11 \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.0.3/Dockerfile
+++ b/docker/base-5.0.3/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:14.04
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.0.2-3ubuntu6.3 \
+  zsh=5.0.2-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.1.1/Dockerfile
+++ b/docker/base-5.1.1/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:16.04
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.1.1-1ubuntu2.3 \
+  zsh=5.1.1-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.2/Dockerfile
+++ b/docker/base-5.2/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:17.10
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.2-5ubuntu1.2 \
+  zsh=5.2-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.3.1/Dockerfile
+++ b/docker/base-5.3.1/Dockerfile
@@ -3,12 +3,12 @@ FROM debian:stretch
 # We switched here to debian, as there seems no ZSH 5.3 in ubuntu.
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.3.1-4+b2 \
+  zsh=5.3.1-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.4.2/Dockerfile
+++ b/docker/base-5.4.2/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:18.04
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.4.2-3ubuntu3.1 \
+  zsh=5.4.2-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.5.1/Dockerfile
+++ b/docker/base-5.5.1/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:18.10
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.5.1-1ubuntu2 \
+  zsh=5.5.1-* \
   mercurial \
   subversion \
   golang \

--- a/docker/base-5.6.2/Dockerfile
+++ b/docker/base-5.6.2/Dockerfile
@@ -3,12 +3,12 @@ FROM debian:buster
 # We switched here to debian, as there seems no ZSH 5.6 in ubuntu.
 
 RUN \
-  apt-get update && \
+  apt update && \
   echo 'golang-go golang-go/dashboard boolean false' | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
   curl \
   git \
-  zsh=5.6.2-3 \
+  zsh=5.6.2-* \
   mercurial \
   subversion \
   golang \


### PR DESCRIPTION
The Dockerfiles break regularly because of distros releasing patches for ZSH and it seems to be impossible to install a fuzzy version of ZSH (like 5.6.2-*) with `apt-get`. This PR switches to `apt` that has that ability.

//cc @Syphdias