### PR TITLE
Add Async Functionality per Segment

### DIFF
--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -33,9 +33,10 @@ local last_segment_index=$2
 local -a elements
 elements=(${=3})
 
-local current_segment=${elements[$current_index]}
+local raw_current_segment=${elements[$current_index]}
+local current_segment="${(s.::.)raw_current_segment}"
 local joined=false
-if [[ ${current_segment[-7,-1]} == '_joined' ]]; then
+if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -47,11 +48,12 @@ if [[ ${current_segment[-7,-1]} == '_joined' ]]; then
     # segment as well.
     local examined_index=$((current_index - 1))
     while (( ${examined_index} > ${last_segment_index} )); do
-      local previous_segment=${elements[$examined_index]}
+      local raw_previous_segment=${elements[$examined_index]}
+      local previous_segment="${(s.::.)raw_previous_segment}"
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ ${previous_segment[-7,-1]} != '_joined' ]]; then
+      if [[ ${previous_segment[(r)joined]} != 'joined' ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -34,9 +34,9 @@ local -a elements
 elements=(${=3})
 
 local raw_current_segment=${elements[$current_index]}
-local current_segment="${(s.::.)raw_current_segment}"
+local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
+if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -49,11 +49,11 @@ if [[ ${current_segment[(r)joined]} == 'joined' ]]; then
     local examined_index=$((current_index - 1))
     while (( ${examined_index} > ${last_segment_index} )); do
       local raw_previous_segment=${elements[$examined_index]}
-      local previous_segment="${(s.::.)raw_previous_segment}"
+      local -a previous_segment=(${(s.::.)raw_previous_segment})
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ ${previous_segment[(r)joined]} != 'joined' ]]; then
+      if [[ "${previous_segment[(r)joined]}" != 'joined' ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -36,7 +36,7 @@ elements=(${=3})
 local raw_current_segment=${elements[$current_index]}
 local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
+if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -53,7 +53,7 @@ if [[ "${current_segment[(r)joined]}" == 'joined' ]]; then
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ "${previous_segment[(r)joined]}" != 'joined' ]]; then
+      if [[ "${previous_segment[(ie)joined]}" -gt "${#previous_segment}" ]]; then
         joined=false
         break
       fi

--- a/functions/autoload/__p9k_segment_should_be_joined
+++ b/functions/autoload/__p9k_segment_should_be_joined
@@ -36,7 +36,7 @@ elements=(${=3})
 local raw_current_segment=${elements[$current_index]}
 local -a current_segment=(${(s.::.)raw_current_segment})
 local joined=false
-if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
+if p9k::segment_is_tagged_as "joined" "${current_segment}"; then
   joined=true
   # promote segment to a full one, if the predecessing full segment
   # was conditional. So this can only be the case for segments that
@@ -53,7 +53,7 @@ if [[ "${current_segment[(ie)joined]}" -le "${#current_segment}" ]]; then
       # If one of the examined segments is not joined, then we know
       # that the current segment should not be joined, as the target
       # segment is the wrong one.
-      if [[ "${previous_segment[(ie)joined]}" -gt "${#previous_segment}" ]]; then
+      if ! p9k::segment_is_tagged_as "joined" "${previous_segment}"; then
         joined=false
         break
       fi

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -235,7 +235,7 @@ function p9k::segment_is_tagged_as() {
   # All following parameters
   local segment_meta=(${=@[2,-1]})
 
-  [[ "${segment_meta[(i)${tag}]}" -le "${#segment_meta}" ]]
+  [[ "${segment_meta[(re)${tag}]:-}" == "${tag}" ]]
 }
 
 ###############################################################

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -233,7 +233,7 @@ function p9k::set_default() {
 function p9k::segment_is_tagged_as() {
   local tag="${1}"
   # All following parameters
-  local segment_meta=($@[2,-1])
+  local segment_meta=(${=@[2,-1]})
 
   [[ "${segment_meta[(i)${tag}]}" -le "${#segment_meta}" ]]
 }

--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -221,6 +221,25 @@ function p9k::set_default() {
 
 ###############################################################
 # @description
+#   Tests if a segment is tagged as given tag.
+##
+# @args
+#   $1 string The tag to test
+#   $2 array The segments tags
+##
+# @returns
+#   0 if the segment contains the tag
+##
+function p9k::segment_is_tagged_as() {
+  local tag="${1}"
+  # All following parameters
+  local segment_meta=($@[2,-1])
+
+  [[ "${segment_meta[(i)${tag}]}" -le "${#segment_meta}" ]]
+}
+
+###############################################################
+# @description
 #   Converts large memory values into a human-readable unit (e.g., bytes --> GB)
 ##
 # @args

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -284,20 +284,21 @@ function __p9k_prompt_custom() {
 function __p9k_build_left_prompt() {
   [[ ${P9K_LEFT_PROMPT_ELEMENTS[1]} == "" ]] && return
   local index=1
-  local element joined
-  for element in "${P9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+  local raw_segment joined
+  for raw_segment in "${P9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${element[-7,-1]}" == '_joined' ]] && joined=true || joined=false
-
-    # Remove joined information in direct calls
-    element="${element%_joined}"
+    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ $element[0,7] =~ "custom_" ]]; then
-      "__p9k_prompt_custom" "left" "$index" ${joined} $element[8,-1]
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+      "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
-      "prompt_$element" "left" "$index" $joined
+      "prompt_${segment}" "left" "$index" $joined
     fi
 
     index=$((index + 1))
@@ -316,19 +317,20 @@ function __p9k_build_left_prompt() {
 function __p9k_build_right_prompt() {
   [[ ${P9K_RIGHT_PROMPT_ELEMENTS[1]:-} == "" ]] && return
   local index=1
-  local element joined
-  for element in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
+  local raw_segment joined
+  for raw_segment in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${element[-7,-1]}" == '_joined' ]] && joined=true || joined=false
-
-    # Remove joined information in direct calls
-    element="${element%_joined}"
+    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
-    if [[ $element[0,7] =~ "custom_" ]]; then
-      "__p9k_prompt_custom" "right" "$index" ${joined} $element[8,-1]
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+      "__p9k_prompt_custom" "right" "$index" ${joined} $segment
     else
-      "prompt_$element" "right" "$index" $joined
+      "prompt_${segment}" "right" "$index" $joined
     fi
 
     index=$((index + 1))

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -482,6 +482,8 @@ function __p9k_prepare_prompts() {
 
   # stop any running async jobs
   async_flush_jobs "__p9k_async_worker"
+  # Update the current working directory of the async worker.
+  async_worker_eval "__p9k_async_worker" builtin cd -q $PWD
 
   __p9k_build_segment_cache "left"
   __p9k_build_segment_cache "right"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -291,11 +291,11 @@ function __p9k_build_left_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
+    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if [[ "${segment_meta[(ie)custom]}" -le "${#segment_meta}" ]]; then
       "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
       "prompt_${segment}" "left" "$index" $joined
@@ -324,7 +324,7 @@ function __p9k_build_right_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ ${segment_meta[(r)joined]} == "joined" ]] && joined=true || joined=false
+    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
     if [[ ${segment_meta[(r)custom]} == "custom" ]]; then

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -291,11 +291,11 @@ function __p9k_build_left_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
+    p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if [[ "${segment_meta[(ie)custom]}" -le "${#segment_meta}" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       "__p9k_prompt_custom" "left" "$index" ${joined} $segment
     else
       "prompt_${segment}" "left" "$index" $joined
@@ -324,10 +324,10 @@ function __p9k_build_right_prompt() {
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
-    [[ "${segment_meta[(ie)joined]}" -le "${#segment_meta}" ]] && joined=true || joined=false
+    p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
 
     # Check if it is a custom command, otherwise interpet it as a prompt.
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       "__p9k_prompt_custom" "right" "$index" ${joined} $segment
     else
       "prompt_${segment}" "right" "$index" $joined

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -301,24 +301,26 @@ function __p9k_build_segment_cache() {
     local custom=false
     p9k::segment_is_tagged_as "custom" "${segment_meta}" && custom=true
 
+    local cache_key="${alignment}::${index}"
+
     if ${custom} && ${async}; then
       async_job "__p9k_async_worker" "__p9k_prompt_custom" "${alignment}" "${index}" "${joined}" "${segment}"
 
       # Placeholder
-      __p9k_segment_cache["${alignment}::${index}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|·"
+      __p9k_segment_cache["${cache_key}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|··|·true"
       # __p9k_render
     elif ${custom}; then
-      __p9k_segment_cache["${alignment}::${index}"]=$("__p9k_prompt_custom" "${alignment}" "${index}" "${joined}" "${segment}")
+      __p9k_segment_cache["${cache_key}"]=$("__p9k_prompt_custom" "${alignment}" "${index}" "${joined}" "${segment}")
       # __p9k_render
     elif ${async}; then
       async_job "__p9k_async_worker" "prompt_${segment}" "${alignment}" "${index}" "${joined}"
 
       # Placeholder
-      __p9k_segment_cache["${alignment}::${index}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|·"
+      __p9k_segment_cache["${cache_key}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|··|·true"
       # __p9k_render
     else
       # TODO: Skip computation if cache is fresh for some segments?
-      __p9k_segment_cache["${alignment}::${index}"]=$("prompt_${segment}" "${alignment}" "$index" "${joined}")
+      __p9k_segment_cache["${cache_key}"]=$("prompt_${segment}" "${alignment}" "$index" "${joined}")
       # __p9k_render
     fi
 
@@ -340,7 +342,7 @@ function __p9k_async_callback() {
   # split ${RAW_SEGMENT_DATA} into an array - see https://unix.stackexchange.com/a/28873
   local segment_meta=("${(@s:·|·:)RAW_SEGMENT_DATA}") # split on delimiter "·|·" (@s:<delim>:)
   local cache_key="${segment_meta[2]}::${segment_meta[3]}"
-  __p9k_segment_cache[${cache_key}]="${RAW_SEGMENT_DATA}"
+  __p9k_segment_cache["${cache_key}"]="${RAW_SEGMENT_DATA}"
 
   # Trigger re-rendering
   __p9k_render "true"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -233,16 +233,6 @@ function p9k::prepare_segment() {
   fi
 }
 
-
-################################################################
-# Prompt Segment Definitions
-################################################################
-
-# The `CURRENT_BG` variable is used to remember what the last BG color used was
-# when building the left-hand prompt. Because the RPROMPT is created from
-# right-left but reads the opposite, this isn't necessary for the other side.
-CURRENT_BG='NONE'
-
 ################################################################
 # @description
 #   The `custom` prompt provides a way for users to invoke commands and display

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -226,7 +226,10 @@ function p9k::prepare_segment() {
   [[ -n "${2}" ]] && STATEFUL_NAME="${STATEFUL_NAME}_${(U)2}"
 
   # Precompile condition.
-  if __p9k_segment_should_be_printed "${STATEFUL_NAME}" "${7}" "${6}"; then
+  local shouldPrint=false
+  __p9k_segment_should_be_printed "${STATEFUL_NAME}" "${7}" "${6}" && shouldPrint=true
+
+  if ${shouldPrint}; then
     local SEGMENT_ICON
     if [[ -z "${8}" ]]; then
       SEGMENT_ICON=${__P9K_ICONS[${STATEFUL_NAME}]}
@@ -236,10 +239,10 @@ function p9k::prepare_segment() {
       # otherwise use it literally
       [[ -z "${SEGMENT_ICON}" ]] && SEGMENT_ICON="${8}"
     fi
-
-    # Return the data to the main process, delimited with "·|·"
-    echo "${STATEFUL_NAME}·|·${3}·|·${4}·|·${5}·|·${6}·|·${SEGMENT_ICON}"
   fi
+
+  # Return the data to the main process, delimited with "·|·"
+  echo "${STATEFUL_NAME}·|·${3}·|·${4}·|·${5}·|·${6}·|·${SEGMENT_ICON}·|·${shouldPrint}"
 }
 
 ################################################################
@@ -353,8 +356,8 @@ function __p9k_async_callback() {
 #   $1 - boolean True if rendered through ZLE widget (in async mode)
 function __p9k_render() {
   # Resets
-  local LAST_LEFT_BACKGROUND='NONE'
-  local LAST_RIGHT_BACKGROUND='NONE'
+  CURRENT_BG='NONE'
+  CURRENT_RIGHT_BG='NONE'
   PROMPT=''
   RPROMPT=''
   # __p9k_unsafe must be a global variable, because we set
@@ -368,6 +371,8 @@ function __p9k_render() {
     [[ -z "${data}" ]] && continue
 
     local segment_meta=("${(@s:·|·:)data}")
+    [[ "${segment_meta[7]}" == "false" ]] && continue # Segment should not be printed
+
     local alignment="${segment_meta[2]}"
     __p9k_${alignment}_prompt_segment "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}"
   done

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -211,8 +211,6 @@ function __p9k_right_prompt_segment() {
 #   $6 string Content of the segment
 #   $7 string The condition - if the segment should be shown (gets evaluated)
 #   $8 string Visual identifier overide - *must* be a named icon string
-#   $9 string Background overide
-#   $10 string Foreground overide
 ##
 function p9k::prepare_segment() {
   local STATEFUL_NAME="${${(U)1}#PROMPT_}"
@@ -227,7 +225,7 @@ function p9k::prepare_segment() {
       # check if it is a named icon
       SEGMENT_ICON=${__P9K_ICONS[${8}]}
       # otherwise use it literally
-      [[ -z "${SEGMENT_ICON}" ]] && SEGMENT_ICON=$(echo ${8})
+      [[ -z "${SEGMENT_ICON}" ]] && SEGMENT_ICON="${8}"
     fi
 
     # Return the data to the main process, delimited with "·|·"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -54,6 +54,7 @@ p9k::set_default P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS " "
 #   $5 string Visual identifier (must be a key of the icons array)
 ##
 function __p9k_left_prompt_segment() {
+  local result
   local STATEFUL_NAME="${1}"
   local current_index="${2}"
   # Check if the segment should be joined with the previous one
@@ -74,13 +75,13 @@ function __p9k_left_prompt_segment() {
 
   if [[ ${CURRENT_BG} != 'NONE' ]]; then # not first segment
     if [[ "${bg}" != "${CURRENT_BG}" ]]; then # background colors are different
-      echo -n "${bg}%F${CURRENT_BG#%K}"
-      [[ ${joined} == false ]] && echo -n "$__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]${left_ws}"
+      result+="${bg}%F${CURRENT_BG#%K}"
+      [[ ${joined} == false ]] && result+="$__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]${left_ws}"
     else # background colors are the same
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment. This should have enough contrast.
-      [[ ${joined} == false ]] && echo -n "$__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]${left_ws}"
+      [[ ${joined} == false ]] && result+="$__P9K_ICONS[LEFT_SUBSEGMENT_SEPARATOR]${left_ws}"
     fi
   else # First segment
 
@@ -92,7 +93,7 @@ function __p9k_left_prompt_segment() {
       first_symbol="%K{${CURRENT_BG}}%F${bg#%K}$P9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL"
     fi
 
-    echo -n "${first_symbol}${bg}${first_ws}"
+    result+="${first_symbol}${bg}${first_ws}"
   fi
 
   # Print the visual identifier and content if any
@@ -100,10 +101,12 @@ function __p9k_left_prompt_segment() {
   [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
   [[ -n "${content}" ]] && content="${fg}${content}"
   [[ -n "${visual_identifier}" && -n "${content}" ]] && visual_identifier="${visual_identifier}${middle_ws}"
-  echo -n "${visual_identifier}${content}${right_ws}"
+  result+="${visual_identifier}${content}${right_ws}"
 
   CURRENT_BG=$bg
   last_left_element_index=$current_index
+
+  __p9k_unsafe[left]+="${result}"
 }
 
 ################################################################
@@ -113,13 +116,16 @@ function __p9k_left_prompt_segment() {
 # @noargs
 ##
 function __p9k_left_prompt_end() {
+  local result
   if [[ -n ${CURRENT_BG} ]]; then
-    echo -n "%k%F${CURRENT_BG#%K}${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
+    result+="%k%F${CURRENT_BG#%K}${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
   else
-    echo -n "%k"
+    result+="%k"
   fi
-  echo -n "%f${__P9K_ICONS[LEFT_SEGMENT_END_SEPARATOR]}"
+  result+="%f${__P9K_ICONS[LEFT_SEGMENT_END_SEPARATOR]}"
   CURRENT_BG=''
+
+  __p9k_unsafe[left]+="${result}"
 }
 
 p9k::set_default last_right_element_index 1
@@ -141,6 +147,7 @@ p9k::set_default P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS " "
 #   No ending for the right prompt segment is needed (unlike the left prompt, above).
 ##
 function __p9k_right_prompt_segment() {
+  local result
   local STATEFUL_NAME="${1}"
   local current_index="${2}"
   # Check if the segment should be joined with the previous one
@@ -161,20 +168,20 @@ function __p9k_right_prompt_segment() {
   local right_ws="$__P9K_DATA[${last_right_element_stateful_name}_RIGHT_RIGHT_WHITESPACE]"
 
   # If CURRENT_RIGHT_BG is "NONE", we are the first right segment.
-  [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "${right_ws}" # print right whitespace of prev segment
+  [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || result+="${right_ws}" # print right whitespace of prev segment
   if [[ ${joined} == false ]] || [[ ${CURRENT_RIGHT_BG} == 'NONE' ]]; then
     if [[ "${bg}" != "${CURRENT_RIGHT_BG}" ]]; then
       # Use the new BG color for the foreground with separator
-      echo -n "%F${bg#%K}${__P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]}"
+      result+="%F${bg#%K}${__P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]}"
     else
       # Middle segment with same color as previous segment
       # We take the current foreground color as color for our
       # subsegment. This should have enough contrast.
-      echo -n "${fg}${__P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]}"
+      result+="${fg}${__P9K_ICONS[RIGHT_SUBSEGMENT_SEPARATOR]}"
     fi
   fi
 
-  echo -n "${bg}${fg}"
+  result+="${bg}${fg}"
 
   local visual_identifier
   if [[ -n "${SEGMENT_ICON}" ]]; then
@@ -186,15 +193,17 @@ function __p9k_right_prompt_segment() {
   fi
 
   # Print whitespace only if segment is not joined or first right segment
-  [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && echo -n "${left_ws}"
+  [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && result+="${left_ws}"
   # Print segment content and icon, if any
   [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
-    && echo -n "${content}${visual_identifier}" \
-    || echo -n "${visual_identifier}${fg}${content}"
+    && result+="${content}${visual_identifier}" \
+    || result+="${visual_identifier}${fg}${content}"
 
   CURRENT_RIGHT_BG=${bg}
   last_right_element_index=${current_index}
   last_right_element_stateful_name=${STATEFUL_NAME}
+
+  __p9k_unsafe[right]+="${result}"
 }
 
 ################################################################
@@ -360,11 +369,11 @@ function __p9k_render() {
 
     local segment_meta=("${(@s:·|·:)data}")
     local alignment="${segment_meta[2]}"
-    __p9k_unsafe[${alignment}]+=$("__p9k_${alignment}_prompt_segment" "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}")
+    __p9k_${alignment}_prompt_segment "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}"
   done
 
   # Render End of left prompt
-  __p9k_unsafe[left]+="$(__p9k_left_prompt_end)"
+  __p9k_left_prompt_end
 
   # Render End of right prompt
   # last whitespace with last segments right symbol, if any

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -370,11 +370,11 @@ function __p9k_render() {
 
     local segment_meta=("${(@s:·|·:)data}")
     local alignment="${segment_meta[2]}"
-    __p9k_unsafe[${alignment}]="$__p9k_unsafe[${alignment}]"$("__p9k_${alignment}_prompt_segment" "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}")
+    __p9k_unsafe[${alignment}]+=$("__p9k_${alignment}_prompt_segment" "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}")
   done
 
   # Render End of left prompt
-  __p9k_unsafe[left]="${__p9k_unsafe[left]}$(__p9k_left_prompt_end)"
+  __p9k_unsafe[left]+="$(__p9k_left_prompt_end)"
 
   # Render End of right prompt
   # last whitespace with last segments right symbol, if any
@@ -382,7 +382,7 @@ function __p9k_render() {
   if p9k::defined "P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL"; then
     last_symbol="%K{none}%F${CURRENT_RIGHT_BG#%K}${P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL}"
   fi
-  __p9k_unsafe[right]="${__p9k_unsafe[right]}${__P9K_DATA[LAST_WHITESPACE]}${last_symbol}"
+  __p9k_unsafe[right]+="${__P9K_DATA[LAST_WHITESPACE]}${last_symbol}"
 
   # Render actual PROMPTS
   local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -34,6 +34,9 @@
 # right-left but reads the opposite, this isn't necessary for the other side.
 CURRENT_BG='NONE'
 
+# Global segment cache
+typeset -gAh __p9k_segment_cache
+
 p9k::set_default last_left_element_index 1
 p9k::set_default P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS " "
 p9k::set_default P9K_MIDDLE_WHITESPACE_OF_LEFT_SEGMENTS " "
@@ -196,8 +199,8 @@ function __p9k_right_prompt_segment() {
 
 ################################################################
 # @description
-#   This function wraps `__p9k_left_prompt_segment` and `__p9k_right_prompt_segment`
-#   (for compatibility with the async generator).
+#   This function returns all information about the segment in
+#   serialized form.
 ##
 # @args
 #   $1 string Name of the function that was originally invoked (mandatory)
@@ -227,13 +230,8 @@ function p9k::prepare_segment() {
       [[ -z "${SEGMENT_ICON}" ]] && SEGMENT_ICON=$(echo ${8})
     fi
 
-    # Background overide
-    [[ -n "${9}" ]] && __P9K_DATA[${STATEFUL_NAME}_BG]="${9}"
-
-    # Foreground overide
-    [[ -n "${10}" ]] && __P9K_DATA[${STATEFUL_NAME}_FG]="${10}"
-
-    "__p9k_${3}_prompt_segment" "${STATEFUL_NAME}" "${4}" "${5}" "${6}" "${SEGMENT_ICON}"
+    # Return the data to the main process, delimited with "·|·"
+    echo "${STATEFUL_NAME}·|·${3}·|·${4}·|·${5}·|·${6}·|·${SEGMENT_ICON}"
   fi
 }
 
@@ -253,7 +251,7 @@ CURRENT_BG='NONE'
 #   the output in a segment.
 ##
 # @args
-#   $1 string Left|Right
+#   $1 string left|right
 #   $2 integer Segment index
 #   $3 boolean Whether the segment should be joined
 #   $4 string Custom segment name
@@ -265,8 +263,8 @@ function __p9k_prompt_custom() {
 
   p9k::register_segment "${STATEFUL_NAME}" "" "white" "black"
 
-  if [[ -n ${segment_content} ]]; then
-    p9k::prepare_segment "${STATEFUL_NAME}" "" "$1" $2 $3 "$segment_content"
+  if [[ -n "${segment_content}" ]]; then
+    p9k::prepare_segment "${STATEFUL_NAME}" "" "${1}" "${2}" "${3}" "${segment_content}"
   fi
 }
 
@@ -281,68 +279,164 @@ function __p9k_prompt_custom() {
 ##
 # @noargs
 ##
-function __p9k_build_left_prompt() {
-  [[ ${P9K_LEFT_PROMPT_ELEMENTS[1]} == "" ]] && return
+function __p9k_build_segment_cache() {
+  local alignment="${1}"
+  local segments_var="P9K_${(U)alignment}_PROMPT_ELEMENTS"
+  local -a segments=(${(P)segments_var})
+  [[ ${#segments} == 0 ]] && return
+
   local index=1
   local raw_segment joined
-  for raw_segment in "${P9K_LEFT_PROMPT_ELEMENTS[@]}"; do
+  for raw_segment in "${(@)segments}"; do
     local -a segment_meta
     # Split by double-colon
     segment_meta=(${(s.::.)raw_segment})
     local segment="$segment_meta[1]"
     # Check if segment should be joined
     p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
+
+    local async=false
+    p9k::segment_is_tagged_as "async" "${segment_meta}" && async=true
 
     # Check if it is a custom command, otherwise interpet it as
     # a prompt.
-    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
-      "__p9k_prompt_custom" "left" "$index" ${joined} $segment
+    local custom=false
+    p9k::segment_is_tagged_as "custom" "${segment_meta}" && custom=true
+
+    if ${custom} && ${async}; then
+      async_job "__p9k_async_worker" "__p9k_prompt_custom" "${alignment}" "${index}" "${joined}" "${segment}"
+
+      # Placeholder
+      __p9k_segment_cache["${alignment}::${index}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|·"
+      # __p9k_render
+    elif ${custom}; then
+      __p9k_segment_cache["${alignment}::${index}"]=$("__p9k_prompt_custom" "${alignment}" "${index}" "${joined}" "${segment}")
+      # __p9k_render
+    elif ${async}; then
+      async_job "__p9k_async_worker" "prompt_${segment}" "${alignment}" "${index}" "${joined}"
+
+      # Placeholder
+      __p9k_segment_cache["${alignment}::${index}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|·"
+      # __p9k_render
     else
-      "prompt_${segment}" "left" "$index" $joined
+      # TODO: Skip computation if cache is fresh for some segments?
+      __p9k_segment_cache["${alignment}::${index}"]=$("prompt_${segment}" "${alignment}" "$index" "${joined}")
+      # __p9k_render
     fi
 
     index=$((index + 1))
   done
-
-  __p9k_left_prompt_end
+  __p9k_render
 }
 
-###############################################################
-# @description
-#   This function loops through the right prompt elements and calls
-#   the related segment functions.
-##
-# @noargs
-##
-function __p9k_build_right_prompt() {
-  [[ ${P9K_RIGHT_PROMPT_ELEMENTS[1]:-} == "" ]] && return
-  local index=1
-  local raw_segment joined
-  for raw_segment in "${P9K_RIGHT_PROMPT_ELEMENTS[@]}"; do
-    local -a segment_meta
-    # Split by double-colon
-    segment_meta=(${(s.::.)raw_segment})
-    local segment="$segment_meta[1]"
-    # Check if segment should be joined
-    p9k::segment_is_tagged_as "joined" "${segment_meta}" && joined=true || joined=false
+# Exchange result of prompt_<segment> function in the cache and
+# trigger re-rendering of prompt.
+function __p9k_async_callback() {
+  local JOB="${1}" CODE="${2}" RAW_SEGMENT_DATA="${3}" EXEC_TIME="${4}" ERR="${5}"
 
-    # Check if it is a custom command, otherwise interpet it as a prompt.
-    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
-      "__p9k_prompt_custom" "right" "$index" ${joined} $segment
-    else
-      "prompt_${segment}" "right" "$index" $joined
-    fi
+  # Exit early, if ${RAW_SEGMENT_DATA} is empty
+  if [[ -z "${RAW_SEGMENT_DATA}" ]]; then
+    return
+  fi
 
-    index=$((index + 1))
+  # split ${RAW_SEGMENT_DATA} into an array - see https://unix.stackexchange.com/a/28873
+  local segment_meta=("${(@s:·|·:)RAW_SEGMENT_DATA}") # split on delimiter "·|·" (@s:<delim>:)
+  local cache_key="${segment_meta[2]}::${segment_meta[3]}"
+  __p9k_segment_cache[${cache_key}]="${RAW_SEGMENT_DATA}"
+
+  # Trigger re-rendering
+  __p9k_render "true"
+}
+
+# P9K Render function.
+# Goes through cache and renders each entry.
+# Parameters:
+#   $1 - boolean True if rendered through ZLE widget (in async mode)
+function __p9k_render() {
+  # Resets
+  local LAST_LEFT_BACKGROUND='NONE'
+  local LAST_RIGHT_BACKGROUND='NONE'
+  PROMPT=''
+  RPROMPT=''
+  # __p9k_unsafe must be a global variable, because we set
+  # PROMPT='$__p9k_unsafe[left]', so without letting ZSH
+  # expand this value (single quotes). This is a workaround
+  # to avoid double expansion of the contents of the PROMPT.
+  typeset -gAh __p9k_unsafe=()
+
+  # Process Cache
+  for data in "${(@v)__p9k_segment_cache}"; do
+    [[ -z "${data}" ]] && continue
+
+    local segment_meta=("${(@s:·|·:)data}")
+    local alignment="${segment_meta[2]}"
+    __p9k_unsafe[${alignment}]="$__p9k_unsafe[${alignment}]"$("__p9k_${alignment}_prompt_segment" "${segment_meta[1]}" "${segment_meta[3]}" "${segment_meta[4]}" "${segment_meta[5]}" "${segment_meta[6]}")
   done
 
+  # Render End of left prompt
+  __p9k_unsafe[left]="${__p9k_unsafe[left]}$(__p9k_left_prompt_end)"
+
+  # Render End of right prompt
   # last whitespace with last segments right symbol, if any
   local last_symbol
   if p9k::defined "P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL"; then
     last_symbol="%K{none}%F${CURRENT_RIGHT_BG#%K}${P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL}"
   fi
+  __p9k_unsafe[right]="${__p9k_unsafe[right]}${__P9K_DATA[LAST_WHITESPACE]}${last_symbol}"
 
-  echo -n "${__P9K_DATA[LAST_WHITESPACE]}${last_symbol}"
+  # Render actual PROMPTS
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
+
+  if [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]]; then
+    __p9k_unsafe[left]="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k${__p9k_unsafe[left]}
+${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
+    if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
+      # The right prompt should be on the same line as the first line of the left
+      # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
+      # the RPROMPT, we advise it, to go one line up. At the end of RPROMPT, we
+      # advise it to go one line down. See:
+      # http://superuser.com/questions/357107/zsh-right-justify-in-ps1
+      RPROMPT_PREFIX='%{'$'\e[1A''%}' # one line up
+      RPROMPT_SUFFIX='%{'$'\e[1B''%}' # one line down
+    else
+      RPROMPT_PREFIX=''
+      RPROMPT_SUFFIX=''
+    fi
+  else
+    __p9k_unsafe[left]="%f%b%k${__p9k_unsafe[left]}"
+    RPROMPT_PREFIX=''
+    RPROMPT_SUFFIX=''
+  fi
+
+  if [[ "${P9K_DISABLE_RPROMPT:-}" != true ]]; then
+    __p9k_unsafe[right]="${RPROMPT_PREFIX}%f%b%k${__p9k_unsafe[right]}%{${reset_color}%}${RPROMPT_SUFFIX}"
+    RPROMPT='${__p9k_unsafe[right]}'
+  fi
+
+  # Allow iTerm integration to work
+  [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]] \
+    && __p9k_unsafe[left]="%{$(iterm2_prompt_mark)%}${__p9k_unsafe[left]}"
+
+local NEWLINE='
+'
+
+  if [[ "${P9K_PROMPT_ADD_NEWLINE:-}" == true ]]; then
+    NEWLINES=""
+    repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
+    __p9k_unsafe[left]="$NEWLINES${__p9k_unsafe[left]}"
+  fi
+
+  # By evaluating $__p9k_unsafe[left] here in __p9k_render we avoid
+  # the evaluation of $PROMPT being interrupted.
+  # For security $PROMPT is never set directly. This way the prompt render is
+  # forced to evaluate the variable and the contents of $__p9k_unsafe[left]
+  # are never executed. The same applies to $RPROMPT.
+  PROMPT='${__p9k_unsafe[left]}'
+
+  # About .reset-promt see:
+  # https://github.com/sorin-ionescu/prezto/issues/1026
+  # https://github.com/zsh-users/zsh-autosuggestions/issues/107#issuecomment-183824034
+  [[ "${1}" == "true" ]] && zle .reset-prompt
 }
 
 ###############################################################
@@ -386,53 +480,11 @@ function __p9k_prepare_prompts() {
   # Reset start time
   _P9K_TIMER_START=0x7FFFFFFF
 
-  local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
+  # stop any running async jobs
+  async_flush_jobs "__p9k_async_worker"
 
-  if [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]]; then
-    __p9k_unsafe_PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
-${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
-    if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
-      # The right prompt should be on the same line as the first line of the left
-      # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
-      # the RPROMPT, we advise it, to go one line up. At the end of RPROMPT, we
-      # advise it to go one line down. See:
-      # http://superuser.com/questions/357107/zsh-right-justify-in-ps1
-      RPROMPT_PREFIX='%{'$'\e[1A''%}' # one line up
-      RPROMPT_SUFFIX='%{'$'\e[1B''%}' # one line down
-    else
-      RPROMPT_PREFIX=''
-      RPROMPT_SUFFIX=''
-    fi
-  else
-    __p9k_unsafe_PROMPT="%f%b%k$(__p9k_build_left_prompt)"
-    RPROMPT_PREFIX=''
-    RPROMPT_SUFFIX=''
-  fi
-
-  if [[ "${P9K_DISABLE_RPROMPT:-}" != true ]]; then
-    __p9k_unsafe_RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{${reset_color}%}${RPROMPT_SUFFIX}"
-    RPROMPT='$__p9k_unsafe_RPROMPT'
-  fi
-
-  # Allow iTerm integration to work
-  [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]] \
-    && __p9k_unsafe_PROMPT="%{$(iterm2_prompt_mark)%}$__p9k_unsafe_PROMPT"
-
-local NEWLINE='
-'
-
-  if [[ "${P9K_PROMPT_ADD_NEWLINE:-}" == true ]]; then
-    NEWLINES=""
-    repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
-    __p9k_unsafe_PROMPT="$NEWLINES$__p9k_unsafe_PROMPT"
-  fi
-
-  # By evaluating $__p9k_unsafe_PROMPT here in __p9k_prepare_prompts we avoid
-  # the evaluation of $PROMPT being interrupted.
-  # For security $PROMPT is never set directly. This way the prompt render is
-  # forced to evaluate the variable and the contents of $__p9k_unsafe_PROMPT
-  # are never executed. The same applies to $RPROMPT.
-  PROMPT='$__p9k_unsafe_PROMPT'
+  __p9k_build_segment_cache "left"
+  __p9k_build_segment_cache "right"
 }
 
 p9k::set_default P9K_IGNORE_TERM_COLORS false

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -33,6 +33,8 @@
 # when building the left-hand prompt. Because the RPROMPT is created from
 # right-left but reads the opposite, this isn't necessary for the other side.
 CURRENT_BG='NONE'
+# `CURRENT_RIGHT_BG` does the same for the right-hand prompt.
+CURRENT_RIGHT_BG='NONE'
 
 # Global segment cache
 typeset -gAh __p9k_segment_cache
@@ -119,8 +121,6 @@ function __p9k_left_prompt_end() {
   echo -n "%f${__P9K_ICONS[LEFT_SEGMENT_END_SEPARATOR]}"
   CURRENT_BG=''
 }
-
-CURRENT_RIGHT_BG='NONE'
 
 p9k::set_default last_right_element_index 1
 p9k::set_default last_right_element_stateful_name ""

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -365,7 +365,7 @@ function __p9k_render() {
   typeset -gAh __p9k_unsafe=()
 
   # Process Cache
-  for data in "${(@v)__p9k_segment_cache}"; do
+  for data in "${(Oa@v)__p9k_segment_cache}"; do
     [[ -z "${data}" ]] && continue
 
     local segment_meta=("${(@s:·|·:)data}")

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -212,13 +212,16 @@ __p9k_polyfill_segment_tags
 p9k::set_default P9K_CUSTOM_SEGMENT_LOCATION "$HOME/.config/powerlevel9k/segments"
 # load only the segments that are being used!
 function __p9k_load_segments() {
-  local segment
-  for segment in ${P9K_LEFT_PROMPT_ELEMENTS} ${P9K_RIGHT_PROMPT_ELEMENTS}; do
-    # Remove joined information
-    segment=${segment%_joined}
+  local segment raw_segment
+  for raw_segment in ${P9K_LEFT_PROMPT_ELEMENTS} ${P9K_RIGHT_PROMPT_ELEMENTS}; do
+    local -a segment_meta
+    # Split by double-colon
+    segment_meta=(${(s.::.)raw_segment})
+    # First value is always segment name
+    segment=${segment_meta[1]}
 
     # Custom segments must be loaded by user
-    if [[ $segment[0,7] =~ "custom_" ]]; then
+    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
       continue
     fi
     # check if the file exists as a core segment

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -199,11 +199,12 @@ function __p9k_polyfill_segment_tags() {
   # #b enables pattern matching
   # ? is any character
   # ## is one or more
+  # S Flag for non-greedy matching
   P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
-  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@S)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
 
   P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
-  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@S)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
 
   # echo $P9K_LEFT_PROMPT_ELEMENTS
 }

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -193,6 +193,22 @@ p9k::defined P9K_RIGHT_PROMPT_ELEMENTS || P9K_RIGHT_PROMPT_ELEMENTS=(status root
 # Load Prompt Segment Definitions
 ################################################################
 
+function __p9k_polyfill_segment_tags() {
+  # Replace old "custom_" elements with new Tag syntax.
+  # This is done via the internal ZSH regex engine.
+  # #b enables pattern matching
+  # ? is any character
+  # ## is one or more
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
+  P9K_LEFT_PROMPT_ELEMENTS=("${(@)P9K_LEFT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)custom_(?##)/${match[1]}::custom}")
+  P9K_RIGHT_PROMPT_ELEMENTS=("${(@)P9K_RIGHT_PROMPT_ELEMENTS//(#b)(?##)_joined/${match[1]}::joined}")
+
+  # echo $P9K_LEFT_PROMPT_ELEMENTS
+}
+__p9k_polyfill_segment_tags
+
 p9k::set_default P9K_CUSTOM_SEGMENT_LOCATION "$HOME/.config/powerlevel9k/segments"
 # load only the segments that are being used!
 function __p9k_load_segments() {

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -173,14 +173,7 @@ __p9k_print_deprecation_var_warning deprecated_variables
 # Choose the generator
 ################################################################
 
-case "${(L)P9K_GENERATOR}" in
-  "zsh-async")
-    source "${__P9K_DIRECTORY}/generator/zsh-async.p9k"
-  ;;
-  *)
-    source "${__P9K_DIRECTORY}/generator/default.p9k"
-  ;;
-esac
+source "${__P9K_DIRECTORY}/generator/default.p9k"
 
 ################################################################
 # Set default prompt segments

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -222,7 +222,7 @@ function __p9k_load_segments() {
     segment=${segment_meta[1]}
 
     # Custom segments must be loaded by user
-    if [[ ${segment_meta[(r)custom]} == "custom" ]]; then
+    if p9k::segment_is_tagged_as "custom" "${segment_meta}"; then
       continue
     fi
     # check if the file exists as a core segment

--- a/segments/anaconda/anaconda.p9k
+++ b/segments/anaconda/anaconda.p9k
@@ -33,7 +33,7 @@ prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
   local _path=$CONDA_ENV_PATH$CONDA_PREFIX
-  if ! [ -z "$_path" ]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER"
-  fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER" \
+      "[[ -n \"${_path}\" ]]"
 }

--- a/segments/anaconda/anaconda.spec
+++ b/segments/anaconda/anaconda.spec
@@ -13,7 +13,7 @@ function setUp() {
 function testAnacondaSegmentPrintsNothingIfNoAnacondaPathIsSet() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(anaconda custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(anaconda world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   P9K_RIGHT_PROMPT_ELEMENTS=()
 

--- a/segments/aws/aws.p9k
+++ b/segments/aws/aws.p9k
@@ -27,7 +27,5 @@
 prompt_aws() {
   local aws_profile="${AWS_PROFILE:-$P9K_AWS_DEFAULT_PROFILE}"
 
-  if [[ -n "$aws_profile" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile"
 }

--- a/segments/aws_eb_env/aws_eb_env.p9k
+++ b/segments/aws_eb_env/aws_eb_env.p9k
@@ -27,7 +27,5 @@
 prompt_aws_eb_env() {
   local eb_env=${${(s: :)$(grep environment .elasticbeanstalk/config.yml 2> /dev/null)}[2]}
 
-  if [[ -n "$eb_env" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$eb_env"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$eb_env"
 }

--- a/segments/aws_eb_env/aws_eb_env.spec
+++ b/segments/aws_eb_env/aws_eb_env.spec
@@ -15,7 +15,7 @@ function setUp() {
 function testAwsEbEnvSegmentPrintsNothingIfNoElasticBeanstalkEnvironmentIsSet() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(aws_eb_env custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(aws_eb_env world::custom)
 
   # Load Powerlevel9k
   source segments/aws_eb_env/aws_eb_env.p9k

--- a/segments/background_jobs/background_jobs.spec
+++ b/segments/background_jobs/background_jobs.spec
@@ -15,7 +15,7 @@ function setUp() {
 function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(background_jobs world::custom)
   local jobs_running=0
   local jobs_suspended=0
 

--- a/segments/chruby/chruby.p9k
+++ b/segments/chruby/chruby.p9k
@@ -46,7 +46,6 @@ prompt_chruby() {
   chruby_label="${chruby_label%"${chruby_label##*[![:space:]]}"}"
 
   # Don't show anything if the chruby did not change the default ruby
-  if [[ "$RUBY_ENGINE" != "" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${chruby_label}"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${chruby_label}" \
+      "[[ -n \"${RUBY_ENGINE}\" ]]"
 }

--- a/segments/command_execution_time/command_execution_time.p9k
+++ b/segments/command_execution_time/command_execution_time.p9k
@@ -53,7 +53,6 @@ prompt_command_execution_time() {
     humanReadableDuration=$_P9K_COMMAND_DURATION
   fi
 
-  if (( _P9K_COMMAND_DURATION >= P9K_COMMAND_EXECUTION_TIME_THRESHOLD )); then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${humanReadableDuration}"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${humanReadableDuration}" \
+      "(( _P9K_COMMAND_DURATION >= P9K_COMMAND_EXECUTION_TIME_THRESHOLD ))"
 }

--- a/segments/command_execution_time/command_execution_time.spec
+++ b/segments/command_execution_time/command_execution_time.spec
@@ -20,7 +20,7 @@ function setUp() {
 
 function testCommandExecutionTimeIsNotShownIfTimeIsBelowThreshold() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world command_execution_time)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom command_execution_time)
   P9K_CUSTOM_WORLD='echo world'
   local _P9K_COMMAND_DURATION=2
 

--- a/segments/context/context.p9k
+++ b/segments/context/context.p9k
@@ -46,8 +46,6 @@ prompt_context() {
     content="${P9K_CONTEXT_TEMPLATE}"
   elif [[ "$P9K_CONTEXT_ALWAYS_SHOW_USER" == true ]]; then
     content="${me}"
-  else
-    return
   fi
 
   if [[ $(print -P "%#") == '#' ]]; then

--- a/segments/context/context.spec
+++ b/segments/context/context.spec
@@ -46,7 +46,7 @@ function testContextSegmentDoesNotGetRenderedWithDefaultUser() {
   local DEFAULT_USER=$(whoami)
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(context custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(context world::custom)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }

--- a/segments/detect_virt/detect_virt.p9k
+++ b/segments/detect_virt/detect_virt.p9k
@@ -29,5 +29,6 @@ prompt_detect_virt() {
   if [[ "$virt" == "none" ]]; then
     [[ "$(ls -di / | grep -o 2)" != "2" ]] && virt="chroot"
   fi
-  [[ -n "${virt}" ]] && p9k::prepare_segment "$0" "" $1 "$2" $3 "$virt"
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$virt"
 }

--- a/segments/detect_virt/detect_virt.spec
+++ b/segments/detect_virt/detect_virt.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testDetectVirtSegmentPrintsNothingIfSystemdIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(detect_virt custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(detect_virt world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias systemd-detect-virt="novirt"
 

--- a/segments/dir/dir.p9k
+++ b/segments/dir/dir.p9k
@@ -43,7 +43,6 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_dir() {
-  [[ $P9K_GENERATOR == "zsh-async" && -n $4 ]] && cd $4
   local -a paths
   # using ${PWD} instead of "$(print -P '%~')" to allow use of P9K_DIR_PATH_ABSOLUTE
   local current_path=${PWD} # WAS: local current_path="$(print -P '%~')"

--- a/segments/dir_writable/dir_writable.p9k
+++ b/segments/dir_writable/dir_writable.p9k
@@ -25,7 +25,6 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_dir_writable() {
-  if [[ ! -w "$PWD" ]]; then
-    p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" "[[ true ]]"
-  fi
+  p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" \
+      "[[ ! -w \"${PWD}\" ]]"
 }

--- a/segments/disk_usage/disk_usage.p9k
+++ b/segments/disk_usage/disk_usage.p9k
@@ -45,17 +45,18 @@ prompt_disk_usage() {
         current_state='critical'
     fi
   else
+    current_state='normal'
     if [[ "$P9K_DISK_USAGE_ONLY_WARNING" == true ]]; then
         current_state=''
-        return
+        # Avoid printing the prompty, by setting $disk_usage
+        # to empty string, so the condition is not fulfilled.
+        disk_usage=''
     fi
-    current_state='normal'
   fi
 
   local message="${disk_usage}%%"
 
   # Draw the prompt_segment
-  if [[ -n ${disk_usage} ]]; then
-    p9k::prepare_segment "$0" "${current_state}" $1 "$2" $3 "$message"
-  fi
+  p9k::prepare_segment "$0" "${current_state}" $1 "$2" $3 "$message" \
+      "[[ -n \"${disk_usage}\" ]]"
 }

--- a/segments/disk_usage/disk_usage.spec
+++ b/segments/disk_usage/disk_usage.spec
@@ -74,7 +74,7 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
 
 function testDiskUsageSegmentPrintsNothingIfDiskIsQuiteEmptyAndOnlyWarningsShouldBeDisplayed() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(disk_usage custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(disk_usage world::custom)
   df() {
       echo "Filesystem     1K-blocks      Used Available Use% Mounted on
 /dev/disk1     487219288 471466944  15496344  4% /"

--- a/segments/docker_machine/docker_machine.p9k
+++ b/segments/docker_machine/docker_machine.p9k
@@ -25,5 +25,5 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_docker_machine() {
-  [[ -n "${DOCKER_MACHINE_NAME}" ]] && p9k::prepare_segment "$0" "" $1 "$2" $3 "${DOCKER_MACHINE_NAME}"
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${DOCKER_MACHINE_NAME}"
 }

--- a/segments/dropbox/dropbox.p9k
+++ b/segments/dropbox/dropbox.p9k
@@ -29,13 +29,11 @@ prompt_dropbox() {
   local dropbox_status="$(dropbox-cli filestatus . | cut -d\  -f2-)"
 
   # Only show if the folder is tracked and dropbox is running
-  if [[ "$dropbox_status" != 'unwatched' && "$dropbox_status" != "isn't running!" ]]; then
-    # If "up to date", only show the icon
-    if [[ "$dropbox_status" =~ 'up to date' ]]; then
-      dropbox_status=" "
-    fi
-
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$dropbox_status"
+  # If "up to date", only show the icon
+  if [[ "$dropbox_status" =~ 'up to date' ]]; then
+    dropbox_status=" "
   fi
 
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$dropbox_status" \
+      "[[ \"${dropbox_status}\" != 'unwatched' && \"${dropbox_status}\" != \"isn't running!\" ]]"
 }

--- a/segments/go_version/go_version.p9k
+++ b/segments/go_version/go_version.p9k
@@ -30,7 +30,6 @@ prompt_go_version() {
   go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
   go_path=$(go env GOPATH 2>/dev/null)
 
-  if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$go_version"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$go_version" \
+      "[[ -n \"${go_version}\" && \"${PWD##$go_path}\" != \"${PWD}\" ]]"
 }

--- a/segments/go_version/go_version.spec
+++ b/segments/go_version/go_version.spec
@@ -56,7 +56,7 @@ function testGoSegmentPrintsNothingIfEmptyGopath() {
   alias go=mockGoEmptyGopath
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -69,7 +69,7 @@ function testGoSegmentPrintsNothingIfNotInGopath() {
   alias go=mockGo
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -81,7 +81,7 @@ function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   alias go=noGo
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom go_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/ip/ip.spec
+++ b/segments/ip/ip.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testIpSegmentPrintsNothingOnOsxIfNotConnected() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ip world::custom)
   alias networksetup='echo "not connected"'
   local P9K_CUSTOM_WORLD='echo world'
 
@@ -29,7 +29,7 @@ function testIpSegmentPrintsNothingOnOsxIfNotConnected() {
 
 function testIpSegmentPrintsNothingOnLinuxIfNotConnected() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ip world::custom)
   alias ip='echo "not connected"'
   local P9K_CUSTOM_WORLD='echo world'
 

--- a/segments/java_version/java_version.p9k
+++ b/segments/java_version/java_version.p9k
@@ -32,7 +32,6 @@ prompt_java_version() {
   # If yes, we parse the version string (and need to
   # redirect the stderr to stdout to make the pipe work).
   java_version=$(java -version 2>/dev/null && java -fullversion 2>&1 | cut -d '"' -f 2)
-  if [[ -n "$java_version" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3  "${java_version}"
-  fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3  "${java_version}"
 }

--- a/segments/kubecontext/kubecontext.p9k
+++ b/segments/kubecontext/kubecontext.p9k
@@ -26,6 +26,7 @@
 ##
 prompt_kubecontext() {
   local kubectl_version="$(kubectl version --client 2>/dev/null)"
+  local k8s_final_text=""
 
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kuberenetes context
@@ -36,8 +37,6 @@ prompt_kubecontext() {
       cur_namespace="default"
     fi
 
-    local k8s_final_text=""
-
     if [[ "$cur_ctx" == "$cur_namespace" ]]; then
       # No reason to print out the same identificator twice
       k8s_final_text="$cur_ctx"
@@ -45,6 +44,7 @@ prompt_kubecontext() {
       k8s_final_text="$cur_ctx/$cur_namespace"
     fi
 
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$k8s_final_text"
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$k8s_final_text"
 }

--- a/segments/kubecontext/kubecontext.spec
+++ b/segments/kubecontext/kubecontext.spec
@@ -92,7 +92,7 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
   alias kubectl=noKubectl
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world kubecontext)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom kubecontext)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/laravel_version/laravel_version.p9k
+++ b/segments/laravel_version/laravel_version.p9k
@@ -26,10 +26,10 @@
 ##
 prompt_laravel_version() {
   local laravel_version="$(php artisan --version 2> /dev/null)"
-  if [[ -n "${laravel_version}" && "${laravel_version}" =~ "Laravel Framework" ]]; then
-    # Strip out everything but the version
-    laravel_version="${laravel_version//Laravel Framework /}"
 
-    p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${laravel_version}"
-  fi
+  # Strip out everything but the version
+  laravel_version="${laravel_version//Laravel Framework /}"
+
+  p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${laravel_version}" \
+      "[[ -n \"${laravel_version}\" && \"${laravel_version}\" =~ \"Laravel Framework\" ]]"
 }

--- a/segments/laravel_version/laravel_version.spec
+++ b/segments/laravel_version/laravel_version.spec
@@ -44,7 +44,7 @@ function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_LARAVEL_VERSION_ICON='x'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -57,7 +57,7 @@ function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_LARAVEL_VERSION_ICON='x'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"

--- a/segments/newline/newline.p9k
+++ b/segments/newline/newline.p9k
@@ -17,13 +17,14 @@
 #   This is not an actual prompt segment, it is just a workaround to allow more newlines in your prompt.
 ##
 prompt_newline() {
-  [[ "$1" == "right" ]] && return
-
   local newline=$'\n'
   [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]] \
       && newline="${newline}${__P9K_ICONS[MULTILINE_NEWLINE_PROMPT_PREFIX]}"
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "[[ true ]]" "" "%k"
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" \
+      "[[ \"${1}\" == \"left\" ]]" \
+      "" \
+      "%k"
   # Reset color variable, so that next segment starts as first
   CURRENT_BG="NONE"
 }

--- a/segments/node_version/node_version.p9k
+++ b/segments/node_version/node_version.p9k
@@ -26,7 +26,6 @@
 ##
 prompt_node_version() {
   local node_version=$(node -v 2>/dev/null)
-  [[ -z "${node_version}" ]] && return
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${node_version:1}"
 }

--- a/segments/node_version/node_version.spec
+++ b/segments/node_version/node_version.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testNodeVersionSegmentPrintsNothingWithoutNode() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(node_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(node_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 

--- a/segments/nodeenv/nodeenv.p9k
+++ b/segments/nodeenv/nodeenv.p9k
@@ -25,8 +25,8 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_nodeenv() {
-  if [[ -n "${NODE_VIRTUAL_ENV}" && "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" != true ]]; then
-    local info="$(node -v)[${NODE_VIRTUAL_ENV:t}]"
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$info"
-  fi
+  local info="$(node -v)[${NODE_VIRTUAL_ENV:t}]"
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$info" \
+      "[[ -n \"${NODE_VIRTUAL_ENV}\" && \"${NODE_VIRTUAL_ENV_DISABLE_PROMPT}\" != \"true\" ]]"
 }

--- a/segments/nodeenv/nodeenv.spec
+++ b/segments/nodeenv/nodeenv.spec
@@ -22,7 +22,7 @@ function setUp() {
 
 function testNodeenvSegmentPrintsNothingWithoutNode() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 
@@ -33,7 +33,7 @@ function testNodeenvSegmentPrintsNothingWithoutNode() {
 
 function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   node() {
     echo "v1.2.3"
@@ -46,7 +46,7 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
 
 function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvDisablePromptIsSet() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nodeenv world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   node() {
     echo "v1.2.3"

--- a/segments/nvm/nvm.spec
+++ b/segments/nvm/nvm.spec
@@ -36,7 +36,7 @@ function tearDown() {
 
 function testNvmSegmentPrintsNothingIfNvmIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nvm custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nvm world::custom)
   local P9K_CUSTOM_WORLD='echo world'
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -55,7 +55,7 @@ function testNvmSegmentWorksWithoutHavingADefaultAlias() {
 
 function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(nvm custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(nvm world::custom)
   local P9K_CUSTOM_WORLD='echo world'
 
   function nvm_version() {

--- a/segments/openfoam/openfoam.p9k
+++ b/segments/openfoam/openfoam.p9k
@@ -27,9 +27,12 @@
 prompt_openfoam() {
   local wm_project_version="$WM_PROJECT_VERSION"
   local wm_fork="$WM_FORK"
+  local content
   if [[ -n "$wm_project_version" ]] &&  [[ -z "$wm_fork" ]] ; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "OF: ${wm_project_version:t}"
+    content="OF: ${wm_project_version:t}"
   elif [[ -n "$wm_project_version" ]] && [[ -n "$wm_fork" ]] ; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "F-X: ${wm_project_version:t}"
+    content="F-X: ${wm_project_version:t}"
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${content}"
 }

--- a/segments/php_version/php_version.p9k
+++ b/segments/php_version/php_version.p9k
@@ -27,7 +27,6 @@
 prompt_php_version() {
   local php_version
   [[ "$(php -v 2>&1)" =~ "^PHP[[:blank:]]*([0-9.]+)" ]] && php_version="${match[1]}"
-  if [[ -n "$php_version" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${php_version}"
-  fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${php_version}"
 }

--- a/segments/php_version/php_version.spec
+++ b/segments/php_version/php_version.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testPhpVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(php_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(php_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 

--- a/segments/public_ip/public_ip.p9k
+++ b/segments/public_ip/public_ip.p9k
@@ -105,6 +105,7 @@ prompt_public_ip() {
         break
       done
     fi
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${public_ip}" "" "$icon"
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${public_ip}" "" "$icon"
 }

--- a/segments/public_ip/public_ip.spec
+++ b/segments/public_ip/public_ip.spec
@@ -41,7 +41,7 @@ function tearDown() {
 
 function testPublicIpSegmentPrintsNothingByDefaultIfHostIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(public_ip custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(public_ip world::custom)
   local P9K_PUBLIC_IP_HOST='http://unknown.xyz'
   local P9K_CUSTOM_WORLD='echo world'
   # We need to overwrite dig, as this is a fallback method that

--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -41,8 +41,8 @@ prompt_pyenv() {
     if [[ -f "${pyenv_root}/version" ]]; then
       pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
     fi
-    if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
-      p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}"
-    fi
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}" \
+      "[[ \"${pyenv_version_name}\" != \"${pyenv_global}\" || \"${P9K_PYENV_PROMPT_ALWAYS_SHOW}\" == \"true\" ]]"
 }

--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -32,12 +32,14 @@
 #   [Choosing the Python Version](https://github.com/pyenv/pyenv#choosing-the-python-version)
 ##
 prompt_pyenv() {
-  if [[ -n "$PYENV_VERSION" ]]; then
-    "__p9k_$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
-  elif [ $commands[pyenv] ]; then
-    local pyenv_version_name="$(pyenv version-name)"
-    local pyenv_global="system"
-    local pyenv_root="$(pyenv root)"
+  local pyenv_version_name
+  local pyenv_global
+  local pyenv_root
+
+  if [ $commands[pyenv] ]; then
+    pyenv_version_name="$(pyenv version-name)"
+    pyenv_global="system"
+    pyenv_root="$(pyenv root)"
     if [[ -f "${pyenv_root}/version" ]]; then
       pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
     fi

--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -29,11 +29,12 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_rbenv() {
-  if [[ -n "${RBENV_VERSION}" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${RBENV_VERSION}"
-  elif [ ${commands[rbenv]} ]; then
-    local rbenv_version_name="$(rbenv version-name)"
-    local rbenv_global="$(rbenv global)"
+  local rbenv_version_name
+  local rbenv_global
+
+  if [ ${commands[rbenv]} ]; then
+    rbenv_version_name="$(rbenv version-name)"
+    rbenv_global="$(rbenv global)"
   fi
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}" \

--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -34,8 +34,8 @@ prompt_rbenv() {
   elif [ ${commands[rbenv]} ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
-    if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
-      p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}"
-    fi
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}" \
+      "[[ \"${rbenv_version_name}\" != \"${rbenv_global}\" || \"${P9K_RBENV_PROMPT_ALWAYS_SHOW}\" == \"true\" ]]"
 }

--- a/segments/root_indicator/root_indicator.p9k
+++ b/segments/root_indicator/root_indicator.p9k
@@ -25,7 +25,6 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_root_indicator() {
-  if [[ "$UID" -eq 0 ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "[[ true ]]"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "" \
+      "[[ \"${UID}\" -eq 0 ]]"
 }

--- a/segments/rust_version/rust_version.p9k
+++ b/segments/rust_version/rust_version.p9k
@@ -32,7 +32,5 @@ prompt_rust_version() {
   # whitespace. This way we'll end up with only the version.
   rust_version=${${rust_version/rustc /}%% *}
 
-  if [[ -n "$rust_version" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$rust_version"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$rust_version"
 }

--- a/segments/rust_version/rust_version.spec
+++ b/segments/rust_version/rust_version.spec
@@ -43,7 +43,7 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
   alias rustc=""
   P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom rust_version)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/rvm/rvm.p9k
+++ b/segments/rvm/rvm.p9k
@@ -27,7 +27,5 @@
 prompt_rvm() {
   local version_and_gemset=${rvm_env_string/ruby-}
 
-  if [[ -n "$version_and_gemset" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$version_and_gemset"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$version_and_gemset"
 }

--- a/segments/ssh/ssh.p9k
+++ b/segments/ssh/ssh.p9k
@@ -25,7 +25,6 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_ssh() {
-  if [[ -n "$SSH_CLIENT" ]] || [[ -n "$SSH_TTY" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "[[ true ]]"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "" \
+      "[[ -n \"${SSH_CLIENT}\" ]] || [[ -n \"${SSH_TTY}\" ]]"
 }

--- a/segments/ssh/ssh.spec
+++ b/segments/ssh/ssh.spec
@@ -15,7 +15,7 @@ function setUp() {
 
 function testSshSegmentPrintsNothingIfNoSshConnection() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(ssh custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(ssh world::custom)
   local P9K_CUSTOM_WORLD='echo "world"'
   local P9K_SSH_ICON="ssh-icon"
   source segments/ssh/ssh.p9k

--- a/segments/stack_project/stack_project.p9k
+++ b/segments/stack_project/stack_project.p9k
@@ -26,11 +26,14 @@
 ##
 prompt_stack_project() {
   local haskellstack_version=$(stack --version 2>/dev/null)
+  local content
   # Check for both a global Stack installation and a stack.yaml files (in current or parent directories)
   if [[ "${haskellstack_version}" =~ "([0-9.]+)" ]]; then
     local stackyaml_file_search=$(__p9k_upsearch "stack.yaml")
     if [[ "${stackyaml_file_search}" != "$HOME" && "${stackyaml_file_search}" != "/" ]]; then
-      p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "Stack"
+      content="Stack"
     fi
   fi
+
+  p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${content}"
 }

--- a/segments/stack_project/stack_project.spec
+++ b/segments/stack_project/stack_project.spec
@@ -73,7 +73,7 @@ function testStackProjectSegmentNoStackYaml() {
 
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -85,7 +85,7 @@ function testStackProjectSegmentIfStackIsNotAvailable() {
   alias stack=mockNoStackVersion
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
@@ -96,7 +96,7 @@ function testStackProjectSegmentPrintsNothingIfStackIsNotAvailable() {
   alias stack=noStack
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom stack_project)
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
 

--- a/segments/status/status.p9k
+++ b/segments/status/status.p9k
@@ -71,13 +71,18 @@ prompt_status() {
     ec_sum=${RETVAL}
   fi
 
+  local current_state
+  local content
   if (( ec_sum > 0 )); then
     if [[ "$P9K_STATUS_CROSS" == false && "$P9K_STATUS_VERBOSE" == true ]]; then
-      p9k::prepare_segment "$0" "ERROR_CR" $1 "$2" $3 "$ec_text" "[[ true ]]"
+      current_state="ERROR_CR"
+      content="${ec_text}"
     else
-      p9k::prepare_segment "$0" "ERROR" $1 "$2" $3 "" "[[ true ]]"
+      current_state="ERROR"
     fi
   elif [[ "$P9K_STATUS_OK" == true ]] && [[ "$P9K_STATUS_VERBOSE" == true || "$P9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
-    p9k::prepare_segment "$0" "OK" $1 "$2" $3  "" "[[ true ]]"
+    current_state="OK"
   fi
+
+  p9k::prepare_segment "$0" "¢{current_state}" $1 "$2" $3  "${content}" "[[ true ]]"
 }

--- a/segments/status/status.spec
+++ b/segments/status/status.spec
@@ -21,7 +21,7 @@ function setUp() {
 
 function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
   local P9K_CUSTOM_WORLD='echo world'
-  local P9K_LEFT_PROMPT_ELEMENTS=(status custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(status world::custom)
   local P9K_STATUS_VERBOSE=false
   local P9K_STATUS_SHOW_PIPESTATUS=false
 

--- a/segments/swift_version/swift_version.p9k
+++ b/segments/swift_version/swift_version.p9k
@@ -27,7 +27,6 @@
 prompt_swift_version() {
   # Get the first number as this is probably the "main" version number..
   local swift_version=$(swift --version 2>/dev/null | grep -o -E "[0-9.]+" | head -n 1)
-  [[ -z "${swift_version}" ]] && return
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${swift_version}"
 }

--- a/segments/swift_version/swift_version.spec
+++ b/segments/swift_version/swift_version.spec
@@ -33,7 +33,7 @@ function tearDown() {
 
 function testSwiftSegmentPrintsNothingIfSwiftIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(swift_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(swift_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias swift="noswift"
 

--- a/segments/symfony2_version/symfony2_version.p9k
+++ b/segments/symfony2_version/symfony2_version.p9k
@@ -25,9 +25,10 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_symfony2_version() {
+  local symfony2_version
   if [[ -f app/bootstrap.php.cache ]]; then
-    local symfony2_version
     symfony2_version=$(grep " VERSION " app/bootstrap.php.cache | sed -e 's/[^.0-9]*//g')
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$symfony2_version"
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$symfony2_version"
 }

--- a/segments/symfony2_version/symfony_version.spec
+++ b/segments/symfony2_version/symfony_version.spec
@@ -33,7 +33,7 @@ function tearDown() {
 
 function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 
@@ -44,7 +44,7 @@ function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
 
 function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   # "Symfony" is not a command, but rather a framework.
   # To sucessfully execute this test, we just need to
   # navigate into a folder that does not contain symfony.
@@ -55,7 +55,7 @@ function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
 
 function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(symfony2_version world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   mkdir app
   touch app/AppKernel.php

--- a/segments/todo/todo.p9k
+++ b/segments/todo/todo.p9k
@@ -25,10 +25,13 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_todo() {
+  local count
   if $(hash todo.sh 2>&-); then
     count=$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }')
-    if [[ "$count" = <-> ]]; then
-      p9k::prepare_segment "$0" "" $1 "$2" $3 "$count"
+    if [[ "$count" != <-> ]]; then
+      count=''
     fi
   fi
+
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "$count"
 }

--- a/segments/todo/todo.spec
+++ b/segments/todo/todo.spec
@@ -38,7 +38,7 @@ function tearDown() {
 
 function testTodoSegmentPrintsNothingIfTodoShIsNotInstalled() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(todo custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(todo world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   alias todo.sh="echo"
 

--- a/segments/vagrant/vagrant.p9k
+++ b/segments/vagrant/vagrant.p9k
@@ -41,7 +41,6 @@ prompt_vagrant() {
     done
   done
 
-  if [[ "${current_state}" != "NOT_FOUND" ]]; then
-    p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${current_string}"
-  fi
+  p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${current_string}" \
+      "[[ \"${current_state}\" != \"NOT_FOUND\" ]]"
 }

--- a/segments/vagrant/vagrant.spec
+++ b/segments/vagrant/vagrant.spec
@@ -45,7 +45,7 @@ function mockVagrantFolder() {
 
 function testVagrantSegmentPrintsNothingIfVirtualboxIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(vagrant custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(vagrant world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   # Change path, so that VBoxManage is not found
   local PATH=/bin:/usr/bin
@@ -55,7 +55,7 @@ function testVagrantSegmentPrintsNothingIfVirtualboxIsNotAvailable() {
 
 function testVagrantSegmentSaysVmIsDownIfVirtualboxIsNotAvailableButVagrantFolderExists() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(vagrant custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(vagrant world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   # Change path, so that VBoxManage is not found
   local PATH=/bin:/usr/bin

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -430,20 +430,19 @@ prompt_vcs() {
   vcs_info
   local vcs_prompt="${vcs_info_msg_0_}"
 
-  if [[ -n "${vcs_prompt}" ]]; then
-    if [[ "${VCS_WORKDIR_CLOBBERED}" == true ]]; then
-      current_state='clobbered'
-    elif [[ "${VCS_WORKDIR_DIRTY}" == true ]]; then
-      current_state='modified'
+  if [[ "${VCS_WORKDIR_CLOBBERED}" == true ]]; then
+    current_state='clobbered'
+  elif [[ "${VCS_WORKDIR_DIRTY}" == true ]]; then
+    current_state='modified'
+  else
+    if [[ "${VCS_WORKDIR_HALF_DIRTY}" == true ]]; then
+      current_state='untracked'
     else
-      if [[ "${VCS_WORKDIR_HALF_DIRTY}" == true ]]; then
-        current_state='untracked'
-      else
-        current_state='clean'
-      fi
+      current_state='clean'
     fi
-    p9k::prepare_segment ${0} ${current_state} ${1} "${2}" ${3} "${vcs_prompt}" "" "${vcs_segment_icon}"
   fi
+
+  p9k::prepare_segment ${0} ${current_state} ${1} "${2}" ${3} "${vcs_prompt}" "" "${vcs_segment_icon}" "[[ -n \"${vcs_prompt}\" ]]"
 }
 
 ################################################################

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -421,7 +421,6 @@ p9k::register_segment  "VCS" "CLOBBERED" "red"    "${DEFAULT_COLOR}" ''  ''  '' 
 #   ${3} boolean Whether the segment should be joined
 ##
 prompt_vcs() {
-  [[ ${P9K_GENERATOR} == "zsh-async" && -n ${4} ]] && cd ${4}
   VCS_WORKDIR_CLOBBERED=false
   VCS_WORKDIR_DIRTY=false
   VCS_WORKDIR_HALF_DIRTY=false

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -95,7 +95,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
+          p9k::segment_is_tagged_as "joined" "${element}" && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
@@ -104,7 +104,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
+          p9k::segment_is_tagged_as "joined" "${element}" && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -88,11 +88,12 @@ function rebuild_vi_mode {
           current_state="INSERT"
           ;;
       esac
-      local raw_element element joined=false
+      local raw_element joined=false
+      local -a element
       local vi_mode="P9K_VI_${current_state}_MODE_STRING"
       for (( i = 0; i <= ${#P9K_LEFT_PROMPT_ELEMENTS}; i++ )); do
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
-        element="${(s.::.)raw_element}"
+        element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
           [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
@@ -101,7 +102,7 @@ function rebuild_vi_mode {
       done
       for (( i = 0; i <= ${#P9K_RIGHT_PROMPT_ELEMENTS}; i++ )); do
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
-        element="${(s.::.)raw_element}"
+        element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
           [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -95,7 +95,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
+          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
@@ -104,7 +104,7 @@ function rebuild_vi_mode {
         raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
         element=(${(s.::.)raw_element})
         if [[ "${element[1]}" == "vi_mode" ]]; then
-          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
+          [[ "${element[(ie)joined]}" -le "${#element}" ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -88,20 +88,22 @@ function rebuild_vi_mode {
           current_state="INSERT"
           ;;
       esac
-      local element joined=false
+      local raw_element element joined=false
       local vi_mode="P9K_VI_${current_state}_MODE_STRING"
       for (( i = 0; i <= ${#P9K_LEFT_PROMPT_ELEMENTS}; i++ )); do
-        element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
-        if [[ "${element}" =~ "vi_mode" ]]; then
-          [[ "${element[-7,-1]}" == '_joined' ]] && joined=true
+        raw_element="${(L)P9K_LEFT_PROMPT_ELEMENTS[$i]}"
+        element="${(s.::.)raw_element}"
+        if [[ "${element[1]}" == "vi_mode" ]]; then
+          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·left·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi
       done
       for (( i = 0; i <= ${#P9K_RIGHT_PROMPT_ELEMENTS}; i++ )); do
-        element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
-        if [[ "${element}" =~ "vi_mode" ]]; then
-          [[ "${element[-7,-1]}" == '_joined' ]] && joined=true
+        raw_element="${(L)P9K_RIGHT_PROMPT_ELEMENTS[$i]}"
+        element="${(s.::.)raw_element}"
+        if [[ "${element[1]}" == "vi_mode" ]]; then
+          [[ "${element[(r)joined]}" == 'joined' ]] && joined=true
           __p9k_async_callback "" "0" "VI_MODE_${current_state}·|·right·|·${i}·|·${joined}·|·${(P)vi_mode}·|·$__P9K_ICONS[VI_MODE_${current_state}]" "0" "0"
           break
         fi

--- a/segments/virtualenv/virtualenv.p9k
+++ b/segments/virtualenv/virtualenv.p9k
@@ -28,7 +28,6 @@
 #   [virtualenv (Python)](https://virtualenv.pypa.io/en/latest/)
 #   for more information.
 prompt_virtualenv() {
-  if [[ -n "${VIRTUAL_ENV}" && "${VIRTUAL_ENV_DISABLE_PROMPT}" != true ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${VIRTUAL_ENV:t}"
-  fi
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${VIRTUAL_ENV:t}"  \
+      "[[ -n \"${VIRTUAL_ENV}\" && \"${VIRTUAL_ENV_DISABLE_PROMPT}\" != \"true\" ]]"
 }

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -55,7 +55,7 @@ function testColorOverridingOfStatefulSegment() {
 }
 
 function testColorOverridingOfCustomSegment() {
-  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_CUSTOM_WORLD_ICON='CW'
   local P9K_CUSTOM_WORLD_ICON_COLOR='green'

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -15,7 +15,7 @@ function setUp() {
 
 function testLeftNormalSegmentsShouldNotBeJoined() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3 custom_world4_joined custom_world5 custom_world6)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom world4::custom::joined world5::custom world6::custom)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -28,7 +28,7 @@ function testLeftNormalSegmentsShouldNotBeJoined() {
 
 function testLeftJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
@@ -37,7 +37,7 @@ function testLeftJoinedSegments() {
 
 function testLeftTransitiveJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -47,7 +47,7 @@ function testLeftTransitiveJoinedSegments() {
 
 function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined custom_world4_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -58,7 +58,7 @@ function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
 
 function testLeftPromotingSegmentWithConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -68,7 +68,7 @@ function testLeftPromotingSegmentWithConditionalPredecessor() {
 
 function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -79,7 +79,7 @@ function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
 
 function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined custom_world5_joined custom_world6_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined world5::custom::joined world6::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -92,7 +92,7 @@ function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
 
 function testLeftJoiningBuiltinSegmentWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(php_version php_version_joined)
+  P9K_LEFT_PROMPT_ELEMENTS=(php_version php_version::joined)
   alias php="echo PHP 1.2.3 "
   source segments/php_version/php_version.p9k
 
@@ -104,7 +104,7 @@ function testLeftJoiningBuiltinSegmentWorks() {
 function testRightNormalSegmentsShouldNotBeJoined() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3 custom_world4 custom_world5_joined custom_world6)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom world4::custom world5::custom::joined world6::custom)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -118,7 +118,7 @@ function testRightNormalSegmentsShouldNotBeJoined() {
 function testRightJoinedSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
@@ -128,7 +128,7 @@ function testRightJoinedSegments() {
 function testRightTransitiveJoinedSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -139,7 +139,7 @@ function testRightTransitiveJoinedSegments() {
 function testRightTransitiveJoiningWithConditionalJoinedSegment() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined custom_world4_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom::joined world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -151,7 +151,7 @@ function testRightTransitiveJoiningWithConditionalJoinedSegment() {
 function testRightPromotingSegmentWithConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
@@ -162,7 +162,7 @@ function testRightPromotingSegmentWithConditionalPredecessor() {
 function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -174,7 +174,7 @@ function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
 function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined custom_world5_joined custom_world6_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom::joined world4::custom::joined world5::custom::joined world6::custom::joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
@@ -188,7 +188,7 @@ function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
 function testRightJoiningBuiltinSegmentWorks() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(php_version php_version_joined)
+  P9K_RIGHT_PROMPT_ELEMENTS=(php_version php_version::joined)
   alias php="echo PHP 1.2.3"
   source segments/php_version/php_version.p9k
 

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -40,7 +40,7 @@ function testSegmentOnRightSide() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
 
@@ -54,7 +54,7 @@ function testDisablingRightPrompt() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
   local P9K_DISABLE_RPROMPT=true
@@ -66,7 +66,7 @@ function testDisablingRightPrompt() {
 
 function testLeftMultilinePrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_PROMPT_ON_NEWLINE=true
 
@@ -80,7 +80,7 @@ function testRightPromptOnSameLine() {
   # Reset RPROMPT, so a running P9K does not interfere with the test
   local RPROMPT=
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -94,7 +94,7 @@ function testRightPromptOnSameLine() {
 
 function testPrefixingFirstLineOnLeftPrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -109,7 +109,7 @@ function testPrefixingFirstLineOnLeftPrompt() {
 
 function testPrefixingSecondLineOnLeftPrompt() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   local P9K_PROMPT_ON_NEWLINE=true
@@ -128,8 +128,8 @@ function testCustomStartEndSymbolsOnEdgeSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD2='echo world2'
 
@@ -149,8 +149,8 @@ function testCustomWhitespaceOfSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -173,8 +173,8 @@ function testCustomWhitespaceOfLeftAndRightSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -199,8 +199,8 @@ function testCustomWhitespaceOfCustomSegments() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'
@@ -229,8 +229,8 @@ function testCustomWhitespaceWithIconOnLeft() {
   local RPROMPT=
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom world2::custom world3::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='{1}'
   local P9K_CUSTOM_WORLD2='echo world2'

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -17,7 +17,7 @@ function setUp() {
 function testOverwritingIconsWork() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -27,7 +27,7 @@ function testOverwritingIconsWork() {
 function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -37,7 +37,7 @@ function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
 function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_RIGHT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
@@ -47,7 +47,7 @@ function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
 function testVisualIdentifierPrintsNothingIfNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
 
   assertEquals "%K{015} %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -56,7 +56,7 @@ function testVisualIdentifierPrintsNothingIfNotAvailable() {
 function testVisualIdentifierWorksWithUnicodeIcon() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
+  P9K_LEFT_PROMPT_ELEMENTS=(world1::custom)
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='\u2714'
 

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -74,7 +74,7 @@ function testGetRelevantItemDoesNotReturnNotFoundItems() {
 
 function testSegmentShouldBeJoinedIfDirectPredecessingSegmentIsJoined() {
   typeset -a segments
-  segments=(a b_joined c_joined)
+  segments=(a b::joined c::joined)
   # Look at the third segment
   local current_index=3
   local last_element_index=2
@@ -88,7 +88,7 @@ function testSegmentShouldBeJoinedIfDirectPredecessingSegmentIsJoined() {
 
 function testSegmentShouldBeJoinedIfPredecessingSegmentIsJoinedTransitivley() {
   typeset -a segments
-  segments=(a b_joined c_joined)
+  segments=(a b::joined c::joined)
   # Look at the third segment
   local current_index=3
   # The last printed segment was the first one,
@@ -104,7 +104,7 @@ function testSegmentShouldBeJoinedIfPredecessingSegmentIsJoinedTransitivley() {
 
 function testSegmentShouldNotBeJoinedIfPredecessingSegmentIsNotJoinedButConditional() {
   typeset -a segments
-  segments=(a b_joined c d_joined)
+  segments=(a b::joined c d::joined)
   # Look at the fourth segment
   local current_index=4
   # The last printed segment was the first one,

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -26,7 +26,7 @@ function testUsingUnsetVariables() {
 
 function testJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir dir::joined)
   cd /tmp
 
   assertEquals "%K{004} %F{000}/tmp %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
@@ -36,7 +36,7 @@ function testJoinedSegments() {
 
 function testTransitiveJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator::joined dir::joined)
   source segments/root_indicator/root_indicator.p9k
   cd /tmp
 
@@ -47,7 +47,7 @@ function testTransitiveJoinedSegments() {
 
 function testJoiningWithConditionalSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir_joined)
+  local P9K_LEFT_PROMPT_ELEMENTS=(dir background_jobs dir::joined)
   source segments/background_jobs/background_jobs.p9k
   local jobs_running=0
   local jobs_suspended=0
@@ -130,7 +130,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_CUSTOM_RWORLD='echo rworld'
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -132,7 +132,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local -a P9K_RIGHT_PROMPT_ELEMENTS
-  local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(rworld::custom)
 
   __p9k_prepare_prompts
 

--- a/test/segments/custom.spec
+++ b/test/segments/custom.spec
@@ -16,7 +16,7 @@ function setUp() {
 
 function testCustomDirectOutputSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -24,7 +24,7 @@ function testCustomDirectOutputSegment() {
 
 function testCustomClosureSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   function p9k_hello_world() {
     echo "world"
   }
@@ -35,7 +35,7 @@ function testCustomClosureSegment() {
 
 function testSettingBackgroundForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_BACKGROUND="yellow"
 
@@ -44,7 +44,7 @@ function testSettingBackgroundForCustomSegment() {
 
 function testSettingForegroundForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_FOREGROUND="red"
 
@@ -53,7 +53,7 @@ function testSettingForegroundForCustomSegment() {
 
 function testSettingVisualIdentifierForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_ICON="hw"
 
@@ -62,7 +62,7 @@ function testSettingVisualIdentifierForCustomSegment() {
 
 function testSettingVisualIdentifierForegroundColorForCustomSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  P9K_LEFT_PROMPT_ELEMENTS=(world::custom)
   local P9K_CUSTOM_WORLD="echo world"
   local P9K_CUSTOM_WORLD_ICON="hw"
   local P9K_CUSTOM_WORLD_ICON_COLOR="red"


### PR DESCRIPTION
This is my fourth iteration on async functionality and adds such (currently based solely on ZSH-Async) to every segment that is tagged as `async`.

#### Preconditions
This branch is based on the `segment_tags` branch (#1171 ).

#### Caveat
This is still in a pretty raw stage. So don't expect everything to be working. I drafted this at an early stage, to get feedback as early as possible.

#### Todo
These things are still open:
- [ ] Avoid warning, if no segment is tagged as async, and therefore ZSH-Async is not loaded. This happens because `async_flush_jobs` and `async_worker_eval` are always called.
- [ ] Support other async methods. See https://github.com/agkozak/agkozak-zsh-prompt#asynchronous-methods
- [ ] Avoid old prompts being eaten up. This happens on my machine when a segment is async, and I just press enter.
- [ ] Make path to ZSH-Async configurable.
- [ ] Fix tests
- [ ] Fix `vi_mode` segment. This contains old code based on `generators/async.p9k`..
- [ ] Improve code structure. The clarity of the functions in `generator/default.p9k` could be improved..
- [ ] Every segment must report their metadata to the P9K engine. This is important as this example illustrates: If a segment is conditional and that condition is met if we enter a special directory, the cached data of the segment must be reset, if we leave the special directory.
So `p9k::prepare_segment` must always be called (we have to look on conditions enclosing `p9k::prepare_segment` and early `return` statements). This is already done for most of the segments, but not for all:
- - [ ] battery
- - [ ] nvm
- - [ ] rspec_stats
- - [ ] symfony2_tests
