### PR TITLE
[Bugfix] Removes whitespace from virtualenv icon if Awesome-Mapped-FontConfig is uses (for consistency)

### DIFF
--- a/segments/virtualenv/virtualenv.p9k
+++ b/segments/virtualenv/virtualenv.p9k
@@ -12,7 +12,7 @@
   # Parameters:
   #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
   #                                                                                        🐍          
-  p9k::register_segment "VIRTUALENV" "" "blue" "${DEFAULT_COLOR}"  ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C '
+  p9k::register_segment "VIRTUALENV" "" "blue" "${DEFAULT_COLOR}"  ''  $'\uE63C'  $'\uE63C'  $'\U1F40D'  $'\uE73C'
 }
 
 ################################################################


### PR DESCRIPTION
see title