### PR TITLE
Fix tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - mercurial
       - subversion
       - jq
-      - node
+      - nodejs
       - golang
       - ruby
       - python


### PR DESCRIPTION
Seems like the default image has changed. Here the package name
has changed from `node` to `nodejs`.
