### PR TITLE
[Enhancement] Refactor command_execution_time.p9k segment

### DIFF
--- a/segments/command_execution_time/command_execution_time.p9k
+++ b/segments/command_execution_time/command_execution_time.p9k
@@ -30,22 +30,21 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_command_execution_time() {
-  # Print time in human readable format
-  # For that use `strftime` and convert
-  # the duration (float) to an seconds
-  # (integer).
-  # See http://unix.stackexchange.com/a/89748
-  local humanReadableDuration
-  if (( _P9K_COMMAND_DURATION > 3600 )); then
-    humanReadableDuration=$(TZ=GMT; strftime '%H:%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
-  elif (( _P9K_COMMAND_DURATION > 60 )); then
-    humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
-  else
-    # If the command executed in seconds, round to desired precision and append "s"
-    humanReadableDuration=$(printf %.${P9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
-  fi
-
   if (( _P9K_COMMAND_DURATION >= P9K_COMMAND_EXECUTION_TIME_THRESHOLD )); then
+    # Print time in human readable format
+    # For that use `strftime` and convert
+    # the duration (float) to an seconds
+    # (integer).
+    # See http://unix.stackexchange.com/a/89748
+    local humanReadableDuration
+    if (( _P9K_COMMAND_DURATION > 3600 )); then
+      humanReadableDuration=$(TZ=GMT; strftime '%H:%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
+    elif (( _P9K_COMMAND_DURATION > 60 )); then
+      humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
+    else
+      # If the command executed in seconds, round to desired precision and append "s"
+      humanReadableDuration=$(printf %.${P9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
+    fi
     p9k::prepare_segment "$0" "" $1 "$2" $3 "${humanReadableDuration}"
   fi
 }

--- a/segments/command_execution_time/command_execution_time.p9k
+++ b/segments/command_execution_time/command_execution_time.p9k
@@ -41,16 +41,8 @@ prompt_command_execution_time() {
   elif (( _P9K_COMMAND_DURATION > 60 )); then
     humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
   else
-    # If the command executed in seconds, print as float.
-    # Convert to float
-    if [[ "${P9K_COMMAND_EXECUTION_TIME_PRECISION}" == "0" ]]; then
-      # If user does not want microseconds, then we need to convert
-      # the duration to an integer.
-      typeset -i humanReadableDuration
-    else
-      typeset -F ${P9K_COMMAND_EXECUTION_TIME_PRECISION} humanReadableDuration
-    fi
-    humanReadableDuration=$_P9K_COMMAND_DURATION
+    # If the command executed in seconds, round to desired precision and append "s"
+    humanReadableDuration=$(printf %.${P9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
   fi
 
   if (( _P9K_COMMAND_DURATION >= P9K_COMMAND_EXECUTION_TIME_THRESHOLD )); then

--- a/segments/command_execution_time/command_execution_time.spec
+++ b/segments/command_execution_time/command_execution_time.spec
@@ -61,7 +61,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=0
   local _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{001} %F{226}Dur %F{226}23s %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}24s %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() {

--- a/segments/command_execution_time/command_execution_time.spec
+++ b/segments/command_execution_time/command_execution_time.spec
@@ -33,7 +33,7 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   local _P9K_COMMAND_DURATION=2.03
 
-  assertEquals "%K{001} %F{226}Dur %F{226}2.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}2.03s %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeSetToZero() {
@@ -42,7 +42,7 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   local _P9K_COMMAND_DURATION=0.03
 
-  assertEquals "%K{001} %F{226}Dur %F{226}0.03 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}0.03s %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeChanged() {
@@ -52,7 +52,7 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=4
   local _P9K_COMMAND_DURATION=0.0001
 
-  assertEquals "%K{001} %F{226}Dur %F{226}0.0001 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}0.0001s %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeSetToZero() {
@@ -61,7 +61,7 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=0
   local _P9K_COMMAND_DURATION=23.5001
 
-  assertEquals "%K{001} %F{226}Dur %F{226}23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}23s %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() {


### PR DESCRIPTION
I wanted to add an "s" after the seconds display, in the case that the execution time was under a minute, to make it clearer what units were being displayed, when there were no colons. 

In the process of investigating this modification, I noticed that the code for formatting either whole or partial seconds (depending on the `P9K_COMMAND_EXECUTION_TIME_PRECISION` variable) seemed unnecessarily complex. By eliminating the pre-declaration of the number type and replacing it with a `printf` statement to format on the fly, I was able to squash a three-way `if`/`elif`/`else` control structure into a single line.

I also noticed that all this formatting was being done every time, regardless of whether the execution time actually exceeded the threshold, so I moved that logic to the front of the module, so that none of those computations happen if nothing will be displayed anyway.