### PR TITLE
[Enhancement] Bold Icons

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -159,6 +159,9 @@ function p9k::register_segment() {
   local BOLD_USER_VARIABLE="P9K_${STATEFUL_NAME}_BOLD"
   local BOLD="${(P)BOLD_USER_VARIABLE}"
   [[ -z "${BOLD}" ]] || __P9K_DATA[${STATEFUL_NAME}_BD]=true
+  local BOLD_ICON_USER_VARIABLE="P9K_${STATEFUL_NAME}_ICON_BOLD"
+  local BOLD_ICON="${(P)BOLD_ICON_USER_VARIABLE}"
+  [[ -z "${BOLD_ICON}" ]] || __P9K_DATA[${STATEFUL_NAME}_ICON_BD]=true
 }
 
 (){

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -56,9 +56,14 @@ function __p9k_left_prompt_segment() {
   [[ "${3}" == "true" ]] \
       && __p9k_segment_should_be_joined ${current_index} ${last_left_element_index} "$P9K_LEFT_PROMPT_ELEMENTS" && joined=true
   local content
+  local SEGMENT_ICON
   # Support for bold segment
-  [[ -n ${4} ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
-  local SEGMENT_ICON="${5}"
+  [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] \
+    && content="%B${4}%b" \
+    || content="${4}"
+  [[ -n "${5}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_ICON_BD] == true ]] \
+    && SEGMENT_ICON="%B${5}%b" \
+    || SEGMENT_ICON="${5}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
@@ -144,9 +149,14 @@ function __p9k_right_prompt_segment() {
   local joined=false
   [[ "${3}" == "true" ]] && __p9k_segment_should_be_joined ${current_index} ${last_right_element_index} "$P9K_RIGHT_PROMPT_ELEMENTS" && joined=true
   local content
+  local SEGMENT_ICON
   # Support for bold segment
-  [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
-  local SEGMENT_ICON="${5}"
+  [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] \
+    && content="%B${4}%b" \
+    || content="${4}"
+  [[ -n "${5}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_ICON_BD] == true ]] \
+    && SEGMENT_ICON="%B${5}%b" \
+    || SEGMENT_ICON="${5}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]

--- a/test/core/bold.spec
+++ b/test/core/bold.spec
@@ -1,0 +1,128 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  emulate -L zsh
+  export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
+  # Load Powerlevel9k
+  source powerlevel9k.zsh-theme
+}
+
+function tearDown() {
+  # __P9K-vars (e.g. __P9K_DATA) have to be unset manually since they are set globally
+  # and leak to other tests
+  unset -m '__P9K_*' || true
+}
+
+# Regular Segment
+function testNoBoldOnregularSegment(){
+  local P9K_LEFT_PROMPT_ELEMENTS=(date)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(date)
+  local P9K_DATE_ICON="date-icon"
+  source segments/date/date.p9k
+  
+  assertEquals "%K{015} %F{000}date-icon %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} %D{%d.%m.%y} %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnRegularSegments() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(date)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(date)
+  local P9K_DATE_ICON="date-icon"
+  local P9K_DATE_BOLD=true
+  source segments/date/date.p9k
+
+  assertEquals "%K{015} %F{000}date-icon %F{000}%B%D{%d.%m.%y}%b %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} %B%D{%d.%m.%y}%b %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnRegularSegmentVisualIdentifiers() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(date)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(date)
+  local P9K_DATE_ICON="date-icon"
+  local P9K_DATE_ICON_BOLD=true
+  source segments/date/date.p9k
+
+  assertEquals "%K{015} %F{000}%Bdate-icon%b %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} %D{%d.%m.%y} %F{000}%Bdate-icon%b%f " "$(__p9k_build_right_prompt)"
+}
+
+# Stateful Segment
+function testNotBoldOnStatefulSegment() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(host)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(host)
+  local P9K_HOST_REMOTE_ICON="ssh-icon"
+  # Provoke state
+  local SSH_CLIENT="x"
+  source segments/host/host.p9k
+
+  assertEquals "%K{003} %F{000}ssh-icon %F{000}%m %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} %m %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnStatefulSegment() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(host)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(host)
+  local P9K_HOST_REMOTE_ICON="ssh-icon"
+  local P9K_HOST_REMOTE_BOLD=true
+  # Provoke state
+  local SSH_CLIENT="x"
+  source segments/host/host.p9k
+
+  assertEquals "%K{003} %F{000}ssh-icon %F{000}%B%m%b %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} %B%m%b %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnStatefulVisualIdentifiers() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(host)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(host)
+  local P9K_HOST_REMOTE_ICON="ssh-icon"
+  local P9K_HOST_REMOTE_ICON_BOLD=true
+  # Provoke state
+  local SSH_CLIENT="x"
+  source segments/host/host.p9k
+
+  assertEquals "%K{003} %F{000}%Bssh-icon%b %F{000}%m %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} %m %F{000}%Bssh-icon%b%f " "$(__p9k_build_right_prompt)"
+}
+
+# Custom Segment
+function testNotBoldOnCustomSegment() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+  local P9K_CUSTOM_WORLD_ICON='CW'
+
+  assertEquals "%K{015} %F{000}CW %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world %F{000}CW%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnCustomSegment() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+  local P9K_CUSTOM_WORLD_ICON='CW'
+  local P9K_CUSTOM_WORLD_BOLD=true
+
+  assertEquals "%K{015} %F{000}CW %F{000}%Bworld%b %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} %Bworld%b %F{000}CW%f " "$(__p9k_build_right_prompt)"
+}
+
+function testBoldOnCustomSegmentVisualIdentifiers() {
+  local P9K_LEFT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_RIGHT_PROMPT_ELEMENTS=(custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+  local P9K_CUSTOM_WORLD_ICON='CW'
+  local P9K_CUSTOM_WORLD_ICON_BOLD=true
+
+  assertEquals "%K{015} %F{000}%BCW%b %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} world %F{000}%BCW%b%f " "$(__p9k_build_right_prompt)"
+}
+
+source shunit2/shunit2


### PR DESCRIPTION
Instead of `_BACKGROUND`, `_FOREGROUND` or `_ICON` you can append:
- `_BOLD` to the stateful name to get bold text
- `_ICON_BOLD` to the stateful name to get bold visual identifier/"icon"
  (this only works if the font allows for it to be bold)

The `_BOLD` feature seems to be undocumented which should be changed. And
also document `_ICON_BOLD` next to it.

aims to resolves #1223