### PR TITLE
[Enhancement] adds ...PROJECT_ONLY option to node_version.p9k

### DIFF
--- a/segments/node_version/README.md
+++ b/segments/node_version/README.md
@@ -10,6 +10,16 @@ where you want to show this segment.
 
 ## Configuration
 
+### Segment Display
+
+By default, this segment is always shown. You can also choose to have it 
+displayed only when inside of a Node project by setting
+```
+P9K_NODE_VERSION_PROJECT_ONLY=true
+```
+The current directory and its ancestors will be searched for a `project.json` 
+file, and the segment will only be displayed if one is located before `/`.
+
 ### Color Customization
 
 You can change the foreground and background color of this segment by setting

--- a/segments/node_version/node_version.p9k
+++ b/segments/node_version/node_version.p9k
@@ -24,9 +24,33 @@
 #   $2 integer Segment index
 #   $3 boolean Whether the segment should be joined
 ##
+p9k::set_default P9K_NODE_VERSION_PROJECT_ONLY=false
 prompt_node_version() {
-  local node_version=$(node -v 2>/dev/null)
-  [[ -z "${node_version}" ]] && return
+  if [ "$P9K_NODE_VERSION_PROJECT_ONLY" = true ] ; then
+    local foundProject=false # Variable to stop searching if a project is found
+    local currentDir=$(pwd)  # Variable to iterate through the path ancestry tree
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${node_version:1}"
+    # Search as long as no project could been found or until the root directory 
+    # has been reached
+    while [ "$foundProject" = false -a ! "$currentDir" = "/" ] ; do
+      # Check if directory contains a project description
+      if [[ -e "$currentDir/package.json" ]] ; then
+        foundProject=true
+        break
+      fi
+      # Go to the parent directory
+      currentDir="$(dirname "$currentDir")"
+    done
+  fi
+
+  # Show version if a project has been found, or set to always show
+  if [ "$P9K_NODE_VERSION_PROJECT_ONLY" != true -o "$foundProject" = true ] ; then
+    # Get the node version
+    local node_version=$(node -v 2>/dev/null)
+
+    # Return if node is not installed
+    [[ -z "${node_version}" ]] && return
+
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${node_version:1}"
+  fi
 }

--- a/segments/node_version/node_version.spec
+++ b/segments/node_version/node_version.spec
@@ -5,19 +5,56 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
-function setUp() {
+function oneTimeSetUp() {
   export TERM="xterm-256color"
-  local -a P9K_RIGHT_PROMPT_ELEMENTS
-  P9K_RIGHT_PROMPT_ELEMENTS=()
+
+  OLDPATH="${PATH}"
+  PATH="${NODE_VERSION_TEST_FOLDER}:${PATH}"
+  
+  OLD_DIR="${PWD}"
+
+  TEST_BASE_FOLDER="/tmp/powerlevel9k-test"
+  NODE_VERSION_TEST_FOLDER="${TEST_BASE_FOLDER}/node_version-test"
+
+  node() {
+    echo "v1.2.3"
+  }
+}
+
+function setUp() {
   # Load Powerlevel9k
-  source powerlevel9k.zsh-theme
-  source segments/node_version/node_version.p9k
+  source "${OLD_DIR}/powerlevel9k.zsh-theme"
+  source "${OLD_DIR}/segments/node_version/node_version.p9k"
+
+  P9K_LEFT_PROMPT_ELEMENTS=(node_version)
+  P9K_RIGHT_PROMPT_ELEMENTS=()
+
+  mkdir -p "${NODE_VERSION_TEST_FOLDER}"
+  cd "${NODE_VERSION_TEST_FOLDER}"
+}
+
+function tearDown() {
+  cd "${OLD_DIR}"
+  rm -rf "${NODE_VERSION_TEST_FOLDER}"
+}
+
+function oneTimeTearDown() {
+  PATH="${OLDPATH}"
+
+  cd "${OLD_DIR}"
+  rm -rf "${TEST_BASE_FOLDER}"
+}
+
+function testNodeVersionSegmentWorks() {
+  P9K_NODE_VERSION_PROJECT_ONLY=false
+  
+  assertEquals "%K{002} %F{015}⬢ %F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNodeVersionSegmentPrintsNothingWithoutNode() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(node_version custom_world)
   local P9K_CUSTOM_WORLD='echo world'
+  
   alias node="nonode 2>/dev/null"
 
   assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
@@ -25,16 +62,36 @@ function testNodeVersionSegmentPrintsNothingWithoutNode() {
   unalias node
 }
 
-function testNodeVersionSegmentWorks() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
-  P9K_LEFT_PROMPT_ELEMENTS=(node_version)
-  node() {
-    echo "v1.2.3"
-  }
+function testNodeVersionSegmentProjectOnlyPrintsNothingOutsideProjectDirectory() {
+  P9K_LEFT_PROMPT_ELEMENTS=(node_version custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+
+  P9K_NODE_VERSION_PROJECT_ONLY=true
+  
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+}
+
+function testNodeVersionSegmentProjectOnlyWorksInsideProjectDirectory() {
+  P9K_NODE_VERSION_PROJECT_ONLY=true
+
+  touch ./package.json
 
   assertEquals "%K{002} %F{015}⬢ %F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
-  unfunction node
+  rm ./package.json
+}
+
+function testNodeVersionSegmentProjectOnlyWorksInsideProjectChildDirectory() {
+  P9K_NODE_VERSION_PROJECT_ONLY=true
+
+  touch ./package.json
+  mkdir test-child
+  cd test-child
+
+  assertEquals "%K{002} %F{015}⬢ %F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  
+  cd ..
+  rm ./package.json
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
This is a port of @weilbith's #760, updated for the `v0.7.0`+ branch, with docs and tests added. It works identically to his description in the previous PR, and is described in [`README.md`](https://github.com/ChrisBaker97/powerlevel9k/blob/db3bfbf31563bae183fbda58627fafa00e5d4212/segments/node_version/README.md#segment-display).

tl;dr: A new environment variable `P9K_NODE_VERSION_PROJECT_ONLY` defaults to `false`. When set to `true`, it will mute the `node_version` segment unless a `package.json` file is located in a search of the current directory or one of its ancestors, prior to reaching `/`.