### PR TITLE
[Enhancement] Updates to kubecontext Segment to include a delimiter

### DIFF
--- a/segments/kubecontext/README.md
+++ b/segments/kubecontext/README.md
@@ -10,6 +10,10 @@ where you want to show this segment.
 
 ## Configuration
 
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`P9K_KUBECONTEXT_DELIMITER`|`\|`|Delimiter to use between the kubernetes context and namespace. This can be any string you choose, including an empty string if you wish to have no delimiter.|
 ### Color Customization
 
 You can change the foreground and background color of this segment by setting

--- a/segments/kubecontext/kubecontext.p9k
+++ b/segments/kubecontext/kubecontext.p9k
@@ -13,6 +13,7 @@
   #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
   #                                                        ⎈          ⎈         ⎈         ⎈         ⎈
   p9k::register_segment "KUBECONTEXT" "" "blue" "white" $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'  $'\u2388'
+  p9k::set_default P9K_KUBECONTEXT_DELIMITER "|"
 }
 
 ################################################################
@@ -42,7 +43,7 @@ prompt_kubecontext() {
       # No reason to print out the same identificator twice
       k8s_final_text="$cur_ctx"
     else
-      k8s_final_text="$cur_ctx/$cur_namespace"
+      k8s_final_text="$cur_ctx$P9K_KUBECONTEXT_DELIMITER$cur_namespace"
     fi
 
     p9k::prepare_segment "$0" "" $1 "$2" $3 "$k8s_final_text"

--- a/segments/kubecontext/kubecontext.spec
+++ b/segments/kubecontext/kubecontext.spec
@@ -73,7 +73,7 @@ function testKubeContext() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{004} %F{015}⎈ %F{015}minikube/default %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{015}⎈ %F{015}minikube|default %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -83,7 +83,7 @@ function testKubeContextOtherNamespace() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{004} %F{015}⎈ %F{015}minikube/kube-system %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{015}⎈ %F{015}minikube|kube-system %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl


### PR DESCRIPTION
#### [Enhancement] Updates to kubecontext Segment to include a delimiter

#### Description

In the `kubecontext` segment, specify a delimiter to use between the context and namespace.
