### PR TITLE
Remove checking for NODEENV_DISABLE_PROMPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The segments that are currently available are:
     * `go_version` - Show the current GO version.
 * **Javascript / Node.js Segments:**
     * `node_version` - Show the version number of the installed Node.js.
-    * `nodeenv` - [nodeenv](https://github.com/ekalinin/nodeenv) prompt for displaying node version and environment name.
+    * [`nodeenv`](#nodeenv) - [nodeenv](https://github.com/ekalinin/nodeenv) prompt for displaying node version and environment name.
     * `nvm` - Show the version of Node that is currently active, if it differs from the version used by NVM
 * **PHP Segments:**
     * `php_version` - Show the current PHP version.
@@ -556,6 +556,12 @@ line. This allows you to use segments on both lines, unlike
 prompt itself.
 
 This only works on the left side.  On the right side it does nothing.
+
+##### nodeenv
+
+Shows the currently used [nodeenv](https://github.com/ekalinin/nodeenv). To avoid
+Nodeenvs activate command from interfering with Powerlevel9k, you should set
+`NODE_VIRTUAL_ENV_DISABLE_PROMPT=1` in your `~/.zshrc`.
 
 ##### rbenv
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1238,9 +1238,8 @@ prompt_nvm() {
 ################################################################
 # Segment to display NodeEnv
 prompt_nodeenv() {
-  local nodeenv_path="$NODE_VIRTUAL_ENV"
-  if [[ -n "$nodeenv_path" && "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
-    local info="$(node -v)[$(basename "$nodeenv_path")]"
+  if [[ -n "$NODE_VIRTUAL_ENV" ]]; then
+    local info="$(node -v)[${NODE_VIRTUAL_ENV:t}]"
     "$1_prompt_segment" "$0" "$2" "black" "green" "$info" 'NODE_ICON'
   fi
 }

--- a/test/segments/nodeenv.spec
+++ b/test/segments/nodeenv.spec
@@ -44,26 +44,6 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
     unfunction node
 }
 
-function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvDisablePromptIsSet() {
-    local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
-    local POWERLEVEL9K_CUSTOM_WORLD='echo world'
-    node() {
-        echo "v1.2.3"
-    }
-    NODE_VIRTUAL_ENV="node-env"
-    NODE_VIRTUAL_ENV_DISABLE_PROMPT=true
-
-    # Load Powerlevel9k
-    source powerlevel9k.zsh-theme
-
-    assertEquals "%K{007} %F{000}world %k%F{007}%f " "$(build_left_prompt)"
-
-    unset NODE_VIRTUAL_ENV_DISABLE_PROMPT
-    unset NODE_VIRTUAL_ENV
-    unfunction node
-}
-
 function testNodeenvSegmentPrintsAtLeastNodeEnvWithoutNode() {
     local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
     POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(nodeenv)


### PR DESCRIPTION
`NODEENV_DISABLE_PROMPT` is not meant for us. This is similar to #1128 , where we did a similar thing for virtualenv.