### PR TITLE
[Bugfix] dir: Fix package name path truncation inside home dir

### DIFF
--- a/segments/dir/dir.p9k
+++ b/segments/dir/dir.p9k
@@ -135,6 +135,7 @@ prompt_dir() {
         local -a markedFolders
         markedFolders=( $(__p9k_upsearch "(${(j:|:)P9K_DIR_PACKAGE_FILES})") )
         local package_path="${markedFolders[1]}"
+        [[ ${(L)P9K_DIR_PATH_ABSOLUTE} != "true" ]] && package_path=${package_path//$HOME/"~"}
 
         # Replace the shortest possible match of the marked folder from
         # the current path. Remove the amount of characters up to the


### PR DESCRIPTION
#### Description
Without this, `current_path` would be `~/foo/bar` whereas `package_path` would be `/home/user/foo/bar` which breaks the substring replacement when calculating the subdirectory relative to the package (making the truncation far too greedy).

#### Questions
I presume there is a reason for the complexity in this:

```zsh
# Replace the shortest possible match of the marked folder from
# the current path. Remove the amount of characters up to the
# folder marker from the left. Count only the visible characters
# in the path (this is done by the "zero" pattern; see
# http://stackoverflow.com/a/40855342/5586433).
local zero='%([BSUbfksu]|([FB]|){*})'
# Then, find the length of the package_path string, and save the
# subdirectory path as a substring of the current directory's path from 0
# to the length of the package path's string
subdirectory_path=$(__p9k_truncate_path "${current_path:${#${(S%%)package_path//$~zero/}}}" $P9K_DIR_SHORTEN_LENGTH $P9K_DIR_SHORTEN_DELIMITER)
```

And that something simpler would not work? Something like this

```zsh
subdirectory_path=$(__p9k_truncate_path "${current_path/${package_path}/}" $P9K_DIR_SHORTEN_LENGTH $P9K_DIR_SHORTEN_DELIMITER)
```