### PR TITLE
[Enhancement] Refactor command_execution_time segment

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -745,16 +745,8 @@ prompt_command_execution_time() {
   elif (( _P9K_COMMAND_DURATION > 60 )); then
     humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
   else
-    # If the command executed in seconds, print as float.
-    # Convert to float
-    if [[ "${POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION}" == "0" ]]; then
-      # If user does not want microseconds, then we need to convert
-      # the duration to an integer.
-      typeset -i humanReadableDuration
-    else
-      typeset -F ${POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION} humanReadableDuration
-    fi
-    humanReadableDuration=$_P9K_COMMAND_DURATION
+    # If the command executed in seconds, round to desired precision and append "s"
+      humanReadableDuration=$(printf %.${POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
   fi
 
   if (( _P9K_COMMAND_DURATION >= POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD )); then

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -734,22 +734,21 @@ prompt_command_execution_time() {
   set_default POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD 3
   set_default POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION 2
 
-  # Print time in human readable format
-  # For that use `strftime` and convert
-  # the duration (float) to an seconds
-  # (integer).
-  # See http://unix.stackexchange.com/a/89748
-  local humanReadableDuration
-  if (( _P9K_COMMAND_DURATION > 3600 )); then
-    humanReadableDuration=$(TZ=GMT; strftime '%H:%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
-  elif (( _P9K_COMMAND_DURATION > 60 )); then
-    humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
-  else
-    # If the command executed in seconds, round to desired precision and append "s"
-      humanReadableDuration=$(printf %.${POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
-  fi
-
   if (( _P9K_COMMAND_DURATION >= POWERLEVEL9K_COMMAND_EXECUTION_TIME_THRESHOLD )); then
+    # Print time in human readable format
+    # For that use `strftime` and convert
+    # the duration (float) to an seconds
+    # (integer).
+    # See http://unix.stackexchange.com/a/89748
+    local humanReadableDuration
+    if (( _P9K_COMMAND_DURATION > 3600 )); then
+      humanReadableDuration=$(TZ=GMT; strftime '%H:%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
+    elif (( _P9K_COMMAND_DURATION > 60 )); then
+      humanReadableDuration=$(TZ=GMT; strftime '%M:%S' $(( int(rint(_P9K_COMMAND_DURATION)) )))
+    else
+      # If the command executed in seconds, round to desired precision and append "s"
+      humanReadableDuration=$(printf %.${POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
+    fi
     "$1_prompt_segment" "$0" "$2" "red" "yellow1" "${humanReadableDuration}" 'EXECUTION_TIME_ICON'
   fi
 }


### PR DESCRIPTION
This is a back-port of #1214 on the `next` branch.

I wanted to add an "s" after the seconds display, in the case that the execution time was under a minute, to make it clearer what units were being displayed, when there were no colons.

In the process of investigating this modification, I noticed that the code for formatting either whole or partial seconds (depending on the POWERLEVEL9K_COMMAND_EXECUTION_TIME_PRECISION variable) seemed unnecessarily complex. By eliminating the pre-declaration of the number type and replacing it with a printf statement to format on the fly, I was able to squash a three-way if/elif/else control structure into a single line.

I also noticed that all this formatting was being done every time, regardless of whether the execution time actually exceeded the threshold, so I moved that logic to the front of the module, so that none of those computations happen if nothing will be displayed anyway.