### PR TITLE
Improve show_defined_icons

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -219,5 +219,5 @@ function p9k::print_icon() {
 ##
 function show_defined_icons() {
   # changed (kv) to (k) in case there are empty keys, which causes the printing to be done wrong
-  for k in ${(k)__P9K_ICONS}; do; echo "${k} -> '${__P9K_ICONS[$k]}'"; done | sort
+  for k in ${(k)__P9K_ICONS}; do; echo "P9K_${k}_ICON -> '${__P9K_ICONS[$k]}'"; done | sort
 }

--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -219,5 +219,8 @@ function p9k::print_icon() {
 ##
 function show_defined_icons() {
   # changed (kv) to (k) in case there are empty keys, which causes the printing to be done wrong
+  print "You can copy these variables to your ~/.zshrc and modify them to your needs."
+  print -P "Know that the variable definition %F{red}must be written before the theme is sourced%f!"
+  print
   for k in ${(k)__P9K_ICONS}; do; echo "P9K_${k}_ICON -> '${__P9K_ICONS[$k]}'"; done | sort
 }


### PR DESCRIPTION
`show_defined_icons` prints out all defined icons. Before, it just printed the internal name, which was not very helpful to users. Now it prints the copy&paste ready variable name plus a info on how to use these variable overrides.