### PR TITLE
[Bugfix] rbenv doesn't respect POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW=false

### DIFF
--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -29,11 +29,11 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_rbenv() {
-  if [[ -n "${RBENV_VERSION}" ]]; then
+  local rbenv_global="$(rbenv global)"
+  if [[ -n "${RBENV_VERSION}" && ("${RBENV_VERSION}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == true) ]]; then
     p9k::prepare_segment "$0" "" $1 "$2" $3 "${RBENV_VERSION}"
   elif [ ${commands[rbenv]} ]; then
     local rbenv_version_name="$(rbenv version-name)"
-    local rbenv_global="$(rbenv global)"
     if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}"
     fi


### PR DESCRIPTION
Similar to #1283

resolves #1282