### PR TITLE
[Bugfix] Right-side prompt segments with an icon but no content double-print whitespace

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -182,8 +182,9 @@ function __p9k_right_prompt_segment() {
       || visual_identifier="${visual_identifier}${middle_ws}"
   fi
 
-  # Print whitespace only if segment is not joined or first right segment
-  [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && echo -n "${left_ws}"
+  # Print whitespace only if segment is not joined or first right segment,
+  # however, avoid double-printing whitespace if ${content} is empty
+  [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && [[ -n "${content}" ]] && echo -n "${left_ws}"
   # Print segment content and icon, if any
   [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
     && echo -n "${content}${visual_identifier}" \


### PR DESCRIPTION
When generating a right-side prompt segment that has an icon but no other content (like `status` in the `OK` state), whitespace is inserted both before and after this empty content, resulting in an extended prompt segment. When there is content, it looks fine, because there should be whitespace on both sides of the text:

<img width="939" alt="image" src="https://user-images.githubusercontent.com/2942518/54493862-e8ddc900-48aa-11e9-87e1-3bae98baff35.png">

(Showing `status` segment on both left and right for comparison.)

This fix modifies the logic in `default.p9k` for right-side prompt generation so that a second whitespace character is not inserted in the event of an empty `${content}` string. However, it leaves the previous bracketing whitespace intact if content exists:

<img width="937" alt="image" src="https://user-images.githubusercontent.com/2942518/54494066-d4023500-48ac-11e9-9eb1-60d78ebc4b03.png">