### PR TITLE
[Enhancement] Updates to aws Segment to include region and delimiter

### DIFF
--- a/segments/aws/README.md
+++ b/segments/aws/README.md
@@ -11,13 +11,17 @@ where you want to show this segment.
 ## Configuration
 
 If you would like to display the [current AWS
-profile](http://docs.aws.amazon.com/cli/latest/userguide/installing.html), add
-the `aws` segment to one of the prompts, and define `AWS_DEFAULT_PROFILE` in
-your `~/.zshrc`:
+profile and region](http://docs.aws.amazon.com/cli/latest/userguide/installing.html), add
+the `aws` segment to one of the prompts, and define `P9K_AWS_DEFAULT_PROFILE` 
+(and optionally `AWS_DEFAULT_REGION`) in your `~/.zshrc`:
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|`AWS_DEFAULT_PROFILE`|None|Your AWS profile name|
+|`P9K_AWS_DEFAULT_PROFILE`|None|Your AWS profile name|
+|`AWS_DEFAULT_REGION`|None|Your AWS region|
+|`P9K_AWS_INCLUDE_PROFILE`|None|Show the current profile even if unset (`default`).|
+|`P9K_AWS_INCLUDE_REGION`|None|Show the current region, either from environment variable or awscli.|
+|`P9K_AWS_DELIMITER`|`/`|Delimiter to use between the AWS profile and region. This can be any string you choose, including an empty string if you wish to have no delimiter.|
 
 ### Color Customization
 

--- a/segments/aws/README.md
+++ b/segments/aws/README.md
@@ -21,7 +21,7 @@ the `aws` segment to one of the prompts, and define `P9K_AWS_DEFAULT_PROFILE`
 |`AWS_DEFAULT_REGION`|None|Your AWS region|
 |`P9K_AWS_INCLUDE_PROFILE`|None|Show the current profile even if unset (`default`).|
 |`P9K_AWS_INCLUDE_REGION`|None|Show the current region, either from environment variable or awscli.|
-|`P9K_AWS_DELIMITER`|`|`|Delimiter to use between the AWS profile and region. This can be any string you choose, including an empty string if you wish to have no delimiter.|
+|`P9K_AWS_DELIMITER`|`\|`|Delimiter to use between the AWS profile and region. This can be any string you choose, including an empty string if you wish to have no delimiter.|
 
 ### Color Customization
 

--- a/segments/aws/README.md
+++ b/segments/aws/README.md
@@ -21,7 +21,7 @@ the `aws` segment to one of the prompts, and define `P9K_AWS_DEFAULT_PROFILE`
 |`AWS_DEFAULT_REGION`|None|Your AWS region|
 |`P9K_AWS_INCLUDE_PROFILE`|None|Show the current profile even if unset (`default`).|
 |`P9K_AWS_INCLUDE_REGION`|None|Show the current region, either from environment variable or awscli.|
-|`P9K_AWS_DELIMITER`|`/`|Delimiter to use between the AWS profile and region. This can be any string you choose, including an empty string if you wish to have no delimiter.|
+|`P9K_AWS_DELIMITER`|`|`|Delimiter to use between the AWS profile and region. This can be any string you choose, including an empty string if you wish to have no delimiter.|
 
 ### Color Customization
 

--- a/segments/aws/aws.p9k
+++ b/segments/aws/aws.p9k
@@ -26,8 +26,27 @@
 ##
 prompt_aws() {
   local aws_profile="${AWS_PROFILE:-$P9K_AWS_DEFAULT_PROFILE}"
+  # If profile is not set by env and included, then set as "default"
+  if [[ -n "$P9K_AWS_INCLUDE_PROFILE" && -z "$aws_profile" ]]; then
+    local aws_profile="default"
+  fi
+
+  local aws_region="${AWS_REGION:-$AWS_DEFAULT_REGION}"
+  # If region is not set by env and awscli is installed, get region from awscli
+  if [[ -n "$P9K_AWS_INCLUDE_REGION" && -z "$aws_region" ]]; then
+    which aws > /dev/null 2>&1 
+    if [[ $? -eq 0 && -n "$aws_profile" ]]; then
+      local aws_region="$(aws --profile ${aws_profile} configure get region 2> /dev/null)"
+    fi
+  fi
+
+  if [[ -n "$aws_region" ]]; then
+    local aws_delimiter="${P9K_AWS_DELIMITER:-/}"
+  else
+    local aws_delimiter=""
+  fi
 
   if [[ -n "$aws_profile" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile$aws_delimiter$aws_region"
   fi
 }

--- a/segments/aws/aws.p9k
+++ b/segments/aws/aws.p9k
@@ -13,6 +13,7 @@
   #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
   #                                                                                                        
   p9k::register_segment 'AWS' '' red white 'AWS:'  $'\uE895'  $'\uF270'  '\u'${CODEPOINT_OF_AWESOME_AMAZON}  $'\uF270'
+  p9k::set_default P9K_AWS_DELIMITER "|"
 }
 
 ################################################################
@@ -41,9 +42,7 @@ prompt_aws() {
   fi
 
   if [[ -n "$aws_region" ]]; then
-    local aws_delimiter="${P9K_AWS_DELIMITER:-/}"
-  else
-    local aws_delimiter=""
+    local aws_delimiter="${P9K_AWS_DELIMITER:-|}"
   fi
 
   if [[ -n "$aws_profile" ]]; then


### PR DESCRIPTION
#### [Enhancement] Updates to aws Segment to include region and delimiter

#### Description

In the `aws` segment, optionally include the region with the profile and specify a delimiter to use between the two. Will pull region from environment variables or awscli configuration.

#### Questions

First PR here. Let me know if I need to do anything else.

I also could use some help to change the segment graphic to show the region.