### PR TITLE
[Enhancement] allow go_version prompt to work with go modules

### DIFF
--- a/segments/go_version/go_version.p9k
+++ b/segments/go_version/go_version.p9k
@@ -30,7 +30,7 @@ prompt_go_version() {
   go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
   go_path=$(go env GOPATH 2>/dev/null)
 
-  if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
+  if [[ -n "$go_version" && ("${PWD##$go_path}" != "$PWD" || -f "$PWD/go.mod") ]]; then
     p9k::prepare_segment "$0" "" $1 "$2" $3 "$go_version"
   fi
 }


### PR DESCRIPTION
#### Description

Go 1.11 introduced modules which allow go projects to no longer need to be in a static GOPATH. This PR will let Go devs see the Go version even if they are using modules.

#### Questions

I couldn't find any testing around these prompts, if there is somewhere I missed please let me know and I'll update.
