### PR TITLE
[Enhancement] adds P9K_DIR_SHORTEN_STRATEGY_FALLBACK

### DIFF
--- a/segments/dir/dir.p9k
+++ b/segments/dir/dir.p9k
@@ -171,6 +171,14 @@ prompt_dir() {
     esac
   fi
 
+  # fall back to other strategy because the truncate_with_package_name or
+  # truncate_with_folder_marker did not work
+  if [[ ${#P9K_DIR_SHORTEN_STRATEGY_FALLBACK} > 0 && -z "${packageName}" && -z ${shortenedFolder} ]]; then
+    P9K_DIR_SHORTEN_STRATEGY=${P9K_DIR_SHORTEN_STRATEGY_FALLBACK[1]} \
+      P9K_DIR_SHORTEN_STRATEGY_FALLBACK=($P9K_DIR_SHORTEN_STRATEGY_FALLBACK[2,-1]) prompt_dir $@
+    return
+  fi
+
   # save state of path for highlighting and bold options
   local path_opt=$current_path
 


### PR DESCRIPTION
This aims to make it possible to use the `P9K_DIR_SHORTEN_STRATEGY`s but define a fallback or fallbacks, if it does not work.

Example:
```
P9K_DIR_SHORTEN_FOLDER_MARKER=".git"
P9K_DIR_SHORTEN_STRATEGY_FALLBACK=("truncate_with_folder_marker" "truncate_to_unique")
P9K_DIR_SHORTEN_STRATEGY="truncate_with_package_name"
```
![image](https://user-images.githubusercontent.com/16988672/52382644-5d387780-2a76-11e9-89ed-c580addc9335.png)

I haven't added any new tests or docs. I wanted to hear some feedback first if it works and is wanted.