### PR TITLE
[Enhancement] variable to show chruby segment only if .ruby-version is readable

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1288,6 +1288,11 @@ prompt_rbenv() {
 # Segment to display chruby information
 # see https://github.com/postmodern/chruby/issues/245 for chruby_auto issue with ZSH
 prompt_chruby() {
+  set_default POWERLEVEL9K_CHRUBY_SHOW_DEFAULT true
+  if [[ "$POWERLEVEL9K_CHRUBY_SHOW_DEFAULT" == false ]] && ! [[ -r ".ruby-version" ]]; then
+    return
+  fi
+
   # Uses $RUBY_VERSION and $RUBY_ENGINE set by chruby
   set_default POWERLEVEL9K_CHRUBY_SHOW_VERSION true
   set_default POWERLEVEL9K_CHRUBY_SHOW_ENGINE true


### PR DESCRIPTION
#### Description

Currently the chruby segment activates only if it changes from the default.  This is problematic if a .zshrc sets a default chruby version and causes the segment to display all the time.

Here I've introduced the `POWERLEVEL9K_CHRUBY_SHOW_DEFAULT` variable that defaults to `true`, maintaining the existing functionality.  When set to `false`, the chruby segment only shows when the `.ruby-version` file is present and readable in the current directory.

#### Questions

My first PR here!  I see there are no existing tests for this segment, not sure if that is an issue.