### PR TITLE
[New Segment] - Add environment segment

### DIFF
--- a/.test.zshrc
+++ b/.test.zshrc
@@ -1,3 +1,0 @@
-#source /Users/alex/workspace/powerlevel9k@new-environment/powerlevel9k.zsh-theme
-source /Users/alex/workspace/powerlevel9k/powerlevel9k.zsh-theme
-

--- a/.test.zshrc
+++ b/.test.zshrc
@@ -1,0 +1,3 @@
+#source /Users/alex/workspace/powerlevel9k@new-environment/powerlevel9k.zsh-theme
+source /Users/alex/workspace/powerlevel9k/powerlevel9k.zsh-theme
+

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The segments that are currently available are:
 * [`user`](#user) - Your current username
 * [`vi_mode`](#vi_mode)- Your prompt's Vi editing mode (NORMAL|INSERT).
 * `ssh` - Indicates whether or not you are in an SSH session.
+* [`environment`](#environment)- Your environment from hostname.
 
 **Development Environment Segments:**
 * [`vcs`](#vcs) - Information about this `git` or `hg` repository (if you are in one).
@@ -475,6 +476,43 @@ The `disk_usage` segment will show the usage level of the partition that your cu
 |P9K_DISK_USAGE_WARNING_LEVEL|90|The usage level that triggers a warning state.|
 |P9K_DISK_USAGE_CRITICAL_LEVEL|95|The usage level that triggers a critical state.|
 |P9K_DISK_USAGE_PATH|`.` (working directory)|Set a path to use a fixed directory instead of the working 
+
+##### environment
+
+The `environment` segment will print the environment from hostname.
+
+This segment has four configurable work environments that are obtained by looking at the hostname and taking the value after the first point. In case of obtaining not contemplated a special environment is assigned
+
+This segment can have different states. They might help you to visualize your
+different environments. Read more about styling with states [here](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#special-segment-colors).
+
+| State         | Meaning                                                   |
+|---------------|-----------------------------------------------------------|
+| `LOCAL`       | Local work environment                                    |
+| `DEV`         | Work environment development on a server                  |
+| `TEST`        | Work environment of testing on a server                   |
+| `PROD`        | Production environment on a server                        |
+| `OTHER`       | Non-controlled work environment, default value            |
+
+Each of the states is identified with a key. The key is compared to the environment obtained from the hostname and in this way the state is obtained. 
+`P9K_<name-of-segment>_KEY_<state> == $ENVIRONMENT` 
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|P9K_ENVIRONMENT_KEY_LOCAL  |local  |key of the local environment|
+|P9K_ENVIRONMENT_KEY_DEV    |dev    |key of the development environment|
+|P9K_ENVIRONMENT_KEY_TEST   |test   |key of the testing environment|
+|P9K_ENVIRONMENT_KEY_PROD   |prod   |key of the production environment|
+
+Each of the states shows a text that is obtained from the variable `P9K_ <name-of-segment> _VALUE_ <state>` of each segment.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|P9K_ENVIRONMENT_VALUE_LOCAL|Local|Value of the local environment|
+|P9K_ENVIRONMENT_VALUE_DEV  |Dev|Value of the development environment|
+|P9K_ENVIRONMENT_VALUE_TEST |Test|Value of the testing environment|
+|P9K_ENVIRONMENT_VALUE_PROD |Prod|Value of the production environment|
+|P9K_ENVIRONMENT_VALUE_OTHER|Other|Value of the other environment|
 
 ##### host
 

--- a/segments/environment.p9k
+++ b/segments/environment.p9k
@@ -33,6 +33,7 @@
   p9k::set_default P9K_ENVIRONMENT_VALUE_DEV "Dev"
   p9k::set_default P9K_ENVIRONMENT_VALUE_TEST "Test"
   p9k::set_default P9K_ENVIRONMENT_VALUE_PROD "Prod"
+  p9k::set_default P9K_ENVIRONMENT_VALUE_OTHER "Other"
 }
 
 ################################################################
@@ -44,14 +45,32 @@
 #   $2 integer Segment index
 #   $3 boolean Whether the segment should be joined
 # @note
-#   If ${DEFAULT_USER} is not set, this prompt segment will always print.
+#   You get the information of 'hostname'.
 ##
 prompt_environment() {
-    echo "hola"
-    local alias = "POWERLEVEL9K_ENVIRONMENT_VALUE_"
-    local current_state="LOCAL"
-    local content=${alias}${current_state}
-    local environment=$(hostname -d)
+    local default='other'
+    local alias="P9K_ENVIRONMENT_VALUE_"
+    local environment=${default}
 
-    p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${content}"
+    if [[ "$__P9K_OS" == "OSX" ]]; then
+      environment=$(hostname -f | sed -e 's/^[^.]*\.//')
+    else
+      environment=$(hostname -d)
+    fi
+
+    if [[ "$P9K_ENVIRONMENT_KEY_LOCAL" == "$environment" ]]; then
+      current_state="LOCAL"
+    elif [[ "$P9K_ENVIRONMENT_KEY_DEV" == "$environment" ]]; then
+      current_state="DEV"
+    elif [[ "$P9K_ENVIRONMENT_KEY_TEST" == "$environment" ]]; then
+      current_state="TEST"
+    elif [[ "$P9K_ENVIRONMENT_KEY_PROD" == "$environment" ]]; then
+      current_state="PROD"
+    else
+      current_state=${default:u}
+    fi
+
+    local content=${alias}${current_state:u}
+
+    p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${(P)content}"
 }

--- a/segments/environment.p9k
+++ b/segments/environment.p9k
@@ -12,13 +12,13 @@
   # Parameters:
   #                     segment_name  context   background      foreground          Generic     Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
   #                                                                                                                          
-  p9k::register_segment "ENVIRONMENT" "LOCAL"   "mediumorchid"  "${DEFAULT_COLOR}"  $'\uF108'   $'\uF108'   $'\uF108'   $'\uF108'  $'\uF108'
+  p9k::register_segment "ENVIRONMENT" "LOCAL"   "skyblue3"  "${DEFAULT_COLOR}"  $'\uF108'   $'\uF108'   $'\uF108'   $'\uF108'  $'\uF108'
   #                                                                                                                         
-  p9k::register_segment "ENVIRONMENT" "DEV"     "darkgreen"     "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  p9k::register_segment "ENVIRONMENT" "DEV"     "chartreuse3"     "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
   #                                                                                                                         
-  p9k::register_segment "ENVIRONMENT" "TEST"    "darkorange"    "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  p9k::register_segment "ENVIRONMENT" "TEST"    "orange3"    "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
   #                                                                                                                         
-  p9k::register_segment "ENVIRONMENT" "PROD"    "red3"          "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  p9k::register_segment "ENVIRONMENT" "PROD"    "red1"          "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
   #                                                                                                                         
   p9k::register_segment "ENVIRONMENT" "OTHER"   "indianred1"    "${DEFAULT_COLOR}"  $'\uF0C2'   $'\uF0C2'   $'\uF0C2'   $'\uF0C2'  $'\uF0C2'
 

--- a/segments/environment.p9k
+++ b/segments/environment.p9k
@@ -1,0 +1,57 @@
+# vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+################################################################
+# @title powerlevel9k Segment - Environment
+# @source [powerlevel9k](https://github.com/alexperegrina/powerlevel9k)
+##
+
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #                     segment_name  context   background      foreground          Generic     Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                          
+  p9k::register_segment "ENVIRONMENT" "LOCAL"   "mediumorchid"  "${DEFAULT_COLOR}"  $'\uF108'   $'\uF108'   $'\uF108'   $'\uF108'  $'\uF108'
+  #                                                                                                                         
+  p9k::register_segment "ENVIRONMENT" "DEV"     "darkgreen"     "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  #                                                                                                                         
+  p9k::register_segment "ENVIRONMENT" "TEST"    "darkorange"    "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  #                                                                                                                         
+  p9k::register_segment "ENVIRONMENT" "PROD"    "red3"          "${DEFAULT_COLOR}"  $'\uF233'   $'\uF233'   $'\uF233'   $'\uF233'  $'\uF233'
+  #                                                                                                                         
+  p9k::register_segment "ENVIRONMENT" "OTHER"   "indianred1"    "${DEFAULT_COLOR}"  $'\uF0C2'   $'\uF0C2'   $'\uF0C2'   $'\uF0C2'  $'\uF0C2'
+
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_ENVIRONMENT_KEY_LOCAL "local"
+  p9k::set_default P9K_ENVIRONMENT_KEY_DEV "dev"
+  p9k::set_default P9K_ENVIRONMENT_KEY_TEST "test"
+  p9k::set_default P9K_ENVIRONMENT_KEY_PROD "prod"
+
+  p9k::set_default P9K_ENVIRONMENT_VALUE_LOCAL "Local"
+  p9k::set_default P9K_ENVIRONMENT_VALUE_DEV "Dev"
+  p9k::set_default P9K_ENVIRONMENT_VALUE_TEST "Test"
+  p9k::set_default P9K_ENVIRONMENT_VALUE_PROD "Prod"
+}
+
+################################################################
+# @description
+#   Display environment from hostname.
+##
+# @args
+#   $1 string Alignment - left | right
+#   $2 integer Segment index
+#   $3 boolean Whether the segment should be joined
+# @note
+#   If ${DEFAULT_USER} is not set, this prompt segment will always print.
+##
+prompt_environment() {
+    echo "hola"
+    local alias = "POWERLEVEL9K_ENVIRONMENT_VALUE_"
+    local current_state="LOCAL"
+    local content=${alias}${current_state}
+    local environment=$(hostname -d)
+
+    p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${content}"
+}

--- a/test/segments/environment.spec
+++ b/test/segments/environment.spec
@@ -1,0 +1,488 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+  source segments/environment.p9k
+}
+
+# ================================ #
+# ============ MOCKS ============= #
+# ================================ #
+
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+#   $2 integer custom, custom=1 -> is custom, custom=0 -> default
+function mockHostname() {
+    local ret='fake'
+
+    case "$1" in
+    'local')
+        if [[ $2 == 1 ]]; then
+            ret='house'
+        else
+            ret='local'
+        fi
+    ;;
+    'dev')
+        if [[ $2 == 1 ]]; then
+            ret='develop'
+        else
+            ret='dev'
+        fi
+    ;;
+    'test')
+        if [[ $2 == 1 ]]; then
+            ret='testing'
+        else
+            ret='test'
+        fi
+    ;;
+    'prod')
+        if [[ $2 == 1 ]]; then
+            ret='production'
+        else
+            ret='prod'
+        fi
+    ;;
+    'other')
+        ret='fake'
+    ;;
+    esac
+
+    echo $ret
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+#   $2 integer custom, custom=1 -> is custom, custom=0 -> default
+function mockHostnameCommand() {
+    local env="$1"
+    local custom=$2
+    local ret='func() {
+      local ret='$(mockHostname "$env" $custom)';
+      local alias="test";
+      [[ "$1" == "-t" ]] && ret=$alias.$ret;
+      echo $ret;
+    }; func'
+
+    echo $ret
+}
+
+# ================================ #
+# ========== FUNCTIONS =========== #
+# ================================ #
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+#   $2 integer custom, custom=1 -> is custom, custom=0 -> default
+function getKey() {
+    local ret='other'
+
+    case "$1" in
+    'local')
+        if [[ $2 == 1 ]]; then
+            ret='house'
+        else
+            ret='local'
+        fi
+    ;;
+    'dev')
+        if [[ $2 == 1 ]]; then
+            ret='develop'
+        else
+            ret='dev'
+        fi
+    ;;
+    'test')
+        if [[ $2 == 1 ]]; then
+            ret='testing'
+        else
+            ret='test'
+        fi
+    ;;
+    'prod')
+        if [[ $2 == 1 ]]; then
+            ret='production'
+        else
+            ret='prod'
+        fi
+    ;;
+    'other')
+        ret='other'
+    ;;
+    esac
+
+    echo $ret
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+#   $2 integer custom, custom=1 -> is custom, custom=0 -> default
+function getValue() {
+    local ret='other'
+
+    case "$1" in
+    'local')
+        if [[ $2 == 1 ]]; then
+            ret='House'
+        else
+            ret='Local'
+        fi
+    ;;
+    'dev')
+        if [[ $2 == 1 ]]; then
+            ret='Develop'
+        else
+            ret='Dev'
+        fi
+    ;;
+    'test')
+        if [[ $2 == 1 ]]; then
+            ret='Testing'
+        else
+            ret='Test'
+        fi
+    ;;
+    'prod')
+        if [[ $2 == 1 ]]; then
+            ret='Production'
+        else
+            ret='Prod'
+        fi
+    ;;
+    'other')
+        if [[ $2 == 1 ]]; then
+            ret='Fake'
+        else
+            ret='Other'
+        fi
+    ;;
+    esac
+
+    echo $ret
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+function getColorBackground() {
+    case "$1" in
+    'local')
+        echo '074'
+    ;;
+    'dev')
+        echo '070'
+    ;;
+    'test')
+        echo '172'
+    ;;
+    'prod')
+        echo '196'
+    ;;
+    'other')
+        echo '203'
+    ;;
+    esac
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+function getColorForeground() {
+    case "$1" in
+    'local')
+        echo '000'
+    ;;
+    'dev')
+        echo '000'
+    ;;
+    'test')
+        echo '000'
+    ;;
+    'prod')
+        echo '000'
+    ;;
+    'other')
+        echo '000'
+    ;;
+    esac
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+function getIcon() {
+    case "$1" in
+    'local')
+        echo ''
+    ;;
+    'dev')
+        echo ''
+    ;;
+    'test')
+        echo ''
+    ;;
+    'prod')
+        echo ''
+    ;;
+    'other')
+        echo ''
+    ;;
+    esac
+}
+
+# @args
+#   $1 string environment {local, dev, test, prod, other}
+#   $2 integer custom, custom=1 -> is custom, custom=0 -> default
+function getPrompAssert() {
+  local env="$1"
+  local custom=$2
+  local background=$(getColorBackground $env)
+  local foreground=$(getColorForeground $env)
+  local icon=$(getIcon $env)
+  local value=$(getValue $env $custom)
+
+  local ret="%K{$background} %F{$foreground}$icon%f %F{$foreground}$value %k%F{$background}%f "
+
+  echo $ret
+}
+
+# ================================ #
+# ========= TEST DEFAULT ========= #
+# ================================ #
+
+function testDefaultLocalCase() {
+  local env="local"
+  local custom=0
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testDefaultDevCase() {
+  local env="dev"
+  local custom=0
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testDefaultTestCase() {
+  local env="test"
+  local custom=0
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testDefaultProdCase() {
+  local env="prod"
+  local custom=0
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+}
+
+function testDefaultOtherCase() {
+  local env="other"
+  local custom=0
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+}
+
+# ================================ #
+# ========= TEST CUSTOM ========== #
+# ================================ #
+
+function testCustomLocalCase() {
+  local env="local"
+  local custom=1
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  eval P9K_ENVIRONMENT_KEY_${env:u}=$(getKey $env $custom)
+  eval P9K_ENVIRONMENT_VALUE_${env:u}=$(getValue $env $custom)
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+  unset P9K_ENVIRONMENT_KEY_${env:u}
+  unset P9K_ENVIRONMENT_VALUE_${env:u}
+}
+
+function testCustomDevCase() {
+  local env="dev"
+  local custom=1
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  eval P9K_ENVIRONMENT_KEY_${env:u}=$(getKey $env $custom)
+  eval P9K_ENVIRONMENT_VALUE_${env:u}=$(getValue $env $custom)
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+  unset P9K_ENVIRONMENT_KEY_${env:u}
+  unset P9K_ENVIRONMENT_VALUE_${env:u}
+}
+
+function testCustomTestCase() {
+  local env="test"
+  local custom=1
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  eval P9K_ENVIRONMENT_KEY_${env:u}=$(getKey $env $custom)
+  eval P9K_ENVIRONMENT_VALUE_${env:u}=$(getValue $env $custom)
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+  unset P9K_ENVIRONMENT_KEY_${env:u}
+  unset P9K_ENVIRONMENT_VALUE_${env:u}
+}
+
+function testCustomProdCase() {
+  local env="prod"
+  local custom=1
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  eval P9K_ENVIRONMENT_KEY_${env:u}=$(getKey $env $custom)
+  eval P9K_ENVIRONMENT_VALUE_${env:u}=$(getValue $env $custom)
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+  unset P9K_ENVIRONMENT_KEY_${env:u}
+  unset P9K_ENVIRONMENT_VALUE_${env:u}
+}
+
+function testCustomOtherCase() {
+  local env="other"
+  local custom=1
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  local promptAssert=$(getPrompAssert $env $custom)
+
+  alias hostname="$(mockHostnameCommand $env $custom)"
+
+  eval P9K_ENVIRONMENT_KEY_${env:u}=$(getKey $env $custom)
+  eval P9K_ENVIRONMENT_VALUE_${env:u}=$(getValue $env $custom)
+
+  P9K_LEFT_PROMPT_ELEMENTS=(environment)
+
+  local __P9K_OS="Linux" # Fake Linux
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  local __P9K_OS="OSX" # Fake OSX
+  assertEquals "$promptAssert " "$(__p9k_build_left_prompt)"
+
+  unalias hostname
+  unset P9K_LEFT_PROMPT_ELEMENTS
+  unset P9K_ENVIRONMENT_KEY_${env:u}
+  unset P9K_ENVIRONMENT_VALUE_${env:u}
+}
+
+source shunit2/shunit2


### PR DESCRIPTION
#### Description
The `environment` segment will print the environment from hostname.

This segment has four configurable work environments that are obtained by looking at the hostname and taking the value after the first point. In case of obtaining not contemplated a special environment is assigned

Each of the states is identified with a key. The key is compared to the environment obtained from the hostname and in this way the state is obtained. 
`P9K_<name-of-segment>_KEY_<state> == $ENVIRONMENT`

Each of the states shows a text that is obtained from the variable `P9K_ <name-of-segment> _VALUE_ <state>` of each segment.

#### Screenshot
##### Local
![image](https://user-images.githubusercontent.com/5008031/51191527-e11e9a00-18e4-11e9-92f0-0ae8ba664762.png)

##### Dev
![image](https://user-images.githubusercontent.com/5008031/51191593-04e1e000-18e5-11e9-87fd-3e64efdb5a68.png)

##### Test
![image](https://user-images.githubusercontent.com/5008031/51191653-25aa3580-18e5-11e9-8dff-73fc20497165.png)

##### Prod
![image](https://user-images.githubusercontent.com/5008031/51191692-3bb7f600-18e5-11e9-822d-d8d6262d06b5.png)

##### Other
![image](https://user-images.githubusercontent.com/5008031/51191747-5be7b500-18e5-11e9-823c-4374f0e876ca.png)