### PR TITLE
[Bugfix] fix #1013 TERM="xterm-256color" not recognized anymore on FreeBSD

### DIFF
--- a/functions/colors.zsh
+++ b/functions/colors.zsh
@@ -278,7 +278,11 @@ function termColors() {
   local term_colors
 
   if which tput &>/dev/null; then
-	term_colors=$(tput colors)
+    if [[ "$OSTYPE" == "freebsd"* ]]; then
+      term_colors=$(tput Co)
+    else
+      term_colors=$(tput colors)
+    fi
   else
 	term_colors=$(echotc Co)
   fi


### PR DESCRIPTION
#### Description

In FreeBSD (My version is ``FreeBSD 11.2``), ``tput colors`` is the same as ``tput co``, it returns the number of columns instead of the number of colors.  ``tput Co`` returns the number of colors.

But in other OS, like my MacBook, ``tput Co`` failed to be executed.  So some kind OS based logic has to be introduced to use difference terminfo capability at difference OS.

This PR use ``tput Co`` for and only for FreeBSD, use original ``tput colors`` otherwise.