### PR TITLE
adds *.zwc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test-vm/.vagrant
 *.swp
 .idea
+*.zwc


### PR DESCRIPTION
I have a zshexit hook that zcompiles every `*.p9k` file and some other zsh stuff.
To keep my git status clean I would like ignore `*.zwc` files.