### PR TITLE
Fix remote icon detection

### DIFF
--- a/segments/vcs/README.md
+++ b/segments/vcs/README.md
@@ -27,7 +27,7 @@ customization is provided via:
 |`P9K_VCS_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
 |`P9K_VCS_SHOW_SUBMODULE_DIRTY`|`true`|Set to `false` to not reflect submodule status in the top-level repository prompt.|
 |`P9K_VCS_HIDE_TAGS`|`false`|Set to `true` to stop tags being displayed in the segment.|
-|`P9K_VCS_GIT_HOOKS`|`(vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)`|Layout of the segment for git repositories.|
+|`P9K_VCS_GIT_HOOKS`|`(vcs-detect-changes vcs-remote-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)`|Layout of the segment for git repositories.|
 |`P9K_VCS_HG_HOOKS`|`(vcs-detect-changes)`|Layout of the segment for Mercurial repositories.|
 |`P9K_VCS_SVN_HOOKS`|`(vcs-detect-changes svn-detect-changes)`|Layout of the segment for SVN repositories.|
 |`P9K_VCS_ACTIONFORMAT_FOREGROUND`|`red`|The color of the foreground font during actions (e.g., `REBASE`).|
@@ -93,6 +93,7 @@ Git hooks (`P9K_VCS_GIT_HOOKS`):
 | Hook               | Description
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
+| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
 | git-untracked      | Check for untracked files. |
 | git-aheadbehind    | Check for commits ahead/behind the repo. This does not request changes from the remote repo. Only interacts with the local repo. |
 | git-stash          | Check for stashes. |
@@ -105,6 +106,7 @@ Mercurial hooks (`P9K_VCS_HG_HOOKS`):
 | Hook               | Description
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
+| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
 | hg-branch          | Escape special characters in branch name. |
 | hg-bookmarks       | Check for Mercurial Bookmarks. |
 
@@ -114,6 +116,7 @@ SVN hooks (`P9K_VCS_SVN_HOOKS`):
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
 | svn-detect-changes | Check for staged/unstaged changes in your SVN checkout. |
+| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
 
 ### Color Customization
 

--- a/segments/vcs/README.md
+++ b/segments/vcs/README.md
@@ -27,7 +27,7 @@ customization is provided via:
 |`P9K_VCS_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
 |`P9K_VCS_SHOW_SUBMODULE_DIRTY`|`true`|Set to `false` to not reflect submodule status in the top-level repository prompt.|
 |`P9K_VCS_HIDE_TAGS`|`false`|Set to `true` to stop tags being displayed in the segment.|
-|`P9K_VCS_GIT_HOOKS`|`(vcs-detect-changes vcs-remote-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)`|Layout of the segment for git repositories.|
+|`P9K_VCS_GIT_HOOKS`|`(vcs-detect-changes vcs-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)`|Layout of the segment for git repositories.|
 |`P9K_VCS_HG_HOOKS`|`(vcs-detect-changes)`|Layout of the segment for Mercurial repositories.|
 |`P9K_VCS_SVN_HOOKS`|`(vcs-detect-changes svn-detect-changes)`|Layout of the segment for SVN repositories.|
 |`P9K_VCS_ACTIONFORMAT_FOREGROUND`|`red`|The color of the foreground font during actions (e.g., `REBASE`).|
@@ -93,7 +93,7 @@ Git hooks (`P9K_VCS_GIT_HOOKS`):
 | Hook               | Description
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
-| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
+| vcs-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. If no remote given, it uses the default icon from `P9K_VCS_GIT_ICON`. |
 | git-untracked      | Check for untracked files. |
 | git-aheadbehind    | Check for commits ahead/behind the repo. This does not request changes from the remote repo. Only interacts with the local repo. |
 | git-stash          | Check for stashes. |
@@ -106,7 +106,7 @@ Mercurial hooks (`P9K_VCS_HG_HOOKS`):
 | Hook               | Description
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
-| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
+| vcs-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. If no remote given, it uses the default icon from `P9K_VCS_HG_ICON`. |
 | hg-branch          | Escape special characters in branch name. |
 | hg-bookmarks       | Check for Mercurial Bookmarks. |
 
@@ -116,7 +116,7 @@ SVN hooks (`P9K_VCS_SVN_HOOKS`):
 |--------------------|----------------------------------------------------|
 | vcs-detect-changes | General check for changed files and responsible for selecting a proper icon according to the remote url. |
 | svn-detect-changes | Check for staged/unstaged changes in your SVN checkout. |
-| vcs-remote-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. |
+| vcs-icon | Detects the icon base on the remote url. E.g. shows the Github icon for a repository cloned from Github. If no remote given, it uses the default icon from `P9K_VCS_SVN_ICON`. |
 
 ### Color Customization
 

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -292,7 +292,7 @@ function +vi-vcs-detect-changes() {
   fi
 }
 
-function +vi-vcs-remote-icon() {
+function +vi-vcs-icon() {
   local remote
   if [[ "${hook_com[vcs]}" == "git" ]]; then
     remote=$(command git ls-remote --get-url 2> /dev/null)
@@ -389,11 +389,11 @@ __p9k_vcs_init() {
   # Hooks are places in vcs_info where you can run your own code. That code can communicate with the code that called it and through that, change the system’s behaviour.
   # For configuration, hooks change the style context:
   #   :vcs_info:vcs-string+hook-name:user-context:repo-root-name
-  p9k::defined P9K_VCS_GIT_HOOKS || P9K_VCS_GIT_HOOKS=(vcs-detect-changes vcs-remote-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)
+  p9k::defined P9K_VCS_GIT_HOOKS || P9K_VCS_GIT_HOOKS=(vcs-detect-changes vcs-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)
   zstyle ':vcs_info:git*+set-message:*' hooks ${P9K_VCS_GIT_HOOKS}
-  p9k::defined P9K_VCS_HG_HOOKS || P9K_VCS_HG_HOOKS=(vcs-detect-changes vcs-remote-icon hg-branch)
+  p9k::defined P9K_VCS_HG_HOOKS || P9K_VCS_HG_HOOKS=(vcs-detect-changes vcs-icon hg-branch)
   zstyle ':vcs_info:hg*+set-message:*' hooks ${P9K_VCS_HG_HOOKS}
-  p9k::defined P9K_VCS_SVN_HOOKS || P9K_VCS_SVN_HOOKS=(vcs-detect-changes vcs-remote-icon svn-detect-changes)
+  p9k::defined P9K_VCS_SVN_HOOKS || P9K_VCS_SVN_HOOKS=(vcs-detect-changes vcs-icon svn-detect-changes)
   zstyle ':vcs_info:svn*+set-message:*' hooks ${P9K_VCS_SVN_HOOKS}
 
   # For Hg, only show the branch name

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -285,6 +285,14 @@ function +vi-hg-bookmarks() {
 }
 
 function +vi-vcs-detect-changes() {
+  if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
+    VCS_WORKDIR_DIRTY=true
+  else
+    VCS_WORKDIR_DIRTY=false
+  fi
+}
+
+function +vi-vcs-remote-icon() {
   if [[ "${hook_com[vcs]}" == "git" ]]; then
 
     local remote=$(command git ls-remote --get-url 2> /dev/null)
@@ -304,12 +312,6 @@ function +vi-vcs-detect-changes() {
     vcs_segment_icon=${__P9K_ICONS[VCS_HG]}
   elif [[ "${hook_com[vcs]}" == "svn" ]]; then
     vcs_segment_icon=${__P9K_ICONS[VCS_SVN]}
-  fi
-
-  if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
-    VCS_WORKDIR_DIRTY=true
-  else
-    VCS_WORKDIR_DIRTY=false
   fi
 }
 
@@ -386,11 +388,11 @@ __p9k_vcs_init() {
   # Hooks are places in vcs_info where you can run your own code. That code can communicate with the code that called it and through that, change the system’s behaviour.
   # For configuration, hooks change the style context:
   #   :vcs_info:vcs-string+hook-name:user-context:repo-root-name
-  p9k::defined P9K_VCS_GIT_HOOKS || P9K_VCS_GIT_HOOKS=(vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)
+  p9k::defined P9K_VCS_GIT_HOOKS || P9K_VCS_GIT_HOOKS=(vcs-detect-changes vcs-remote-icon git-untracked git-aheadbehind git-stash git-remotebranch git-gitdir git-tagname)
   zstyle ':vcs_info:git*+set-message:*' hooks ${P9K_VCS_GIT_HOOKS}
-  p9k::defined P9K_VCS_HG_HOOKS || P9K_VCS_HG_HOOKS=(vcs-detect-changes hg-branch)
+  p9k::defined P9K_VCS_HG_HOOKS || P9K_VCS_HG_HOOKS=(vcs-detect-changes vcs-remote-icon hg-branch)
   zstyle ':vcs_info:hg*+set-message:*' hooks ${P9K_VCS_HG_HOOKS}
-  p9k::defined P9K_VCS_SVN_HOOKS || P9K_VCS_SVN_HOOKS=(vcs-detect-changes svn-detect-changes)
+  p9k::defined P9K_VCS_SVN_HOOKS || P9K_VCS_SVN_HOOKS=(vcs-detect-changes vcs-remote-icon svn-detect-changes)
   zstyle ':vcs_info:svn*+set-message:*' hooks ${P9K_VCS_SVN_HOOKS}
 
   # For Hg, only show the branch name

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -301,7 +301,7 @@ function +vi-vcs-icon() {
     remote=$(command hg paths default)
     vcs_segment_icon=${__P9K_ICONS[VCS_HG]}
   elif [[ "${hook_com[vcs]}" == "svn" ]]; then
-    remote="${svninfo[URL]}"
+    remote="${svninfo[URL]}" # Set by VCS_INFO
     vcs_segment_icon=${__P9K_ICONS[VCS_SVN]}
   fi
 

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -293,25 +293,26 @@ function +vi-vcs-detect-changes() {
 }
 
 function +vi-vcs-remote-icon() {
+  local remote
   if [[ "${hook_com[vcs]}" == "git" ]]; then
-
-    local remote=$(command git ls-remote --get-url 2> /dev/null)
-    if [[ "$remote" =~ "github" ]] then
-      vcs_segment_icon=${__P9K_ICONS[VCS_GIT_GITHUB]}
-    elif [[ "$remote" =~ "bitbucket" ]] then
-      vcs_segment_icon=${__P9K_ICONS[VCS_GIT_BITBUCKET]}
-    elif [[ "$remote" =~ "stash" ]] then
-      vcs_segment_icon=${__P9K_ICONS[VCS_GIT_BITBUCKET]}
-    elif [[ "$remote" =~ "gitlab" ]] then
-      vcs_segment_icon=${__P9K_ICONS[VCS_GIT_GITLAB]}
-    else
-      vcs_segment_icon=${__P9K_ICONS[VCS_GIT]}
-    fi
-
+    remote=$(command git ls-remote --get-url 2> /dev/null)
+    vcs_segment_icon=${__P9K_ICONS[VCS_GIT]}
   elif [[ "${hook_com[vcs]}" == "hg" ]]; then
+    remote=$(command hg paths default)
     vcs_segment_icon=${__P9K_ICONS[VCS_HG]}
   elif [[ "${hook_com[vcs]}" == "svn" ]]; then
+    remote="${svninfo[URL]}"
     vcs_segment_icon=${__P9K_ICONS[VCS_SVN]}
+  fi
+
+  if [[ "$remote" =~ "github" ]] then
+    vcs_segment_icon=${__P9K_ICONS[VCS_GIT_GITHUB]}
+  elif [[ "$remote" =~ "bitbucket" ]] then
+    vcs_segment_icon=${__P9K_ICONS[VCS_GIT_BITBUCKET]}
+  elif [[ "$remote" =~ "stash" ]] then
+    vcs_segment_icon=${__P9K_ICONS[VCS_GIT_BITBUCKET]}
+  elif [[ "$remote" =~ "gitlab" ]] then
+    vcs_segment_icon=${__P9K_ICONS[VCS_GIT_GITLAB]}
   fi
 }
 


### PR DESCRIPTION
This adds a new hook `vcs-icon`, that sets the icon based on the VCS used and the remote URL.

Fixes #1207 