### PR TITLE
[Bugfix] fixes hidden segment on last line

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -108,9 +108,7 @@ function __p9k_left_prompt_segment() {
 # @noargs
 ##
 function __p9k_left_prompt_end() {
-  if [[ ${(U)CURRENT_BG} == 'NONE' ]]; then
-    echo -n "%k%f${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
-  elif [[ -n ${CURRENT_BG}  ]]; then
+  if [[ -n ${CURRENT_BG} && ${(U)CURRENT_BG} != 'NONE' ]]; then
     echo -n "%k%F${CURRENT_BG#%K}${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
   else
     echo -n "%k"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -108,7 +108,9 @@ function __p9k_left_prompt_segment() {
 # @noargs
 ##
 function __p9k_left_prompt_end() {
-  if [[ -n ${CURRENT_BG} ]]; then
+  if [[ ${(U)CURRENT_BG} == 'NONE' ]]; then
+    echo -n "%k%f${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
+  elif [[ -n ${CURRENT_BG}  ]]; then
     echo -n "%k%F${CURRENT_BG#%K}${__P9K_ICONS[LEFT_SEGMENT_SEPARATOR]}"
   else
     echo -n "%k"

--- a/segments/newline/newline.spec
+++ b/segments/newline/newline.spec
@@ -36,7 +36,7 @@ function testNewlineMakesPreviousSegmentEndWell() {
 
     local newline=$'\n'
 
-    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k%f%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/newline/newline.spec
+++ b/segments/newline/newline.spec
@@ -36,7 +36,7 @@ function testNewlineMakesPreviousSegmentEndWell() {
 
     local newline=$'\n'
 
-    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k%FNONE%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k%f%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
This fixed a bug where the last line is not properly rendered if there is a hidden segment at the end:  
`P9K_LEFT_PROMPT_ELEMENTS=(dir newline background_jobs newline dir_writable)`
![image](https://user-images.githubusercontent.com/16988672/57981582-69e74700-7a39-11e9-8f84-009a505e6254.png)

This PR initially was created to fix #1266. What this does not change is the displaying of the "triangle" (`LEFT_SEGMENT_SEPARATOR`) at the end on newline. Currently the triangle is not shown if there is no segment on this line. This [could be considered a bug](https://github.com/bhilburn/powerlevel9k/issues/1266#issuecomment-493737977) as @romkatv notes, depending on if want that or not. So the question is: Should the triangle be displayed on empty lines? If no, this PR is finished (unless the review brings something up), if so, I could expand on this PR.