### PR TITLE
[Enhancement] Added support for kdig as fallback in prompt_public_ip

### DIFF
--- a/segments/public_ip/public_ip.p9k
+++ b/segments/public_ip/public_ip.p9k
@@ -27,7 +27,7 @@
   p9k::set_default P9K_PUBLIC_IP_NONE ""
   p9k::set_default P9K_PUBLIC_IP_FILE "/tmp/p9k_public_ip"
   p9k::set_default P9K_PUBLIC_IP_HOST "http://ident.me"
-  p9k::defined P9K_PUBLIC_IP_METHODS || P9K_PUBLIC_IP_METHODS=(dig curl wget)
+  p9k::defined P9K_PUBLIC_IP_METHODS || P9K_PUBLIC_IP_METHODS=(dig kdig curl wget)
 }
 
 # On macOS, stat is in /usr/bin/stat. However, if gnu utils are installed, this won't work.
@@ -69,6 +69,10 @@ prompt_public_ip() {
       case ${method} in
         'dig')
             fresh_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
+            [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip
+          ;;
+        'kdig')
+            fresh_ip="$(kdig +timeout=1 +retry=1 +short myip.opendns.com @resolver1.opendns.com 2> /dev/null)"
             [[ "$fresh_ip" =~ ^\; ]] && unset fresh_ip
           ;;
         'curl')

--- a/segments/public_ip/public_ip.spec
+++ b/segments/public_ip/public_ip.spec
@@ -99,11 +99,29 @@ function testPublicIpSegmentUsesCurlAsFallbackMethodIfWgetIsNotAvailable() {
   unalias wget
 }
 
-function testPublicIpSegmentUsesDigAsFallbackMethodIfWgetAndCurlAreNotAvailable() {
+function testPublicIpSegmentUsesKdigAsFallbackMethodIfWgetAndCurlAreNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(public_ip)
   alias curl='nocurl'
   alias wget='nowget'
+  kdig() {
+    echo "kdig 1.2.3.4"
+  }
+
+  # Load Powerlevel9k
+  assertEquals "%K{000} %F{015}kdig 1.2.3.4 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+
+  unfunction kdig
+  unalias curl
+  unalias wget
+}
+
+function testPublicIpSegmentUsesDigAsFallbackMethodIfKdigAndWgetAndCurlAreNotAvailable() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(public_ip)
+  alias curl='nocurl'
+  alias wget='nowget'
+  alias kdig='nokdig'
   dig() {
     echo "dig 1.2.3.4"
   }
@@ -112,6 +130,7 @@ function testPublicIpSegmentUsesDigAsFallbackMethodIfWgetAndCurlAreNotAvailable(
   assertEquals "%K{000} %F{015}dig 1.2.3.4 %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
+  unalias kdig
   unalias curl
   unalias wget
 }


### PR DESCRIPTION
Helpful on systems where dig is not installed by default and knot is used