### PR TITLE
[Enhancement & Bug?] Better P9K_VPN_IP_INTERFACE default

### DIFF
--- a/segments/vpn_ip/vpn_ip.p9k
+++ b/segments/vpn_ip/vpn_ip.p9k
@@ -16,7 +16,7 @@
 
   ################################################################
   # Register segment default values
-  p9k::set_default P9K_VPN_IP_INTERFACE "tun"
+  p9k::set_default P9K_VPN_IP_INTERFACE "tun[^ ]*"
 }
 
 ################################################################


### PR DESCRIPTION
This is a small change to also register interfaces that are not just `tun` but also every interface that starts with "tun".

I do have another problem though:
My non-active VPN interface (`tap0`) is `UP` and my actually working VPN (`tun0`) ins `UNKNOWN`.
`p9k::parseIp` currently needs the interface to be `UP`. This breaks the segment for me atm.

```zsh
❯ /sbin/ip -brief -4 a show
lo               UNKNOWN        127.0.0.1/8 
wlp42s0          UP             10.4.5.6/24 
tap0             UP             10.3.4.5/24 
docker0          DOWN           10.2.3.4/27 
tun0             UNKNOWN        10.1.2.3/32 
```