### PR TITLE
Fix background jobs segment

### DIFF
--- a/segments/background_jobs/background_jobs.p9k
+++ b/segments/background_jobs/background_jobs.p9k
@@ -25,6 +25,10 @@ __p9k_background_jobs() {
   jobs_suspended=${(M)#${jobstates%%:*}:#suspended}
 }
 
+TRAPCLD() {
+  zle -I && __p9k_background_jobs && __p9k_prepare_prompts && zle .reset-prompt && zle -R
+}
+
 # initialize hooks
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd __p9k_background_jobs


### PR DESCRIPTION
The `background_jobs` segment now reports the jobs count immediately. We trap `CLD` (Child process was killed) here, taken from [here](https://www.zsh.org/mla/users/2001/msg00719.html).
Caveat: It might cause some trouble, if in multiline-prompts (cursor position changes, when we show the segment).

Performancewise, this redraws the complete prompt on every child exit (solvable in #1176 ).

I haven't tested it much (running out of time again), and I am not a fan of trapping signals all over, but that seems to be our only chance..

// cc @Syphdias 
Fixes #1196 .
Succeeds #1238 . 