### PR TITLE
[Enhancement] Only show rust version status when in a rust project directory or subdirectory

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1321,13 +1321,19 @@ prompt_root_indicator() {
 # Segment to display Rust version number
 prompt_rust_version() {
   local rust_version
+  local is_rust_dir
   rust_version=$(command rustc --version 2>/dev/null)
   # Remove "rustc " (including the whitespace) from the beginning
   # of the version string and remove everything after the next
   # whitespace. This way we'll end up with only the version.
   rust_version=${${rust_version/rustc /}%% *}
 
-  if [[ -n "$rust_version" ]]; then
+  # Attempts to retrieve project package id, writing `error:...`
+  # if Cargo.toml is not found in this dir or parent dirs
+  is_rust_dir=$(command cargo pkid 2>&1 | cut -c 1)
+
+  # If we have a rust version AND we're in a rust project folder (or subfolder)
+  if [[ -n "$rust_version" && "$is_rust_dir" != "e" ]]; then
     "$1_prompt_segment" "$0" "$2" "darkorange" "$DEFAULT_COLOR" "$rust_version" 'RUST_ICON'
   fi
 }


### PR DESCRIPTION
#### Only show rust status in a rust project folder
 
#### Description
 ![](https://i.imgur.com/A4dGmsg.png)

Similar to how the go information only displays when in a go source directory, rust info should only show up when in a rust project.
This leverages Rust's package manager Cargo. Specifically, it runs [cargo pkgid](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html) which would normally print the fully qualified package information of the current working directory's project. However, when not in a rust project and none of the parent directories contain `Cargo.toml` it prints `error:`. This simply checks if error was printed by Cargo and assumes we're not in a rust project because of it. 

#### Questions
1. I will need assistance with unit tests.
2. I'm not really sure if this is the right branch to merge onto (master to master) but it's a pretty small change
3. I'd like input on whether or not using Cargo as an underlying driver for this will work for the majority of people. Cargo is one of the best package managers I've used and most if not all rust users I know take advantage of it, meaning it's on their machines. However, this requires an outside tool and I'd understand if that would want to be avoided.