### PR TITLE
Hide stderr from git ls-files

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -15,10 +15,10 @@ function +vi-git-untracked() {
   # dump out if we're outside a git repository (which includes being in the .git folder)
   [[ $? != 0 || -z $repoTopLevel ]] && return
 
-  local untrackedFiles=$(command git ls-files --others --exclude-standard "${repoTopLevel}")
+  local untrackedFiles=$(command git ls-files --others --exclude-standard "${repoTopLevel}" 2> /dev/null)
 
   if [[ -z $untrackedFiles && "$POWERLEVEL9K_VCS_SHOW_SUBMODULE_DIRTY" == "true" ]]; then
-    untrackedFiles+=$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard')
+    untrackedFiles+=$(command git submodule foreach --quiet --recursive 'command git ls-files --others --exclude-standard' 2> /dev/null)
   fi
 
   [[ -z $untrackedFiles ]] && return


### PR DESCRIPTION
#### [Bugfix] Hide stderr from git ls-files
 
Hide `warning: could not open directory 'blabla/': Permission denied` if there are files/folders inside a git repo with no user access.

Fixes https://github.com/bhilburn/powerlevel9k/issues/1134

#### Questions
Should there be unittests for that?
