### PR TITLE
[Bugfix] Simplifing pyenv and rbenv to get rid of unexpected behaviour

### DIFF
--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -33,7 +33,7 @@
 ##
 prompt_pyenv() {
   if [ $commands[pyenv] ]; then
-    local pyenv_version_name="$(pyenv version-name)"
+    local pyenv_version_name="$(pyenv version-name 2>/dev/null)"
     local pyenv_global="$(pyenv global)"
     if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}"

--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -32,15 +32,9 @@
 #   [Choosing the Python Version](https://github.com/pyenv/pyenv#choosing-the-python-version)
 ##
 prompt_pyenv() {
-  if [[ -n "$PYENV_VERSION" ]]; then
-    "__p9k_$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$PYENV_VERSION" 'PYTHON_ICON'
-  elif [ $commands[pyenv] ]; then
+  if [ $commands[pyenv] ]; then
     local pyenv_version_name="$(pyenv version-name)"
-    local pyenv_global="system"
-    local pyenv_root="$(pyenv root)"
-    if [[ -f "${pyenv_root}/version" ]]; then
-      pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
-    fi
+    local pyenv_global="$(pyenv global)"
     if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}"
     fi

--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -30,7 +30,7 @@
 ##
 prompt_rbenv() {
   if [ ${commands[rbenv]} ]; then
-    local rbenv_version_name="$(rbenv version-name)"
+    local rbenv_version_name="$(rbenv version-name 2>/dev/null)"
     local rbenv_global="$(rbenv global)"
     if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
       p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}"

--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -29,9 +29,7 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_rbenv() {
-  if [[ -n "${RBENV_VERSION}" ]]; then
-    p9k::prepare_segment "$0" "" $1 "$2" $3 "${RBENV_VERSION}"
-  elif [ ${commands[rbenv]} ]; then
+  if [ ${commands[rbenv]} ]; then
     local rbenv_version_name="$(rbenv version-name)"
     local rbenv_global="$(rbenv global)"
     if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then


### PR DESCRIPTION
I removed some of the complexity and manual checking for versions. `pyenv` and `rbenv` should:tm: take care of that themselves. This seems to me like the most straight forward solution to not introducing unexpected behaviour. This would also close 3 issues (and 2 PRs I opened without simplifying code).

I did only very little testing since I know very little about `pyenv` and `rbenv` and these segments have no unit test.