### PR TITLE
[Bugfix] Makes `P9K_BATTERY_LEVEL_BACKGROUND` and `P9K_BATTERY_STAGES` usable separately

### DIFF
--- a/segments/battery/battery.p9k
+++ b/segments/battery/battery.p9k
@@ -211,8 +211,7 @@ prompt_battery() {
     segment=$(( 100.0 / (${#P9K_BATTERY_STAGES} - 1 ) ))
     if [[ ${segment} > 1 ]]; then
       offset=$(( (${bat_percent} / $segment) ))
-      # check if the stages are in an array or a string
-      [[ "${(t)P9K_BATTERY_STAGES}" =~ "array" ]] && overideIcon="$P9K_BATTERY_STAGES[$offset]" || overideIcon="${P9K_BATTERY_STAGES:$offset:1}"
+      overideIcon="${P9K_BATTERY_STAGES[((offset + 1))]}"
     fi
   fi
 

--- a/segments/battery/battery.p9k
+++ b/segments/battery/battery.p9k
@@ -210,8 +210,8 @@ prompt_battery() {
   if [[ -n "$P9K_BATTERY_STAGES" ]]; then
     segment=$(( 100.0 / (${#P9K_BATTERY_STAGES} - 1 ) ))
     if [[ ${segment} > 1 ]]; then
-      offset=$(( (${bat_percent} / $segment) ))
-      overideIcon="${P9K_BATTERY_STAGES[((offset + 1))]}"
+      offset=$(( (${bat_percent} / $segment) + 1 ))
+      overideIcon="${P9K_BATTERY_STAGES[$offset]}"
     fi
   fi
 

--- a/segments/battery/battery.p9k
+++ b/segments/battery/battery.p9k
@@ -206,25 +206,24 @@ prompt_battery() {
   # override default icon if we are using battery stages
   local overideIcon="" overideBg="" segment
   declare -i offset
-  if [[ -n "$P9K_BATTERY_STAGES" ]] && [[ -n "$P9K_BATTERY_LEVEL_BACKGROUND" ]]; then
-    # override default icon if we are using battery stages
-    if [[ -n "$P9K_BATTERY_STAGES" ]]; then
-      segment=$(( 100.0 / (${#P9K_BATTERY_STAGES} - 1 ) ))
-      if [[ ${segment} > 1 ]]; then
-        offset=$(( (${bat_percent} / $segment) ))
-        # check if the stages are in an array or a string
-        [[ "${(t)P9K_BATTERY_STAGES}" =~ "array" ]] && overideIcon="$P9K_BATTERY_STAGES[$offset]" || overideIcon="${P9K_BATTERY_STAGES:$offset:1}"
-      fi
-    fi
-
-    # override the default color if we are using a color level array
-    if [[ -n "$P9K_BATTERY_LEVEL_BACKGROUND" ]] && [[ "${(t)P9K_BATTERY_LEVEL_BACKGROUND}" =~ "array" ]]; then
-      segment=$(( 100.0 / (${#P9K_BATTERY_LEVEL_BACKGROUND} - 1 ) ))
-      offset=$(( (${bat_percent} / $segment) + 1 ))
-      overideBg="$(p9k::background_color ${P9K_BATTERY_LEVEL_BACKGROUND[$offset]})"
+  # override default icon if we are using battery stages
+  if [[ -n "$P9K_BATTERY_STAGES" ]]; then
+    segment=$(( 100.0 / (${#P9K_BATTERY_STAGES} - 1 ) ))
+    if [[ ${segment} > 1 ]]; then
+      offset=$(( (${bat_percent} / $segment) ))
+      # check if the stages are in an array or a string
+      [[ "${(t)P9K_BATTERY_STAGES}" =~ "array" ]] && overideIcon="$P9K_BATTERY_STAGES[$offset]" || overideIcon="${P9K_BATTERY_STAGES:$offset:1}"
     fi
   fi
+
+  # override the default color if we are using a color level array
+  if [[ -n "$P9K_BATTERY_LEVEL_BACKGROUND" ]] && [[ "${(t)P9K_BATTERY_LEVEL_BACKGROUND}" =~ "array" ]]; then
+    segment=$(( 100.0 / (${#P9K_BATTERY_LEVEL_BACKGROUND} - 1 ) ))
+    offset=$(( (${bat_percent} / $segment) + 1 ))
+    overideBg="$(p9k::background_color ${P9K_BATTERY_LEVEL_BACKGROUND[$offset]})"
+  fi
   unset offset
+
   # Draw the prompt_segment
   p9k::prepare_segment "$0" "${(U)current_state}" $1 "$2" $3 "${message}" "" "${overideIcon}" "${overideBg}"
 }

--- a/segments/battery/battery.spec
+++ b/segments/battery/battery.spec
@@ -307,4 +307,46 @@ function testBatterySegmentIfBatteryIsCalculatingOnWindows() {
   assertEquals "%K{000} %F{003}🔋 %F{003}99%% (...) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
+function testBatteryStagesString() {
+  # as long as the percentages is ok (other tests),
+  # the P9K_BATTERY_STAGES tests should be independent of OS type
+  local __P9K_OS='Linux'
+  P9K_BATTERY_STAGES="abcde"
+
+  makeBatterySay "1" "Charging"
+  assertEquals "%K{000} %F{003}a %F{003}1%% (2:18) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "26" "Charging"
+  assertEquals "%K{000} %F{003}b %F{003}26%% (1:43) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "52" "Charging"
+  assertEquals "%K{000} %F{003}c %F{003}52%% (1:07) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "99" "Charging"
+  assertEquals "%K{000} %F{003}d %F{003}99%% (0:01) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "100" "Full"
+  assertEquals "%K{000} %F{002}e %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+}
+
+function testBatteryStagesArray() {
+  local __P9K_OS='Linux'
+  P9K_BATTERY_STAGES=("charge!" "low" "med" "high" "full")
+
+  makeBatterySay "1" "Charging"
+  assertEquals "%K{000} %F{003}charge! %F{003}1%% (2:18) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "26" "Charging"
+  assertEquals "%K{000} %F{003}low %F{003}26%% (1:43) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "52" "Charging"
+  assertEquals "%K{000} %F{003}med %F{003}52%% (1:07) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "99" "Charging"
+  assertEquals "%K{000} %F{003}high %F{003}99%% (0:01) " "$(prompt_battery left 1 false ${FOLDER})"
+
+  makeBatterySay "100" "Full"
+  assertEquals "%K{000} %F{002}full %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
This merely removes the extra checking for `P9K_BATTERY_LEVEL_BACKGROUND` AND `P9K_BATTERY_STAGES` being set at the same time. ([here](https://github.com/bhilburn/powerlevel9k/compare/next...Syphdias:batter-stages#diff-972d8453b66adcec8415788a9f7aa1d7L209))

The variables are checked independently anyway since the features are independent.
Fixes #1245