### PR TITLE
[Bugfix] pyenv weirdness

### DIFF
--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -32,8 +32,8 @@
 #   [Choosing the Python Version](https://github.com/pyenv/pyenv#choosing-the-python-version)
 ##
 prompt_pyenv() {
-  if [[ -n "$PYENV_VERSION" ]]; then
-    "__p9k_$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
+  if [[ -n "$PYENV_VERSION" && ("$PYENV_VERSION" != "system" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true") ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$PYENV_VERSION"
   elif [ $commands[pyenv] ]; then
     local pyenv_version_name="$(pyenv version-name)"
     local pyenv_global="system"

--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -32,15 +32,12 @@
 #   [Choosing the Python Version](https://github.com/pyenv/pyenv#choosing-the-python-version)
 ##
 prompt_pyenv() {
-  if [[ -n "$PYENV_VERSION" && ("$PYENV_VERSION" != "system" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true") ]]; then
+  local pyenv_root="$(pyenv root)"
+  local pyenv_global="$(pyenv version-file-read ${pyenv_root}/version || echo system)"
+  if [[ -n "$PYENV_VERSION" && ("$PYENV_VERSION" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true") ]]; then
     p9k::prepare_segment "$0" "" $1 "$2" $3 "$PYENV_VERSION"
   elif [ $commands[pyenv] ]; then
     local pyenv_version_name="$(pyenv version-name)"
-    local pyenv_global="system"
-    local pyenv_root="$(pyenv root)"
-    if [[ -f "${pyenv_root}/version" ]]; then
-      pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
-    fi
     if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}"
     fi


### PR DESCRIPTION
I was a bit confused to find `__p9k_$1_prompt_segment` here...

This produced the wrong segment content, e.g. `systemblack`. Also resolves #1280 by not displaying the version if it is "system" and `P9K_PYENV_PROMPT_ALWAYS_SHOW=false`