### PR TITLE
Add Segment Tags

### DIFF
--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -33,9 +33,10 @@ local last_segment_index=$2
 local -a elements
 elements=(${=3})
 
-local current_segment=${elements[$current_index]}
+local raw_current_segment=${elements[$current_index]}
+local current_segment="${(s.::.)raw_current_segment}"
 local joined=false
-if [[ ${current_segment[-7,-1]} == '_joined' ]]; then
+if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -47,11 +48,12 @@ if [[ ${current_segment[-7,-1]} == '_joined' ]]; then
     # segment as well.
     local examined_index=$((current_index - 1))
     while (( ${examined_index} > ${last_segment_index} )); do
-      local previous_segment=${elements[$examined_index]}
+      local raw_previous_segment=${elements[$examined_index]}
+      local previous_segment="${(s.::.)raw_previous_segment}"
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ ${previous_segment[-7,-1]} != '_joined' ]]; then
+      if [[ ${previous_segment[(r)joined]} != 'joined' ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -34,9 +34,9 @@ local -a elements
 elements=(${=3})
 
 local raw_current_segment=${elements[$current_index]}
-local current_segment="${(s.::.)raw_current_segment}"
+local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
+if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -49,11 +49,11 @@ if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
     local examined_index=$((current_index - 1))
     while (( ${examined_index} > ${last_segment_index} )); do
       local raw_previous_segment=${elements[$examined_index]}
-      local previous_segment="${(s.::.)raw_previous_segment}"
+      local -a previous_segment=(${(s.::.)raw_previous_segment})
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ ${previous_segment[(r)joined]} != 'joined' ]]; then
+      if [[ "${previous_segment[(r)joined]}" != 'joined' ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -36,7 +36,7 @@ elements=(${=3})
 local raw_current_segment=${elements[$current_index]}
 local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
+if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -53,7 +53,7 @@ if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ "${previous_segment[(r)joined]}" != 'joined' ]]; then
+      if [[ "${previous_segment[(ie)joined]}" -gt "${#previous_segment}" ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -36,7 +36,7 @@ elements=(${=3})
 local raw_current_segment=${elements[$current_index]}
 local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
+if p9k::segment_is_tagged_as "joined" "${current_segment}"; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -53,7 +53,7 @@ if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ "${previous_segment[(ie)joined]}" -gt "${#previous_segment}" ]]; then
+      if ! p9k::segment_is_tagged_as "joined" "${previous_segment}"; then
         joined=false
         break
       fi

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -233,7 +233,7 @@ function p9k::set_default() {
 function p9k::segment_is_tagged_as() {
   local tag="${1}"
   # All following parameters
-  local segment_meta=($@[2,-1])
+  local segment_meta=(${=@[2,-1]})
 
   [[ "${segment_meta[(i)${tag}]}" -le "${#segment_meta}" ]]
 }

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -221,6 +221,25 @@ function p9k::set_default() {
 
 ###############################################################
 # @description
+#   Tests if a segment is tagged as given tag.
+##
+# @args
+#   $1 string The tag to test
+#   $2 array The segments tags
+##
+# @returns
+#   0 if the segment contains the tag
+##
+function p9k::segment_is_tagged_as() {
+  local tag="${1}"
+  # All following parameters
+  local segment_meta=($@[2,-1])
+
+  [[ "${segment_meta[(i)${tag}]}" -le "${#segment_meta}" ]]
+}
+
+###############################################################
+# @description
 #   Converts large memory values into a human-readable unit (e.g., bytes --> GB)
 ##
 # @args

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -284,20 +284,21 @@ function __p9k_prompt_custom() {
 function __p9k_build_left_prompt() {
   [[ ${P9K_LEFT_PROMPT_ELEMENTS[1]} == "" ]] && return
   local index=1
-  local element joined
-  for element in "${P9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+  local raw_segment joined
+  for raw_segment in "${P9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${element[-7,-1]}" == '_joined' ]] && joined=true || joined=false
-
-    # Remove joined information in direct calls
-    element="${element%_joined}"
+    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ $element[0,7] =~ "custom_" ]]; then
-      "__p9k_prompt_custom" "left" "$index" ${joined} $element[8,-1]
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+      "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
-      "prompt_$element" "left" "$index" $joined
+      "prompt_${segment}" "left" "$index" $joined
     fi
 
     index=$((index + 1))
@@ -316,19 +317,20 @@ function __p9k_build_left_prompt() {
 function __p9k_build_right_prompt() {
   [[ ${P9K_RIGHT_PROMPT_ELEMENTS[1]:-} == "" ]] && return
   local index=1
-  local element joined
-  for element in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
+  local raw_segment joined
+  for raw_segment in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${element[-7,-1]}" == '_joined' ]] && joined=true || joined=false
-
-    # Remove joined information in direct calls
-    element="${element%_joined}"
+    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
-    if [[ $element[0,7] =~ "custom_" ]]; then
-      "__p9k_prompt_custom" "right" "$index" ${joined} $element[8,-1]
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+      "__p9k_prompt_custom" "right" "$index" ${joined} $segment
     else
-      "prompt_$element" "right" "$index" $joined
+      "prompt_${segment}" "right" "$index" $joined
     fi
 
     index=$((index + 1))

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -291,11 +291,11 @@ function __p9k_build_left_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
+    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if [[ "${segment_meta[(ie)custom]}" -le "${#segment_meta}" ]]; then
       "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
       "prompt_${segment}" "left" "$index" $joined
@@ -324,7 +324,7 @@ function __p9k_build_right_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
+    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
     if [[ ${segment_meta[(r)custom]} == "custom" ]]; then

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -291,11 +291,11 @@ function __p9k_build_left_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
+    p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ "${segment_meta[(ie)custom]}" -le "${#segment_meta}" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
       "prompt_${segment}" "left" "$index" $joined
@@ -324,10 +324,10 @@ function __p9k_build_right_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
+    p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       "__p9k_prompt_custom" "right" "$index" ${joined} $segment
     else
       "prompt_${segment}" "right" "$index" $joined

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -212,13 +212,16 @@ __p9k_polyfill_segment_tags
 p9k::set_default P9K_CUSTOM_SEGMENT_LOCATION "$HOME/.config/powerlevel9k/segments"
 # load only the segments that are being used!
 function __p9k_load_segments() {
-  local segment
-  for segment in ${P9K_LEFT_PROMPT_ELEMENTS} ${P9K_RIGHT_PROMPT_ELEMENTS}; do
-    # Remove joined information
-    segment=${segment%_joined}
+  local segment raw_segment
+  for raw_segment in ${P9K_LEFT_PROMPT_ELEMENTS} ${P9K_RIGHT_PROMPT_ELEMENTS}; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    # First value is always segment name
+    segment=${segment_meta[1]}
 
     # Custom segments must be loaded by user
-    if [[ $segment[0,7] =~ "custom_" ]]; then
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
       continue
     fi
     # check if the file exists as a core segment

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -199,11 +199,12 @@ function __p9k_polyfill_segment_tags() {
   # #b enables pattern matching
   # ? is any character
   # ## is one or more
+  # S Flag for non-greedy matching
   P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
-  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@S)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
 
   P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
-  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@S)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
 
   # echo $P9K_LEFT_PROMPT_ELEMENTS
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -193,6 +193,22 @@ p9k::defined P9K_RIGHT_PROMPT_ELEMENTS || P9K_RIGHT_PROMPT_ELEMENTS=(status root
 # Load Prompt Segment Definitions
 ################################################################
 
+function __p9k_polyfill_segment_tags() {
+  # Replace old "custom_" elements with new Tag syntax.
+  # This is done via the internal ZSH regex engine.
+  # #b enables pattern matching
+  # ? is any character
+  # ## is one or more
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+
+  # echo $P9K_LEFT_PROMPT_ELEMENTS
+}
+__p9k_polyfill_segment_tags
+
 p9k::set_default P9K_CUSTOM_SEGMENT_LOCATION "$HOME/.config/powerlevel9k/segments"
 # load only the segments that are being used!
 function __p9k_load_segments() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -222,7 +222,7 @@ function __p9k_load_segments() {
     segment=${segment_meta[1]}
 
     # Custom segments must be loaded by user
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       continue
     fi
     # check if the file exists as a core segment

--- a/segments/anaconda/anaconda.spec
+++ b/segments/anaconda/anaconda.spec
@@ -13,7 +13,7 @@ function setUp() {
 function testAnacondaSegmentPrintsNothingIfNoAnacondaPathIsSet() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(anaconda custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(anaconda world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   P9K_RIGHT_PROMPT_ELEMENTS=()
 

--- a/segments/aws_eb_env/aws_eb_env.spec
+++ b/segments/aws_eb_env/aws_eb_env.spec
@@ -15,7 +15,7 @@ function setUp() {
 function testAwsEbEnvSegmentPrintsNothingIfNoElasticBeanstalkEnvironmentIsSet() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(aws_eb_env custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(aws_eb_env world::custom)
 
   # Load Powerlevel9k
   source segments/aws_eb_env/aws_eb_env.p9k

--- a/segments/background_jobs/background_jobs.spec
+++ b/segments/background_jobs/background_jobs.spec
@@ -15,7 +15,7 @@ function setUp() {
 function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs world::custom)
   local jobs_running=0
   local jobs_suspended=0
 

--- a/segments/command_execution_time/command_execution_time.spec
+++ b/segments/command_execution_time/command_execution_time.spec
@@ -20,7 +20,7 @@ function setUp() {
 
 function testCommandExecutionTimeIsNotShownIfTimeIsBelowThreshold() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world command_execution_time)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom command_execution_time)
   P9K_CUSTOM_WORLD='echo world'
   local _P9K_COMMAND_DURATION=2
 

--- a/segments/context/context.spec
+++ b/segments/context/context.spec
@@ -46,7 +46,7 @@ function testContextSegmentDoesNotGetRenderedWithDefaultUser() {
   local DEFAULT_USER=$(whoami)
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(context custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(context world::custom)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }

--- a/segments/detect_virt/detect_virt.spec
+++ b/segments/detect_virt/detect_virt.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testDetectVirtSegmentPrintsNothingIfSystemdIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(detect_virt custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(detect_virt world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias systemd-detect-virt="novirt"
 

--- a/segments/disk_usage/disk_usage.spec
+++ b/segments/disk_usage/disk_usage.spec
@@ -74,7 +74,7 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
 
 function testDiskUsageSegmentPrintsNothingIfDiskIsQuiteEmptyAndOnlyWarningsShouldBeDisplayed() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(disk_usage custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(disk_usage world::custom)
   df() {
       echo "Filesystem     1K-blocks      Used Available Use% Mounted on
 /dev/disk1     487219288 471466944  15496344  4% /"

--- a/segments/go_version/go_version.spec
+++ b/segments/go_version/go_version.spec
@@ -56,7 +56,7 @@ function testGoSegmentPrintsNothingIfEmptyGopath() {
   alias go=mockGoEmptyGopath
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -69,7 +69,7 @@ function testGoSegmentPrintsNothingIfNotInGopath() {
   alias go=mockGo
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -81,7 +81,7 @@ function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   alias go=noGo
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/ip/ip.spec
+++ b/segments/ip/ip.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testIpSegmentPrintsNothingOnOsxIfNotConnected() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ip world::custom)
   alias networksetup='echo "not connected"'
   local P9K_CUSTOM_WORLD='echo world'
 
@@ -29,7 +29,7 @@ function testIpSegmentPrintsNothingOnOsxIfNotConnected() {
 
 function testIpSegmentPrintsNothingOnLinuxIfNotConnected() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ip world::custom)
   alias ip='echo "not connected"'
   local P9K_CUSTOM_WORLD='echo world'
 

--- a/segments/kubecontext/kubecontext.spec
+++ b/segments/kubecontext/kubecontext.spec
@@ -92,7 +92,7 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
   alias kubectl=noKubectl
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world kubecontext)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom kubecontext)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/laravel_version/laravel_version.spec
+++ b/segments/laravel_version/laravel_version.spec
@@ -44,7 +44,7 @@ function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_LARAVEL_VERSION_ICON='x'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -57,7 +57,7 @@ function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_LARAVEL_VERSION_ICON='x'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"

--- a/segments/node_version/node_version.spec
+++ b/segments/node_version/node_version.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testNodeVersionSegmentPrintsNothingWithoutNode() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(node_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(node_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 

--- a/segments/nodeenv/nodeenv.spec
+++ b/segments/nodeenv/nodeenv.spec
@@ -22,7 +22,7 @@ function setUp() {
 
 function testNodeenvSegmentPrintsNothingWithoutNode() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 
@@ -33,7 +33,7 @@ function testNodeenvSegmentPrintsNothingWithoutNode() {
 
 function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   node() {
     echo "v1.2.3"
@@ -46,7 +46,7 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
 
 function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvDisablePromptIsSet() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   node() {
     echo "v1.2.3"

--- a/segments/nvm/nvm.spec
+++ b/segments/nvm/nvm.spec
@@ -36,7 +36,7 @@ function tearDown() {
 
 function testNvmSegmentPrintsNothingIfNvmIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nvm custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nvm world::custom)
   local P9K_CUSTOM_WORLD='echo world'
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -55,7 +55,7 @@ function testNvmSegmentWorksWithoutHavingADefaultAlias() {
 
 function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nvm custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nvm world::custom)
   local P9K_CUSTOM_WORLD='echo world'
 
   function nvm_version() {

--- a/segments/php_version/php_version.spec
+++ b/segments/php_version/php_version.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testPhpVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(php_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(php_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 

--- a/segments/public_ip/public_ip.spec
+++ b/segments/public_ip/public_ip.spec
@@ -41,7 +41,7 @@ function tearDown() {
 
 function testPublicIpSegmentPrintsNothingByDefaultIfHostIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(public_ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(public_ip world::custom)
   local P9K_PUBLIC_IP_HOST='http://unknown.xyz'
   local P9K_CUSTOM_WORLD='echo world'
   # We need to overwrite dig, as this is a fallback method that

--- a/segments/rust_version/rust_version.spec
+++ b/segments/rust_version/rust_version.spec
@@ -43,7 +43,7 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
   alias rustc=""
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom rust_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/ssh/ssh.spec
+++ b/segments/ssh/ssh.spec
@@ -15,7 +15,7 @@ function setUp() {
 
 function testSshSegmentPrintsNothingIfNoSshConnection() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ssh custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ssh world::custom)
   local P9K_CUSTOM_WORLD='echo "world"'
   local P9K_SSH_ICON="ssh-icon"
   source segments/ssh/ssh.p9k

--- a/segments/stack_project/stack_project.spec
+++ b/segments/stack_project/stack_project.spec
@@ -73,7 +73,7 @@ function testStackProjectSegmentNoStackYaml() {
 
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -85,7 +85,7 @@ function testStackProjectSegmentIfStackIsNotAvailable() {
   alias stack=mockNoStackVersion
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -96,7 +96,7 @@ function testStackProjectSegmentPrintsNothingIfStackIsNotAvailable() {
   alias stack=noStack
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/status/status.spec
+++ b/segments/status/status.spec
@@ -21,7 +21,7 @@ function setUp() {
 
 function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
   local P9K_CUSTOM_WORLD='echo world'
-  local P9K_LEFT_PROMPT_ELEMENTS=(status custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(status world::custom)
   local P9K_STATUS_VERBOSE=false
   local P9K_STATUS_SHOW_PIPESTATUS=false
 

--- a/segments/swift_version/swift_version.spec
+++ b/segments/swift_version/swift_version.spec
@@ -33,7 +33,7 @@ function tearDown() {
 
 function testSwiftSegmentPrintsNothingIfSwiftIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(swift_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(swift_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias swift="noswift"
 

--- a/segments/symfony2_version/symfony_version.spec
+++ b/segments/symfony2_version/symfony_version.spec
@@ -33,7 +33,7 @@ function tearDown() {
 
 function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 
@@ -44,7 +44,7 @@ function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
 
 function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   # "Symfony" is not a command, but rather a framework.
   # To sucessfully execute this test, we just need to
   # navigate into a folder that does not contain symfony.
@@ -55,7 +55,7 @@ function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
 
 function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   mkdir app
   touch app/AppKernel.php

--- a/segments/todo/todo.spec
+++ b/segments/todo/todo.spec
@@ -38,7 +38,7 @@ function tearDown() {
 
 function testTodoSegmentPrintsNothingIfTodoShIsNotInstalled() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(todo custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(todo world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias todo.sh="echo"
 

--- a/segments/vagrant/vagrant.spec
+++ b/segments/vagrant/vagrant.spec
@@ -45,7 +45,7 @@ function mockVagrantFolder() {
 
 function testVagrantSegmentPrintsNothingIfVirtualboxIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(vagrant custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(vagrant world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   # Change path, so that VBoxManage is not found
   local PATH=/bin:/usr/bin
@@ -55,7 +55,7 @@ function testVagrantSegmentPrintsNothingIfVirtualboxIsNotAvailable() {
 
 function testVagrantSegmentSaysVmIsDownIfVirtualboxIsNotAvailableButVagrantFolderExists() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(vagrant custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(vagrant world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   # Change path, so that VBoxManage is not found
   local PATH=/bin:/usr/bin

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -95,7 +95,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
+          p9k::segment_is_tagged_as "joined" "${element}" && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
@@ -104,7 +104,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
+          p9k::segment_is_tagged_as "joined" "${element}" && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -88,11 +88,12 @@ function rebuild_vi_mode {
           current_state="INSERT"
           ;;
       esac
-      local raw_element element joined=false
+      local raw_element joined=false
+      local -a element
       local vi_mode="P9K_VI_${current_state}_MODE_STRING"
       for (( i = 0; i <= ${#P9K_LEFT_PROMPT_ELEMENTS}; i++ )); do
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
-        element="${(s.::.)raw_element}"
+        element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
           [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
@@ -101,7 +102,7 @@ function rebuild_vi_mode {
       done
       for (( i = 0; i <= ${#P9K_RIGHT_PROMPT_ELEMENTS}; i++ )); do
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
-        element="${(s.::.)raw_element}"
+        element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
           [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -95,7 +95,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
+          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
@@ -104,7 +104,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
+          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -88,20 +88,22 @@ function rebuild_vi_mode {
           current_state="INSERT"
           ;;
       esac
-      local element joined=false
+      local raw_element element joined=false
       local vi_mode="P9K_VI_${current_state}_MODE_STRING"
       for (( i = 0; i <= ${#P9K_LEFT_PROMPT_ELEMENTS}; i++ )); do
-        element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
-        if [[ "${element}" =~ "vi_mode" ]]; then
-          [[ "${element[-7,-1]}" == '_joined' ]] && joined=true
+        raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
+        element="${(s.::.)raw_element}"
+        if [[ "${element[1]}" == "vi_mode" ]]; then
+          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
       done
       for (( i = 0; i <= ${#P9K_RIGHT_PROMPT_ELEMENTS}; i++ )); do
-        element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
-        if [[ "${element}" =~ "vi_mode" ]]; then
-          [[ "${element[-7,-1]}" == '_joined' ]] && joined=true
+        raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
+        element="${(s.::.)raw_element}"
+        if [[ "${element[1]}" == "vi_mode" ]]; then
+          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -55,7 +55,7 @@ function testColorOverridingOfStatefulSegment() {
 }
 
 function testColorOverridingOfCustomSegment() {
-  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_CUSTOM_WORLD_ICON='CW'
   local P9K_CUSTOM_WORLD_ICON_COLOR='green'

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -15,7 +15,7 @@ function setUp() {
 
 function testLeftNormalSegmentsShouldNotBeJoined() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3 custom_world4_joined custom_world5 custom_world6)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom world4::custom::joined world5::custom world6::custom)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -28,7 +28,7 @@ function testLeftNormalSegmentsShouldNotBeJoined() {
 
 function testLeftJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
@@ -37,7 +37,7 @@ function testLeftJoinedSegments() {
 
 function testLeftTransitiveJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -47,7 +47,7 @@ function testLeftTransitiveJoinedSegments() {
 
 function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined custom_world4_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -58,7 +58,7 @@ function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
 
 function testLeftPromotingSegmentWithConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -68,7 +68,7 @@ function testLeftPromotingSegmentWithConditionalPredecessor() {
 
 function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -79,7 +79,7 @@ function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
 
 function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined custom_world5_joined custom_world6_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined world5::custom::joined world6::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -92,7 +92,7 @@ function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
 
 function testLeftJoiningBuiltinSegmentWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(php_version php_version_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(php_version php_version::joined)
   alias php="echo PHP 1.2.3 "
   source segments/php_version/php_version.p9k
 
@@ -104,7 +104,7 @@ function testLeftJoiningBuiltinSegmentWorks() {
 function testRightNormalSegmentsShouldNotBeJoined() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3 custom_world4 custom_world5_joined custom_world6)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom world4::custom world5::custom::joined world6::custom)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -118,7 +118,7 @@ function testRightNormalSegmentsShouldNotBeJoined() {
 function testRightJoinedSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
@@ -128,7 +128,7 @@ function testRightJoinedSegments() {
 function testRightTransitiveJoinedSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -139,7 +139,7 @@ function testRightTransitiveJoinedSegments() {
 function testRightTransitiveJoiningWithConditionalJoinedSegment() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined custom_world4_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -151,7 +151,7 @@ function testRightTransitiveJoiningWithConditionalJoinedSegment() {
 function testRightPromotingSegmentWithConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -162,7 +162,7 @@ function testRightPromotingSegmentWithConditionalPredecessor() {
 function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -174,7 +174,7 @@ function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
 function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined custom_world5_joined custom_world6_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined world5::custom::joined world6::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -188,7 +188,7 @@ function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
 function testRightJoiningBuiltinSegmentWorks() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(php_version php_version_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(php_version php_version::joined)
   alias php="echo PHP 1.2.3"
   source segments/php_version/php_version.p9k
 

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -40,7 +40,7 @@ function testSegmentOnRightSide() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
 
@@ -54,7 +54,7 @@ function testDisablingRightPrompt() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
   local P9K_DISABLE_RPROMPT=true
@@ -66,7 +66,7 @@ function testDisablingRightPrompt() {
 
 function testLeftMultilinePrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_PROMPT_ON_NEWLINE=true
 
@@ -80,7 +80,7 @@ function testRightPromptOnSameLine() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -94,7 +94,7 @@ function testRightPromptOnSameLine() {
 
 function testPrefixingFirstLineOnLeftPrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -109,7 +109,7 @@ function testPrefixingFirstLineOnLeftPrompt() {
 
 function testPrefixingSecondLineOnLeftPrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -128,8 +128,8 @@ function testCustomStartEndSymbolsOnEdgeSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
 
@@ -149,8 +149,8 @@ function testCustomWhitespaceOfSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -173,8 +173,8 @@ function testCustomWhitespaceOfLeftAndRightSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -199,8 +199,8 @@ function testCustomWhitespaceOfCustomSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -229,8 +229,8 @@ function testCustomWhitespaceWithIconOnLeft() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -17,7 +17,7 @@ function setUp() {
 function testOverwritingIconsWork() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -27,7 +27,7 @@ function testOverwritingIconsWork() {
 function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -37,7 +37,7 @@ function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
 function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -47,7 +47,7 @@ function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
 function testVisualIdentifierPrintsNothingIfNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   assertEquals "%K{015} %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -56,7 +56,7 @@ function testVisualIdentifierPrintsNothingIfNotAvailable() {
 function testVisualIdentifierWorksWithUnicodeIcon() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='\u2714'
 

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -74,7 +74,7 @@ function testGetRelevantItemDoesNotReturnNotFoundItems() {
 
 function testSegmentShouldBeJoinedIfDirectPredecessingSegmentIsJoined() {
   typeset -a segments
-  segments=(a b_joined c_joined)
+  segments=(a b::joined c::joined)
   # Look at the third segment
   local current_index=3
   local last_element_index=2
@@ -88,7 +88,7 @@ function testSegmentShouldBeJoinedIfDirectPredecessingSegmentIsJoined() {
 
 function testSegmentShouldBeJoinedIfPredecessingSegmentIsJoinedTransitivley() {
   typeset -a segments
-  segments=(a b_joined c_joined)
+  segments=(a b::joined c::joined)
   # Look at the third segment
   local current_index=3
   # The last printed segment was the first one,
@@ -104,7 +104,7 @@ function testSegmentShouldBeJoinedIfPredecessingSegmentIsJoinedTransitivley() {
 
 function testSegmentShouldNotBeJoinedIfPredecessingSegmentIsNotJoinedButConditional() {
   typeset -a segments
-  segments=(a b_joined c d_joined)
+  segments=(a b::joined c d::joined)
   # Look at the fourth segment
   local current_index=4
   # The last printed segment was the first one,

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -26,7 +26,7 @@ function testUsingUnsetVariables() {
 
 function testJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir dir::joined)
   cd /tmp
 
   assertEquals "%K{004} %F{000}/tmp %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
@@ -36,7 +36,7 @@ function testJoinedSegments() {
 
 function testTransitiveJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator::joined dir::joined)
   source segments/root_indicator/root_indicator.p9k
   cd /tmp
 
@@ -47,7 +47,7 @@ function testTransitiveJoinedSegments() {
 
 function testJoiningWithConditionalSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir::joined)
   source segments/background_jobs/background_jobs.p9k
   local jobs_running=0
   local jobs_suspended=0
@@ -130,7 +130,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_CUSTOM_RWORLD='echo rworld'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -132,7 +132,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(rworld::custom)
 
   __p9k_prepare_prompts
 

--- a/test/segments/custom.spec
+++ b/test/segments/custom.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testCustomDirectOutputSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -24,7 +24,7 @@ function testCustomDirectOutputSegment() {
 
 function testCustomClosureSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   function p9k_hello_world() {
     echo "world"
   }
@@ -35,7 +35,7 @@ function testCustomClosureSegment() {
 
 function testSettingBackgroundForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_BACKGROUND="yellow"
 
@@ -44,7 +44,7 @@ function testSettingBackgroundForCustomSegment() {
 
 function testSettingForegroundForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_FOREGROUND="red"
 
@@ -53,7 +53,7 @@ function testSettingForegroundForCustomSegment() {
 
 function testSettingVisualIdentifierForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_ICON="hw"
 
@@ -62,7 +62,7 @@ function testSettingVisualIdentifierForCustomSegment() {
 
 function testSettingVisualIdentifierForegroundColorForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_ICON="hw"
   local P9K_CUSTOM_WORLD_ICON_COLOR="red"


### PR DESCRIPTION
### Motivation
This adds "segment tags" which is another way of tagging `custom` or `joined` segments. I did this, because in the past I didn't know better than to add "something" to the segments name to mark this segment as something. And having `_joined` as suffix and `custom_` as prefix, that Concept was at maxed out.

### Introducing the new concept
Now we can "tag" segments as we want (at least for boolean tags) by appending `::<tag>` to the segments name in the `P9K_LEFT_PROMPT_ELEMENTS` array. E.g. `dir::joined` will add an joined `dir` segment. Adding `world::custom` will add an custom segment "world". The order of tags does not matter.

### The far future
I always liked the idea of having "configuration packages", which could be done by tags. That means having all configuration for a specific segment at one point. It bothers me (whysoever) that I cannot have different configured segments in the same prompt (like a red and a green `dir` segment).