### PR TITLE
fixes rbenv.p9k fails if specified local ruby version is not present

### DIFF
--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -32,7 +32,7 @@ prompt_rbenv() {
   if [[ -n "${RBENV_VERSION}" ]]; then
     p9k::prepare_segment "$0" "" $1 "$2" $3 "${RBENV_VERSION}"
   elif [ ${commands[rbenv]} ]; then
-    local rbenv_version_name="$(rbenv version-name)"
+    local rbenv_version_name="$(rbenv version-name 2>/dev/null || echo "($(rbenv local 2>/dev/null))")"
     local rbenv_global="$(rbenv global)"
     if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}"


### PR DESCRIPTION
I believe this should fix the same issue as #1197 in the `master` branch, but I can't actually test it, since several segments in the `next` branch are broken on my install, including `rbenv`.