### PR TITLE
Fix prompt status error

### DIFF
--- a/segments/status/status.p9k
+++ b/segments/status/status.p9k
@@ -62,7 +62,7 @@ prompt_status() {
 
     for ec in "${(@)RETVALS[2,-1]}"; do
       ec_text="${ec_text}|$(exit_code_or_status "$ec")"
-      ec_sum=$(( $ec_sum + $ec ))
+      ec_sum=$(( ${ec_sum:-0} + ${ec:-0} ))
     done
   else
     # We use RETVAL instead of the right-most RETVALS item because


### PR DESCRIPTION
#### Fix prompt_status error message - [Bugfix]

#### Description

I pull this plugin from the `next` branch (for the new features it provides). Recently I've noticed that my local machine shows the following error on startup:

```
prompt_status:16: bad math expression: operand expected at end of string
```

Looking into it, it seems like both the `ec` and the `ec_sum` variable are not being initialised. This results in an incorrect arithmetic expression of `$(( + ))` being evaluated.

The actual solution for this might be to actually fix the underlying cause but I though this PR would be appropriate to start a discussion about where the issue might be and why it is showing up for me specifically.
