### PR TITLE
[Bugfix] Only abbreviate $HOME at the beginning of cwd

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -797,7 +797,7 @@ prompt_dir() {
   # using $PWD instead of "$(print -P '%~')" to allow use of POWERLEVEL9K_DIR_PATH_ABSOLUTE
   local current_path=$PWD # WAS: local current_path="$(print -P '%~')"
   # check if the user wants to use absolute paths or "~" paths
-  [[ ${(L)POWERLEVEL9K_DIR_PATH_ABSOLUTE} != "true" ]] && current_path=${current_path//$HOME/"~"}
+  [[ ${(L)POWERLEVEL9K_DIR_PATH_ABSOLUTE} != "true" ]] && current_path=${current_path/#$HOME/"~"}
   # declare all local variables
   local paths directory test_dir test_dir_length trunc_path threshhold
   # if we are not in "~" or "/", split the paths into an array and exclude "~"

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -768,4 +768,22 @@ function testDirSeparatorColorRootSubSubdirWorks() {
   rm -fr /tmp/powerlevel9k-test
 }
 
+function testDirHomeTruncationWorksOnlyAtTheBeginning() {
+  local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+
+  local FOLDER=/tmp/p9ktest
+  local SAVED_HOME="${HOME}"
+  HOME="/p9ktest"
+
+  mkdir -p $FOLDER
+  # Setup folder marker
+  cd $FOLDER
+  assertEquals "%K{004} %F{000}/tmp/p9ktest %k%F{004}%f " "$(build_left_prompt)"
+
+  cd -
+  rm -fr $FOLDER
+  HOME="${SAVED_HOME}"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
#### Description

As requested in #1150.