### PR TITLE
Fix PHP icon

### DIFF
--- a/segments/php_version/php_version.p9k
+++ b/segments/php_version/php_version.p9k
@@ -11,8 +11,8 @@
   # Register segment
   # Parameters:
   #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
-  #                                                                                              
-  p9k::register_segment "PHP_VERSION" "" "fuchsia" "grey93"  'PHP'  $'\uF457'  $'\uF457'  $'\uF457'  $'\uE73D'
+  #                                                                                           
+  p9k::register_segment "PHP_VERSION" "" "fuchsia" "grey93"  'PHP'  'PHP'  $'\uE63D'  "${CODEPOINT_OF_DEVICONS_PHP}"  $'\uE73D'
 }
 
 ################################################################


### PR DESCRIPTION
This is a quick PR to fix #1152 . Thanks to @panosru , who found the problem.

Btw. in #1152 we saw `$'\uE63D'` actually outputting the PHP icon. In my tests that did not work. @panosru it looks like, you have some fallback-font. I changed the PHP icon for `awesome-patched` mode to `PHP`, eventually.