### PR TITLE
[Bugfix] allow set -u to be used

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -314,7 +314,7 @@ function __p9k_build_left_prompt() {
 # @noargs
 ##
 function __p9k_build_right_prompt() {
-  [[ ${P9K_RIGHT_PROMPT_ELEMENTS[1]} == "" ]] && return
+  [[ ${P9K_RIGHT_PROMPT_ELEMENTS[1]:-} == "" ]] && return
   local index=1
   local element joined
   for element in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
@@ -386,7 +386,7 @@ function __p9k_prepare_prompts() {
 
   local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
 
-  if [[ "$P9K_PROMPT_ON_NEWLINE" == true ]]; then
+  if [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]]; then
     __p9k_unsafe_PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
 ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
     if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
@@ -407,19 +407,19 @@ ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
     RPROMPT_SUFFIX=''
   fi
 
-  if [[ "$P9K_DISABLE_RPROMPT" != true ]]; then
+  if [[ "${P9K_DISABLE_RPROMPT:-}" != true ]]; then
     __p9k_unsafe_RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{${reset_color}%}${RPROMPT_SUFFIX}"
     RPROMPT='$__p9k_unsafe_RPROMPT'
   fi
 
   # Allow iTerm integration to work
-  [[ ${ITERM_SHELL_INTEGRATION_INSTALLED} == "Yes" ]] \
+  [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]] \
     && __p9k_unsafe_PROMPT="%{$(iterm2_prompt_mark)%}$__p9k_unsafe_PROMPT"
 
 local NEWLINE='
 '
 
-  if [[ $P9K_PROMPT_ADD_NEWLINE == true ]]; then
+  if [[ "${P9K_PROMPT_ADD_NEWLINE:-}" == true ]]; then
     NEWLINES=""
     repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
     __p9k_unsafe_PROMPT="$NEWLINES$__p9k_unsafe_PROMPT"

--- a/segments/context/context.p9k
+++ b/segments/context/context.p9k
@@ -42,7 +42,7 @@ prompt_context() {
   local content=""
   local me=$(whoami)
 
-  if [[ "$P9K_CONTEXT_ALWAYS_SHOW" == true ]] || [[ "${me}" != "$DEFAULT_USER" ]] || [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
+  if [[ "${P9K_CONTEXT_ALWAYS_SHOW:-}" == true ]] || [[ "${me}" != "${DEFAULT_USER:-}" ]] || [[ -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" ]]; then
     content="${P9K_CONTEXT_TEMPLATE}"
   elif [[ "$P9K_CONTEXT_ALWAYS_SHOW_USER" == true ]]; then
     content="${me}"
@@ -52,13 +52,13 @@ prompt_context() {
 
   if [[ $(print -P "%#") == '#' ]]; then
     current_state="ROOT"
-  elif [[ -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
-    if [[ -n "$SUDO_COMMAND" ]]; then
+  elif [[ -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" ]]; then
+    if [[ -n "${SUDO_COMMAND:-}" ]]; then
       current_state="REMOTE_SUDO"
     else
       current_state="REMOTE"
     fi
-  elif [[ -n "$SUDO_COMMAND" ]]; then
+  elif [[ -n "${SUDO_COMMAND:-}" ]]; then
     current_state="SUDO"
   fi
 

--- a/segments/newline/newline.p9k
+++ b/segments/newline/newline.p9k
@@ -20,7 +20,7 @@ prompt_newline() {
   [[ "$1" == "right" ]] && return
 
   local newline=$'\n'
-  [[ "$P9K_PROMPT_ON_NEWLINE" == true ]] \
+  [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]] \
       && newline="${newline}${__P9K_ICONS[MULTILINE_NEWLINE_PROMPT_PREFIX]}"
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "[[ true ]]" "" "%k"

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -18,6 +18,12 @@ function setUp() {
   # do not interfere with tests
 }
 
+function testUsingUnsetVariables() {
+  setopt local_options
+  set -u
+  __p9k_prepare_prompts
+}
+
 function testJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local P9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)


### PR DESCRIPTION
The surface functions and `if` cases may be called by a script, which means they should work even with `set -u`set.