### PR TITLE
[Enhancement] Adds option to periodically update time segment

### DIFF
--- a/segments/time/README.md
+++ b/segments/time/README.md
@@ -13,6 +13,8 @@ where you want to show this segment.
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`P9K_TIME_FORMAT`|`'H:M:S'`|ZSH time format to use in this segment.|
+|`P9K_TIME_REALTIME`|`false`|Enabling this option will update your prompt every `P9K_TIME_REALTIME_DELAY` seconds to display the current time. Note: This will trigger a `.reset-prompt` and can lead to side effects like history getting "stuck" or suggestions disappearing. |
+|`P9K_TIME_REALTIME_DELAY`|`60`|This only takes effect if `P9K_TIME_REALTIME` is `true` and is used to set the delay between updates.|
 
 As an example, if you wanted a reversed time format, you would use this:
 ```zsh

--- a/segments/time/time.p9k
+++ b/segments/time/time.p9k
@@ -13,6 +13,50 @@
   #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
   #                                                                                                            
   p9k::register_segment "TIME" "" "${DEFAULT_COLOR_INVERTED}" "${DEFAULT_COLOR}"  ''  $'\uE12E'  $'\uF017 '  $'\uF017 '  $'\uF017 '
+
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_TIME_FORMAT "%D{%H:%M:%S}"
+  p9k::set_default P9K_TIME_REALTIME false
+  p9k::set_default P9K_TIME_REALTIME_DELAY 60
+
+  ################################################################
+  # Register handler for realtime prompt resets
+  if [[ $P9K_TIME_REALTIME == true ]]; then
+    local fifo
+    fifo=$(mktemp -u "${TMPDIR:-/tmp}"/p9k.$$.pipe.time.XXXXXXXXXX)
+    typeset -giH __P9K_TIMER_FD=0
+    __p9k_start_timer() {
+      emulate -L zsh
+      setopt err_return
+      unsetopt bg_nice
+      mkfifo $fifo
+      exec {__P9K_TIMER_FD}<>$fifo
+      typeset -gfH __p9k_on_timer() {
+        # reset prompt on pipe update
+        emulate -L zsh
+        local _
+        IFS='' read -u $__P9K_TIMER_FD _ && zle && zle .reset-prompt
+      }
+      # register handler for created name pipe
+      zle -F $__P9K_TIMER_FD __p9k_on_timer
+      # start and disown a loop continuously writing to the pipe
+      # it will exit if shell is closed
+      zsh -c "while kill -0 $$; do
+                sleep $P9K_TIME_REALTIME_DELAY && echo
+              done" >&$__P9K_TIMER_FD 2>/dev/null &!
+    }
+    if ! __p9k_start_timer ; then
+      echo "powerlevel9k: failed to initialize realtime clock" >&2
+      if (( __P9K_TIMER_FD )); then
+        zle -F $__P9K_TIMER_FD
+        exec {__P9K_TIMER_FD}>&-
+      fi
+      unset __P9K_TIMER_FD
+      unset -f __p9k_on_timer
+    fi
+    rm -f "$fifo"
+  fi
 }
 
 ################################################################
@@ -25,7 +69,7 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_time() {
-  p9k::set_default P9K_TIME_FORMAT "%D{%H:%M:%S}"
-
+  # for performance increasments read this:
+  # https://github.com/romkatv/powerlevel10k/blob/0fa2f7ba65add69cb29149a6da8930c5179de1f7/powerlevel9k.zsh-theme#L1456
   p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_TIME_FORMAT"
 }


### PR DESCRIPTION
This implements #1190

Hey @romkatv,
porting your code was easy. Thank you! I do have some questions though.
1. You mentioned big git repos which would take time. I don't think this is the case on `next`. Please correct my if you think I'm wrong. `PROMPT` gets evaluated every time you redraw the prompt. On `master` `PROMPT` is something like `%f%b%k$(__p9k_build_left_prompt)`, on `next` it is `__p9k_unsafe_PROMPT`. This variable get filled in the precmd hook which is not called on `prompt-reset`. This was done to fix #1119 another problem but come is very handy.
2. Any ideas for how to test this?
3. I ran into some issues. Which lead to the notice in the README and a default delay of 60 seconds.
The issues are with going through the history and tab completion/suggestions. Example for weirdness:
This is how it should look:
![image](https://user-images.githubusercontent.com/16988672/54321821-ecdfc180-45f2-11e9-8eb2-47188b530827.png)
This is what happens:
![image](https://user-images.githubusercontent.com/16988672/54321945-7099ae00-45f3-11e9-9526-1464f4a22ebc.png)
~~I even had a segfault once doing this.~~ I can reproduce the segfault by `ls <tab><arrow-keys-especially-up>`
4. Changing keybinds
You mentioned that `zle-keymap-select` was a rude practice in #1190(?) Would you say the same about an option that would do this?
```zsh
renew-prompt-accept-line() {
    zle .reset-prompt
    zle accept-line
}
zle -N renew-prompt-accept-line
bindkey "^M" renew-prompt-accept-line
ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=renew-prompt-accept-line
```