### PR TITLE
[Bugfix] Ensure that vcs init is invoked when using the "vcs_joined" segment. 

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -202,11 +202,10 @@ fi
 #    * $1: The segment to be tested.
 segment_in_use() {
     local key=$1
-    if [[ -n "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[(r)$key]}" ]] || [[ -n "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[(r)$key]}" ]]; then
-        return 0
-    else
-        return 1
-    fi
+    [[ -n "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[(r)${key}]}" ||
+     -n "${POWERLEVEL9K_LEFT_PROMPT_ELEMENTS[(r)${key}_joined]}" ||
+     -n "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[(r)${key}]}" ||
+     -n "${POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS[(r)${key}_joined]}" ]]
 }
 
 # Print a deprecation warning if an old segment is in use.

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1910,7 +1910,7 @@ prompt_powerlevel9k_setup() {
   # initialize colors
   autoload -U colors && colors
 
-  if segment_in_use "vcs" || segment_in_use "vcs_joined"; then
+  if segment_in_use "vcs"; then
     powerlevel9k_vcs_init
   fi
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1910,7 +1910,7 @@ prompt_powerlevel9k_setup() {
   # initialize colors
   autoload -U colors && colors
 
-  if segment_in_use "vcs"; then
+  if segment_in_use "vcs" || segment_in_use "vcs_joined"; then
     powerlevel9k_vcs_init
   fi
 


### PR DESCRIPTION
#### [Bugfix] Ensure that vcs init is invoked when using the "vcs_joined" segment. 

This pull request resolves the `prompt_vcs:6: command not found: vcs_info` error that occurs when using the `vcs_joined` segment in place of the `vcs` segment. Fixes #1116.