### PR TITLE
[Enhancement] adds support for truecolor/24bit

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -317,7 +317,7 @@ function __p9k_term_colors() {
 ##
 function p9k::get_color() {
   # no need to check numerical values
-  [[ "$1" != <-> ]] && 1=$(p9k::get_color_code $1)
+  [[ "$1" != <-> ]] && [[ "$1" != '#'* ]] && 1=$(p9k::get_color_code $1)
   echo -n "$1"
 }
 

--- a/test/functions/colors.spec
+++ b/test/functions/colors.spec
@@ -37,6 +37,12 @@ function testIsSameColorDoesNotYieldNotEqualColorsTruthy() {
   assertFalse "p9k::is_same_color 'green' '003'"
 }
 
+function testGetColorCodeWithTrueColor() {
+  assertEquals '#fff8e7' "$(p9k::get_color '#fff8e7')"  # truecolor (hex)
+  assertEquals '137' "$(p9k::get_color '137')"          # number (dec)
+  assertEquals '100' "$(p9k::get_color 'yellow4')"      # named
+}
+
 function testBrightColorsWork() {
   # We had some code in the past that equalized bright colors
   # with normal ones. This code is now gone, and this test should


### PR DESCRIPTION
This enables users to use truecolor/24bit colors if zsh (>=5.7) and the terminal support it.

To display similar colors if the terminal does not support truecolor, we should document somewhere to recommend the following lines to add to the `.zshrc`:
```zsh
[[ $COLORTERM = *(24bit|truecolor)* ]] || zmodload zsh/nearcolor
```

After this change the following colors formats are supported (this should also be documented):
```zsh
P9K_DIR_PATH_HIGHLIGHT_FOREGROUND='001'     # numeric 001-256 (1-16 are dynamically used for themes for example)
P9K_DIR_PATH_HIGHLIGHT_FOREGROUND='#d10000' # hex code #000000-#ffffff
P9K_DIR_PATH_HIGHLIGHT_FOREGROUND='red'     # name, see `p9k::get_color foreground`
```

I write "should" because the [Customization page](https://github.com/bhilburn/powerlevel9k/wiki/Stylizing-Your-Prompt#segment-color-customization)  is in the GitHub Wiki and I didn't want to touch it since it's for `master` not `next`.

resolves #1259
//cc @migmolrod
//cc @romkatv