### PR TITLE
[Bugfix] Hide kubecontext prompt if there is no current context

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1696,6 +1696,10 @@ prompt_kubecontext() {
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kuberenetes context
     local cur_ctx=$(kubectl config view -o=jsonpath='{.current-context}')
+    if [[ -z "${cur_ctx}" ]]; then
+      return
+    fi
+    
     cur_namespace="$(kubectl config view -o=jsonpath="{.contexts[?(@.name==\"${cur_ctx}\")].context.namespace}")"
     # If the namespace comes back empty set it default.
     if [[ -z "${cur_namespace}" ]]; then


### PR DESCRIPTION
This hides the kubecontext prompt if there is no current context set in `~/.kube/config`. Essentially, this prevents a namespace from being shown all on its own.

**BEFORE this PR - no context set:**
![image](https://user-images.githubusercontent.com/900469/54614290-45f69c00-4ab0-11e9-98da-6a54a0c036fa.png)

**AFTER this PR - no context set:**
![image](https://user-images.githubusercontent.com/900469/54614314-4db64080-4ab0-11e9-8db2-98abfd1eb934.png)

**BEFORE & AFTER this PR (i.e. no change) - context set:**
![image](https://user-images.githubusercontent.com/900469/54614361-61fa3d80-4ab0-11e9-999d-e8cd7a26ffc9.png)
