### PR TITLE
[Bugfix] Fix extra tilde when using truncate_with_folder_marker under $HOME

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -874,7 +874,7 @@ prompt_dir() {
               trunc_path="/"
             elif [[ "$marked_folder" == "$HOME" ]]; then
               # If we reached home folder, stop upsearch.
-              trunc_path="~"
+              trunc_path=""
             elif [[ "${marked_folder%/*}" == $last_marked_folder ]]; then
               trunc_path="${trunc_path%/}/${marked_folder##*/}"
             else

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -213,6 +213,28 @@ function testTruncateWithFolderMarkerWorks() {
   rm -fr $BASEFOLDER
 }
 
+function testHomeWithFolderMarkerWorks() {
+  local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+  POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)
+  local POWERLEVEL9K_SHORTEN_STRATEGY="truncate_with_folder_marker"
+  local POWERLEVEL9K_HOME_FOLDER_ABBREVIATION='~'
+  local dir=$PWD
+
+  mkdir -p ~/powerlevel9k-test
+
+  # Load Powerlevel9k
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+
+  cd ~
+  assertEquals "%K{004} %F{000}~ %k%F{004}%f " "$(build_left_prompt)"
+
+  cd ~/powerlevel9k-test
+  assertEquals "%K{004} %F{000}~/powerlevel9k-test %k%F{004}%f " "$(build_left_prompt)"
+
+  cd $dir
+  rm -fr ~/powerlevel9k-test
+}
+
 function testTruncateWithFolderMarkerWithChangedFolderMarker() {
   local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir)


### PR DESCRIPTION
truncate_with_folder_marker adds a tilde when it finds HOME, but
POWERLEVEL9K_HOME_FOLDER_ABBREVIATION is also prepended, so if you're
in a subdirectory of $HOME you get an extra tilde (although this does not
occur if you're actually in $HOME)

Without the change, the new test I added fails:
```
testHomeWithFolderMarkerWorks
ASSERT:expected:<%K{004} %F{000}~/powerlevel9k-test %k%F{004}%f > but was:<%K{004} %F{000}~~/powerlevel9k-test %k%F{004}%f >
```