### PR TITLE
 [Docs] Added doc for POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ systems without a battery). It is supported on both OSX and Linux (note that it 
 |`POWERLEVEL9K_BATTERY_LOW_THRESHOLD`|`10`|Threshold to consider battery level critical.|
 |`POWERLEVEL9K_BATTERY_LOW_COLOR`|`"red"`|Color to indicate critically low charge level.|
 |`POWERLEVEL9K_BATTERY_VERBOSE`|`true`|Display time remaining next to battery level.|
+|`POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD`|`unset`|Threshold from which the battery segment should not be displayed.|
 
 Note that you can [modify the `_FOREGROUND`
 color](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization)


### PR DESCRIPTION
####  [Docs] Added doc for POWERLEVEL9K_BATTERY_HIDE_ABOVE_THRESHOLD

#### Description
The option was not mentioned in the README.
Code was added in #830.

