### PR TITLE
[Bugfix] Escape control characters

### DIFF
--- a/functions/autoload/__p9k_truncate_path
+++ b/functions/autoload/__p9k_truncate_path
@@ -27,7 +27,8 @@ if (( ${#1} > 1 )); then
   # convert $2 from string to integer
   2=$(( $2 ))
   # set $3 to "" if not defined
-  [[ -z $3 ]] && local delim="" || local delim=$(echo -n $3)
+  local delim=""
+  [[ -n $3 ]] && print -v delim -- "${3}"
   # set $4 to "right" if not defined
   [[ -z $4 ]] && 4="right"
   # create a variable for the truncated path.

--- a/functions/autoload/__p9k_truncate_path
+++ b/functions/autoload/__p9k_truncate_path
@@ -28,7 +28,9 @@ if (( ${#1} > 1 )); then
   2=$(( $2 ))
   # set $3 to "" if not defined
   local delim=""
-  [[ -n $3 ]] && print -v delim -- "${3}"
+  if [[ -n $3 ]]; then
+    (( ${__P9K_USE_PRINT_V} )) && print -v delim -- "${3}" || delim="$(echo ${3})"
+  fi
   # set $4 to "right" if not defined
   [[ -z $4 ]] && 4="right"
   # create a variable for the truncated path.

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -59,6 +59,7 @@ function __p9k_left_prompt_segment() {
   # Support for bold segment
   [[ -n ${4} ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
+  content="\${(Q)\${:-${(qqq)content}}}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]
@@ -147,6 +148,7 @@ function __p9k_right_prompt_segment() {
   # Support for bold segment
   [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
+  content="\${(Q)\${:-${(qqq)content}}}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
   local fg=$__P9K_DATA[${STATEFUL_NAME}_FG]

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -402,7 +402,7 @@ function __p9k_prepare_prompts() {
   local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
 
   if [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]]; then
-    __p9k_unsafe_PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
+    PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
 ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
     if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left
@@ -417,19 +417,18 @@ ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
       RPROMPT_SUFFIX='%{'${P9K_RPROMPT_SUFFIX:-}'%}'
     fi
   else
-    __p9k_unsafe_PROMPT="%f%b%k$(__p9k_build_left_prompt)"
+    PROMPT="%f%b%k$(__p9k_build_left_prompt)"
     RPROMPT_PREFIX='%{'${P9K_RPROMPT_PREFIX:-}'%}'
     RPROMPT_SUFFIX='%{'${P9K_RPROMPT_SUFFIX:-}'%}'
   fi
 
   if [[ "${P9K_DISABLE_RPROMPT:-}" != true ]]; then
-    __p9k_unsafe_RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{${reset_color}%}${RPROMPT_SUFFIX}"
-    RPROMPT='$__p9k_unsafe_RPROMPT'
+    RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{${reset_color}%}${RPROMPT_SUFFIX}"
   fi
 
   # Allow iTerm integration to work
   [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]] \
-    && __p9k_unsafe_PROMPT="%{$(iterm2_prompt_mark)%}$__p9k_unsafe_PROMPT"
+    && PROMPT="%{$(iterm2_prompt_mark)%}${PROMPT}"
 
 local NEWLINE='
 '
@@ -437,15 +436,8 @@ local NEWLINE='
   if [[ "${P9K_PROMPT_ADD_NEWLINE:-}" == true ]]; then
     NEWLINES=""
     repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
-    __p9k_unsafe_PROMPT="$NEWLINES$__p9k_unsafe_PROMPT"
+    PROMPT="${NEWLINES}${PROMPT}"
   fi
-
-  # By evaluating $__p9k_unsafe_PROMPT here in __p9k_prepare_prompts we avoid
-  # the evaluation of $PROMPT being interrupted.
-  # For security $PROMPT is never set directly. This way the prompt render is
-  # forced to evaluate the variable and the contents of $__p9k_unsafe_PROMPT
-  # are never executed. The same applies to $RPROMPT.
-  PROMPT='$__p9k_unsafe_PROMPT'
 }
 
 p9k::set_default P9K_IGNORE_TERM_COLORS false

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -59,6 +59,9 @@ function __p9k_left_prompt_segment() {
   # Support for bold segment
   [[ -n ${4} ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
+  # Escape all unwanted characters. This works by quoting the content
+  # and set it up as a fallback. This has to be done, as we need to
+  # remove one layer of quoting when ZSH evaluates this variable.
   content="\${(Q)\${:-${(qqq)content}}}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]
@@ -148,6 +151,9 @@ function __p9k_right_prompt_segment() {
   # Support for bold segment
   [[ -n "${4}" ]] && [[ $__P9K_DATA[${STATEFUL_NAME}_BD] == true ]] && content="%B${4}%b" || content="${4}"
   local SEGMENT_ICON="${5}"
+  # Escape all unwanted characters. This works by quoting the content
+  # and set it up as a fallback. This has to be done, as we need to
+  # remove one layer of quoting when ZSH evaluates this variable.
   content="\${(Q)\${:-${(qqq)content}}}"
 
   local bg=$__P9K_DATA[${STATEFUL_NAME}_BG]

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -51,6 +51,10 @@ else
 fi
 #readonly __P9K_DIRECTORY
 
+autoload -U is-at-least
+__P9K_USE_PRINT_V=false
+is-at-least 5.3 && __P9K_USE_PRINT_V=true
+
 ################################################################
 # Source utility functions
 ################################################################

--- a/segments/anaconda/anaconda.p9k
+++ b/segments/anaconda/anaconda.p9k
@@ -33,6 +33,7 @@ prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
   local _path=$CONDA_ENV_PATH$CONDA_PREFIX
+  _path="${_path//\%/%%}"
   if ! [ -z "$_path" ]; then
     p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER"
   fi

--- a/segments/anaconda/anaconda.spec
+++ b/segments/anaconda/anaconda.spec
@@ -24,7 +24,7 @@ function testAnacondaSegmentPrintsNothingIfNoAnacondaPathIsSet() {
   unset CONDA_ENV_PATH
   unset CONDA_PREFIX
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAnacondaSegmentWorksIfOnlyAnacondaPathIsSet() {
@@ -38,7 +38,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPathIsSet() {
   CONDA_ENV_PATH=/tmp
   unset CONDA_PREFIX
 
-  assertEquals "%K{004} %F{000}icon-here %F{000}(tmp) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here %F{000}\${(Q)\${:-\"(tmp)\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
@@ -52,7 +52,7 @@ function testAnacondaSegmentWorksIfOnlyAnacondaPrefixIsSet() {
   unset CONDA_ENV_PATH
   local CONDA_PREFIX="test"
 
-  assertEquals "%K{004} %F{000}icon-here %F{000}(test) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here %F{000}\${(Q)\${:-\"(test)\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAnacondaSegmentWorks() {
@@ -66,7 +66,21 @@ function testAnacondaSegmentWorks() {
   local CONDA_ENV_PATH=/tmp
   local CONDA_PREFIX="test"
 
-  assertEquals "%K{004} %F{000}icon-here %F{000}(tmptest) %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here %F{000}\${(Q)\${:-\"(tmptest)\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+}
+
+function testAnacondaDoesNotLeadTermcapChars() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+  local P9K_ANACONDA_ICON="icon-here"
+
+  # Load Powerlevel9k
+  source segments/anaconda/anaconda.p9k
+
+  local CONDA_ENV_PATH=/tmp
+  local CONDA_PREFIX="\r\n%K{blue}leaking%F{red}string"
+
+  assertEquals "%K{004} %F{000}icon-here %F{000}\${(Q)\${:-\"(tmp\\r\\n%%K{blue}leaking%%F{red}string)\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/aws_eb_env/aws_eb_env.spec
+++ b/segments/aws_eb_env/aws_eb_env.spec
@@ -20,7 +20,7 @@ function testAwsEbEnvSegmentPrintsNothingIfNoElasticBeanstalkEnvironmentIsSet() 
   # Load Powerlevel9k
   source segments/aws_eb_env/aws_eb_env.p9k
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAwsEbEnvSegmentWorksIfElasticBeanstalkEnvironmentIsSet() {
@@ -34,7 +34,7 @@ function testAwsEbEnvSegmentWorksIfElasticBeanstalkEnvironmentIsSet() {
   echo "test:\n    environment: test" > /tmp/powerlevel9k-test/.elasticbeanstalk/config.yml
   cd /tmp/powerlevel9k-test
 
-  assertEquals "%K{000} %F{002}🌱  %F{002}test %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}🌱  %F{002}\${(Q)\${:-\"test\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   rm -fr /tmp/powerlevel9k-test
   cd -

--- a/segments/background_jobs/background_jobs.spec
+++ b/segments/background_jobs/background_jobs.spec
@@ -22,7 +22,7 @@ function testBackgroundJobsSegmentPrintsNothingWithoutBackgroundJobs() {
   # Load Powerlevel9k
   source segments/background_jobs/background_jobs.p9k
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentVerboseAlwaysPrintsZeroWithoutBackgroundJobs() {
@@ -35,7 +35,7 @@ function testBackgroundJobsSegmentVerboseAlwaysPrintsZeroWithoutBackgroundJobs()
   # Load Powerlevel9k
   source segments/background_jobs/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %F{000}0 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙ %F{000}\${(Q)\${:-\"0\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
@@ -47,7 +47,7 @@ function testBackgroundJobsSegmentWorksWithOneBackgroundJob() {
 
   # Load Powerlevel9k
   source segments/background_jobs/background_jobs.p9k
-  assertEquals "%K{003} %F{000}⚙ %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙ %F{000}\${(Q)\${:-\"\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
@@ -60,7 +60,7 @@ function testBackgroundJobsSegmentWorksWithMultipleBackgroundJobs() {
   # Load Powerlevel9k
   source segments/background_jobs/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙ %F{000}\${(Q)\${:-\"3\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWithVerboseMode() {
@@ -73,7 +73,7 @@ function testBackgroundJobsSegmentWithVerboseMode() {
     # Load Powerlevel9k
     source segments/background_jobs/background_jobs.p9k
 
-    assertEquals "%K{003} %F{000}⚙ %F{000}3 %k%F{003}%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{003} %F{000}⚙ %F{000}\${(Q)\${:-\"3\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBackgroundJobsSegmentWorksWithExpandedMode() {
@@ -87,7 +87,7 @@ function testBackgroundJobsSegmentWorksWithExpandedMode() {
   # Load Powerlevel9k
   source segments/background_jobs/background_jobs.p9k
 
-  assertEquals "%K{003} %F{000}⚙ %F{000}1r 2s %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}⚙ %F{000}\${(Q)\${:-\"1r 2s\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/battery/battery.spec
+++ b/segments/battery/battery.spec
@@ -152,7 +152,7 @@ function testBatterySegmentIfBatteryIsLowWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; discharging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{001}🔋 %F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %F{001}\${(Q)\${:-\"4%% (0:05)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
@@ -160,7 +160,7 @@ function testBatterySegmentIfBatteryIsLowWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	4%; charging; 0:05 remaining present: true"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"4%% (0:05)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnOSX() {
@@ -168,7 +168,7 @@ function testBatterySegmentIfBatteryIsNormalWhileDischargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; discharging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"98%% (3:57)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnOSX() {
@@ -176,7 +176,7 @@ function testBatterySegmentIfBatteryIsNormalWhileChargingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	98%; charging; 3:57 remaining present: true"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}98%% (3:57) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"98%% (3:57)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnOSX() {
@@ -184,7 +184,7 @@ function testBatterySegmentIfBatteryIsFullOnOSX() {
   makeBatterySay "Now drawing from 'AC Power'
  -InternalBattery-0 (id=1234567)	99%; charged; 0:00 remaining present: true"
 
-  assertEquals "%K{000} %F{002}🔋 %F{002}99%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}🔋 %F{002}\${(Q)\${:-\"99%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnOSX() {
@@ -192,119 +192,119 @@ function testBatterySegmentIfBatteryIsCalculatingOnOSX() {
   makeBatterySay "Now drawing from 'Battery Power'
  -InternalBattery-0 (id=1234567)	99%; discharging; (no estimate) present: true"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"99%% (...)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Discharging"
 
-  assertEquals "%K{000} %F{001}🔋 %F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %F{001}\${(Q)\${:-\"4%% (0:05)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}4%% (2:14) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"4%% (2:14)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileUnknownOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "4" "Unknown"
 
-  assertEquals "%K{000} %F{001}🔋 %F{001}4%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{001}🔋 %F{001}\${(Q)\${:-\"4%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Discharging"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}98%% (2:17) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"98%% (2:17)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Charging"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}98%% (0:02) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"98%% (0:02)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileUnknownOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Unknown"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"98%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsFullOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "100" "Full"
 
-  assertEquals "%K{000} %F{002}🔋 %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}🔋 %F{002}\${(Q)\${:-\"100%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryNearlyFullButNotChargingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "98" "Unknown" "0"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}98%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"98%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnLinux() {
   local __P9K_OS='Linux' # Fake Linux
   makeBatterySay "99" "Charging" "0"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}99%% (...) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"99%% (...)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileDischargingOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "4" "5" "4"
 
-  assertEquals "%K{000} %F{001}🔋 %F{001}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{001}🔋 %F{001}\${(Q)\${:-\"4%% (0:05)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileChargingOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "4" "5" "7"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}4%% (0:05) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"4%% (0:05)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsLowWhileUnknownOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "4" "Unknown" "5"
 
-  assertEquals "%K{000} %F{001}🔋 %F{001}4%% (...) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{001}🔋 %F{001}\${(Q)\${:-\"4%% (...)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileDischargingOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "98" "215" "1"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}98%% (3:35) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"98%% (3:35)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsNormalWhileChargingOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "98" "298" "2"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}98%% (4:58) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"98%% (4:58)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsFullOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "100" "181" "1"
 
-  assertEquals "%K{000} %F{015}🔋 %F{015}100%% (3:01) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{015}🔋 %F{015}\${(Q)\${:-\"100%% (3:01)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatterySegmentIfBatteryIsCalculatingOnWindows() {
   local __P9K_OS='Windows' # Fake Windows
   makeBatterySay "99" "" "2"
 
-  assertEquals "%K{000} %F{003}🔋 %F{003}99%% (...) " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
+  assertEquals "%K{000} %F{003}🔋 %F{003}\${(Q)\${:-\"99%% (...)\"}} " "$(prompt_battery left 1 false ${FOLDER}/usr/bin/)"
 }
 
 function testBatteryStagesString() {
@@ -314,19 +314,19 @@ function testBatteryStagesString() {
   P9K_BATTERY_STAGES="abcde"
 
   makeBatterySay "1" "Charging"
-  assertEquals "%K{000} %F{003}a %F{003}1%% (2:18) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}a %F{003}\${(Q)\${:-\"1%% (2:18)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "26" "Charging"
-  assertEquals "%K{000} %F{003}b %F{003}26%% (1:43) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}b %F{003}\${(Q)\${:-\"26%% (1:43)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "52" "Charging"
-  assertEquals "%K{000} %F{003}c %F{003}52%% (1:07) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}c %F{003}\${(Q)\${:-\"52%% (1:07)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "99" "Charging"
-  assertEquals "%K{000} %F{003}d %F{003}99%% (0:01) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}d %F{003}\${(Q)\${:-\"99%% (0:01)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "100" "Full"
-  assertEquals "%K{000} %F{002}e %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}e %F{002}\${(Q)\${:-\"100%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 function testBatteryStagesArray() {
@@ -334,19 +334,19 @@ function testBatteryStagesArray() {
   P9K_BATTERY_STAGES=("charge!" "low" "med" "high" "full")
 
   makeBatterySay "1" "Charging"
-  assertEquals "%K{000} %F{003}charge! %F{003}1%% (2:18) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}charge! %F{003}\${(Q)\${:-\"1%% (2:18)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "26" "Charging"
-  assertEquals "%K{000} %F{003}low %F{003}26%% (1:43) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}low %F{003}\${(Q)\${:-\"26%% (1:43)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "52" "Charging"
-  assertEquals "%K{000} %F{003}med %F{003}52%% (1:07) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}med %F{003}\${(Q)\${:-\"52%% (1:07)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "99" "Charging"
-  assertEquals "%K{000} %F{003}high %F{003}99%% (0:01) " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{003}high %F{003}\${(Q)\${:-\"99%% (0:01)\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 
   makeBatterySay "100" "Full"
-  assertEquals "%K{000} %F{002}full %F{002}100%% " "$(prompt_battery left 1 false ${FOLDER})"
+  assertEquals "%K{000} %F{002}full %F{002}\${(Q)\${:-\"100%%\"}} " "$(prompt_battery left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/segments/command_execution_time/command_execution_time.spec
+++ b/segments/command_execution_time/command_execution_time.spec
@@ -24,7 +24,7 @@ function testCommandExecutionTimeIsNotShownIfTimeIsBelowThreshold() {
   P9K_CUSTOM_WORLD='echo world'
   local _P9K_COMMAND_DURATION=2
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeChanged() {
@@ -32,8 +32,9 @@ function testCommandExecutionTimeThresholdCouldBeChanged() {
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=1
   local _P9K_COMMAND_DURATION=2.03
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}2.03s %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"2.03s\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeThresholdCouldBeSetToZero() {
@@ -41,8 +42,9 @@ function testCommandExecutionTimeThresholdCouldBeSetToZero() {
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   local _P9K_COMMAND_DURATION=0.03
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}0.03s %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"0.03s\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeChanged() {
@@ -51,8 +53,9 @@ function testCommandExecutionTimePrecisionCouldBeChanged() {
   local P9K_COMMAND_EXECUTION_TIME_THRESHOLD=0
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=4
   local _P9K_COMMAND_DURATION=0.0001
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}0.0001s %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"0.0001s\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimePrecisionCouldBeSetToZero() {
@@ -60,24 +63,27 @@ function testCommandExecutionTimePrecisionCouldBeSetToZero() {
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local P9K_COMMAND_EXECUTION_TIME_PRECISION=0
   local _P9K_COMMAND_DURATION=23.5001
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}24s %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"24s\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForMinuteLongCommand() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local _P9K_COMMAND_DURATION=180
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}03:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"03:00\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testCommandExecutionTimeIsFormattedHumandReadbleForHourLongCommand() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(command_execution_time)
   local _P9K_COMMAND_DURATION=7200
+  local LC_ALL="en_US.utf8"
 
-  assertEquals "%K{001} %F{226}Dur %F{226}02:00:00 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}Dur %F{226}\${(Q)\${:-\"02:00:00\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/context/context.spec
+++ b/segments/context/context.spec
@@ -48,7 +48,7 @@ function testContextSegmentDoesNotGetRenderedWithDefaultUser() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(context custom_world)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testContextSegmentDoesGetRenderedWhenSshConnectionIsOpen() {
@@ -56,14 +56,14 @@ function testContextSegmentDoesGetRenderedWhenSshConnectionIsOpen() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(context)
 
-  assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"%n@%m\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testContextSegmentWithForeignUser() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(context)
 
-  assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"%n@%m\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testContextSegmentWithRootUser() {
@@ -71,7 +71,7 @@ function testContextSegmentWithRootUser() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(context)
 
-  assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"%n@%m\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testOverridingContextTemplate() {
@@ -79,7 +79,7 @@ function testOverridingContextTemplate() {
   P9K_LEFT_PROMPT_ELEMENTS=(context)
   local P9K_CONTEXT_TEMPLATE=xx
 
-  assertEquals "%K{000} %F{003}xx %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"xx\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testContextSegmentIsShownIfDefaultUserIsSetWhenForced() {
@@ -88,7 +88,7 @@ function testContextSegmentIsShownIfDefaultUserIsSetWhenForced() {
   local P9K_CONTEXT_ALWAYS_SHOW=true
   local DEFAULT_USER=$(whoami)
 
-  assertEquals "%K{000} %F{003}%n@%m %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"%n@%m\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testContextSegmentIsShownIfForced() {
@@ -97,7 +97,7 @@ function testContextSegmentIsShownIfForced() {
   local P9K_CONTEXT_ALWAYS_SHOW_USER=true
   local DEFAULT_USER=$(whoami)
 
-  assertEquals "%K{000} %F{003}$(whoami) %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"$(whoami)\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/detect_virt/detect_virt.spec
+++ b/segments/detect_virt/detect_virt.spec
@@ -20,7 +20,7 @@ function testDetectVirtSegmentPrintsNothingIfSystemdIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   alias systemd-detect-virt="novirt"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias systemd-detect-virt
 }
@@ -30,7 +30,7 @@ function testDetectVirtSegmentIfSystemdReturnsPlainName() {
   P9K_LEFT_PROMPT_ELEMENTS=(detect_virt)
   alias systemd-detect-virt="echo 'xxx'"
 
-  assertEquals "%K{000} %F{003}xxx %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"xxx\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unalias systemd-detect-virt
 }
@@ -47,7 +47,7 @@ function testDetectVirtSegmentIfRootFsIsOnExpectedInode() {
   # which translates to: Show the inode number of "/" and test if it is "2".
   alias ls="echo '2'"
 
-  assertEquals "%K{000} %F{003}none %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"none\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unalias ls
   unalias systemd-detect-virt
@@ -65,7 +65,7 @@ function testDetectVirtSegmentIfRootFsIsNotOnExpectedInode() {
   # which translates to: Show the inode number of "/" and test if it is "2".
   alias ls="echo '3'"
 
-  assertEquals "%K{000} %F{003}chroot %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}\${(Q)\${:-\"chroot\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unalias ls
   unalias systemd-detect-virt

--- a/segments/dir/dir.p9k
+++ b/segments/dir/dir.p9k
@@ -31,9 +31,6 @@
   # Parse the 'name' from the package.json; if there are any problems, just
   # print the file path
   p9k::defined P9K_DIR_PACKAGE_FILES || P9K_DIR_PACKAGE_FILES=(package.json composer.json)
-
-  # Decompose the codepoint to a regular utf-character
-  print -v P9K_DIR_SHORTEN_DELIMITER -- "${P9K_DIR_SHORTEN_DELIMITER}"
 }
 
 ################################################################

--- a/segments/dir/dir.p9k
+++ b/segments/dir/dir.p9k
@@ -31,6 +31,9 @@
   # Parse the 'name' from the package.json; if there are any problems, just
   # print the file path
   p9k::defined P9K_DIR_PACKAGE_FILES || P9K_DIR_PACKAGE_FILES=(package.json composer.json)
+
+  # Decompose the codepoint to a regular utf-character
+  print -v P9K_DIR_SHORTEN_DELIMITER -- "${P9K_DIR_SHORTEN_DELIMITER}"
 }
 
 ################################################################

--- a/segments/dir/dir.spec
+++ b/segments/dir/dir.spec
@@ -176,7 +176,7 @@ function testTruncateToFirstAndLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/12345678/123456789\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -192,7 +192,7 @@ function testTruncateAbsoluteWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"\\u202689\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"…89\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -243,7 +243,7 @@ function testTruncateWithFolderMarkerWorks() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -263,7 +263,7 @@ function testTruncateWithFolderMarkerInHome() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -282,7 +282,7 @@ function testTruncateWithFolderMarkerWithChangedFolderMarker() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.xxx
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -308,7 +308,7 @@ function testTruncateWithFolderMarkerWithSymlinks() {
   assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/link2\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   cd -
   cd ${BASEFOLDER}/1/12/123/link3
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/link3\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/link3\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   cd -
 
   rm -fr $BASEFOLDER
@@ -326,7 +326,7 @@ function testTruncateWithFolderMarkerInMarkedFolder() {
   touch $FOLDER/.shorten_folder_marker
   cd $FOLDER
   # setopt xtrace
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   # unsetopt xtrace
 
   cd -

--- a/segments/dir/dir.spec
+++ b/segments/dir/dir.spec
@@ -176,7 +176,7 @@ function testTruncateToFirstAndLastWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/…/…/…/…/…/…/…/12345678/123456789\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/\\u2026/12345678/123456789\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -192,7 +192,7 @@ function testTruncateAbsoluteWorks() {
   mkdir -p $FOLDER
   cd $FOLDER
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"…89\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"\\u202689\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr /tmp/powerlevel9k-test
@@ -243,7 +243,7 @@ function testTruncateWithFolderMarkerWorks() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -263,7 +263,7 @@ function testTruncateWithFolderMarkerInHome() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.shorten_folder_marker
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -282,7 +282,7 @@ function testTruncateWithFolderMarkerWithChangedFolderMarker() {
   # Setup folder marker
   touch $BASEFOLDER/1/12/.xxx
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/1234/12345/123456/1234567\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER
@@ -308,7 +308,7 @@ function testTruncateWithFolderMarkerWithSymlinks() {
   assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp/powerlevel9k-test/link2\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   cd -
   cd ${BASEFOLDER}/1/12/123/link3
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12/123/link3\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12/123/link3\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   cd -
 
   rm -fr $BASEFOLDER
@@ -326,7 +326,7 @@ function testTruncateWithFolderMarkerInMarkedFolder() {
   touch $FOLDER/.shorten_folder_marker
   cd $FOLDER
   # setopt xtrace
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/…/12\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/\\u2026/12\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   # unsetopt xtrace
 
   cd -
@@ -665,7 +665,7 @@ function testBoldHomeSubdirWorks() {
   mkdir -p ~/powerlevel9k-test
   cd ~/powerlevel9k-test
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"%Bpowerlevel9k-test%b\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/%Bpowerlevel9k-test%b\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr ~/powerlevel9k-test
@@ -688,7 +688,7 @@ function testBoldRootSubdirWorks() {
   local P9K_DIR_PATH_HIGHLIGHT_BOLD=true
   cd /tmp
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/%Btmp%b\"}}/%Btmp%b %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/%Btmp%b\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -747,8 +747,7 @@ function testHighlightRootSubdirWorks() {
   local P9K_DIR_PATH_HIGHLIGHT_FOREGROUND='red'
   cd /tmp
 
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"%F{001}/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
-
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/%F{001}tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
   cd -
 }
 
@@ -820,7 +819,7 @@ function testDirSegmentWithDirectoryThatContainsFormattingInstructions() {
 
   mkdir -p $FOLDER
   cd $FOLDER
-  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/'%E%K{red}'\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"~/'%%E%%K{red}'\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   rm -fr $BASEFOLDER

--- a/segments/dir/dir.spec
+++ b/segments/dir/dir.spec
@@ -12,11 +12,17 @@ function setUpOnce() {
 function setUp() {
   export TERM="xterm-256color"
   P9K_HOME="${PWD}"
+
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/dir/dir.p9k
+
+  # Decompose the codepoint to a regular utf-character
+  (( __P9K_USE_PRINT_V )) && \
+      print -v P9K_DIR_SHORTEN_DELIMITER -- "${P9K_DIR_SHORTEN_DELIMITER}" || \
+      P9K_DIR_SHORTEN_DELIMITER="$(echo -n ${P9K_DIR_SHORTEN_DELIMITER})"
 }
 
 function tearDown() {

--- a/segments/disk_usage/disk_usage.spec
+++ b/segments/disk_usage/disk_usage.spec
@@ -38,7 +38,7 @@ function testDiskUsageSegmentWhenDiskIsAlmostFull() {
 /dev/disk1     487219288 471466944  15496344  97% /"
   }
 
-  assertEquals "%K{001} %F{015}hdd  %F{015}97%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}hdd  %F{015}\${(Q)\${:-\"97%%\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -51,7 +51,7 @@ function testDiskUsageSegmentWhenDiskIsVeryFull() {
 /dev/disk1     487219288 471466944  15496344  94% /"
   }
 
-  assertEquals "%K{003} %F{000}hdd  %F{000}94%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd  %F{000}\${(Q)\${:-\"94%%\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -64,7 +64,7 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
 /dev/disk1     487219288 471466944  15496344  4% /"
   }
 
-  assertEquals "%K{000} %F{046}hdd  %F{046}4%% %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{046}hdd  %F{046}\${(Q)\${:-\"4%%\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -80,7 +80,7 @@ function testDiskUsageSegmentPrintsNothingIfDiskIsQuiteEmptyAndOnlyWarningsShoul
   local P9K_DISK_USAGE_ONLY_WARNING=true
   local P9K_CUSTOM_WORLD='echo world'
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -94,7 +94,7 @@ function testDiskUsageSegmentWarningLevelCouldBeAdjusted() {
 /dev/disk1     487219288 471466944  15496344  11% /"
   }
 
-  assertEquals "%K{003} %F{000}hdd  %F{000}11%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}hdd  %F{000}\${(Q)\${:-\"11%%\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }
@@ -109,7 +109,7 @@ function testDiskUsageSegmentCriticalLevelCouldBeAdjusted() {
 /dev/disk1     487219288 471466944  15496344  11% /"
   }
 
-  assertEquals "%K{001} %F{015}hdd  %F{015}11%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}hdd  %F{015}\${(Q)\${:-\"11%%\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
 }

--- a/segments/gitstatus/gitstatus.spec
+++ b/segments/gitstatus/gitstatus.spec
@@ -45,7 +45,7 @@ function testGitstatusRemoteBranchIsDisplayedIfLocalAndRemoteDiffer() {
   local VCS_STATUS_LOCAL_BRANCH='master'
   local VCS_STATUS_REMOTE_BRANCH='remotes/somebody/master'
 
-  assertEquals "%K{002} %F{000} master →remotes/somebody/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master →remotes/somebody/master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitstatusRemoteBranchIsHiddenIfLocalAndRemoteAreEqual() {
@@ -57,7 +57,7 @@ function testGitstatusRemoteBranchIsHiddenIfLocalAndRemoteAreEqual() {
   local VCS_STATUS_LOCAL_BRANCH='master'
   local VCS_STATUS_REMOTE_BRANCH='master'
 
-  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitstatusActionformat() {
@@ -69,7 +69,7 @@ function testGitstatusActionformat() {
   local VCS_STATUS_LOCAL_BRANCH='%E%K{blue}'
   local VCS_STATUS_ACTION="merge"
 
-  assertEquals "%K{002} %F{000} %%E%%K{blue} %F{001}| merge%f%F{} %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" %%E%%K{blue} %F{001}| merge%f%F{}\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNoPercentEscapesLeak() {
@@ -80,7 +80,7 @@ function testNoPercentEscapesLeak() {
   local VCS_STATUS_RESULT="ok-sync"
   local VCS_STATUS_LOCAL_BRANCH='%E%K{red}'
 
-  assertEquals "%K{002} %F{000} %%E%%K{red} %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" %%E%%K{red}\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitstatusVisualIdentifier() {
@@ -93,22 +93,22 @@ function testGitstatusVisualIdentifier() {
   local P9K_GITSTATUS_GIT_ICON='Git-icon'
   source "${P9K_HOME}/segments/gitstatus/gitstatus.p9k"
   local VCS_STATUS_REMOTE_URL="https://some.unknown/url"
-  assertEquals "%K{002} %F{000}Git-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}Git-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_GITSTATUS_BITBUCKET_ICON='BB-icon'
   source "${P9K_HOME}/segments/gitstatus/gitstatus.p9k"
   local VCS_STATUS_REMOTE_URL="https://dritter@bitbucket.org/dritter/dr-test.git"
-  assertEquals "%K{002} %F{000}BB-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}BB-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_GITSTATUS_GITLAB_ICON='GL-icon'
   source "${P9K_HOME}/segments/gitstatus/gitstatus.p9k"
   local VCS_STATUS_REMOTE_URL="https://gitlab.com/dritter/gitlab-test-project.git"
-  assertEquals "%K{002} %F{000}GL-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GL-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_GITSTATUS_GITHUB_ICON='GH-icon'
   source "${P9K_HOME}/segments/gitstatus/gitstatus.p9k"
   local VCS_STATUS_REMOTE_URL="https://github.com/dritter/test.git"
-  assertEquals "%K{002} %F{000}GH-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GH-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/go_version/go_version.spec
+++ b/segments/go_version/go_version.spec
@@ -44,7 +44,7 @@ function testGo() {
 
   PWD="$HOME/go/src/github.com/bhilburn/powerlevel9k"
 
-  assertEquals "%K{002} %F{255}Go %F{255}go1.5.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{255}Go %F{255}\${(Q)\${:-\"go1.5.3\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_GO_ICON
   unset PWD
@@ -58,7 +58,7 @@ function testGoSegmentPrintsNothingIfEmptyGopath() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unset P9K_CUSTOM_WORLD
@@ -71,7 +71,7 @@ function testGoSegmentPrintsNothingIfNotInGopath() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unset P9K_CUSTOM_WORLD
@@ -83,7 +83,7 @@ function testGoSegmentPrintsNothingIfGoIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world go_version)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unset P9K_CUSTOM_WORLD

--- a/segments/ip/ip.spec
+++ b/segments/ip/ip.spec
@@ -208,7 +208,7 @@ function testIpSegmentWorksOnOsxWithNoInterfaceSpecified() {
 
   fakeIfconfig "eth1" "eth2"
 
-  assertEquals "%K{006} %F{000}IP %F{000}1.2.3.4 " "$(prompt_ip left 1 false "$FOLDER")"
+  assertEquals "%K{006} %F{000}IP %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_ip left 1 false "$FOLDER")"
 }
 
 function testIpSegmentWorksOnOsxWithInterfaceSpecified() {
@@ -221,7 +221,7 @@ function testIpSegmentWorksOnOsxWithInterfaceSpecified() {
   source segments/ip/ip.p9k
   local OS='OSX' # Fake OSX
 
-  assertEquals "%K{006} %F{000}IP %F{000}1.2.3.4 " "$(prompt_ip left 1 false "$FOLDER")"
+  assertEquals "%K{006} %F{000}IP %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_ip left 1 false "$FOLDER")"
 }
 
 function testIpSegmentWorksOnLinuxWithNoInterfaceSpecified() {
@@ -232,7 +232,7 @@ function testIpSegmentWorksOnLinuxWithNoInterfaceSpecified() {
 
     fakeIp "eth0"
 
-    assertEquals "%K{006} %F{000}IP %F{000}1.2.3.4 " "$(prompt_ip left 1 false "$FOLDER")"
+    assertEquals "%K{006} %F{000}IP %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_ip left 1 false "$FOLDER")"
 }
 
 function testIpSegmentWorksOnLinuxWithInterfaceSpecified() {
@@ -245,7 +245,7 @@ function testIpSegmentWorksOnLinuxWithInterfaceSpecified() {
   source segments/ip/ip.p9k
   local OS='Linux' # Fake Linux
 
-  assertEquals "%K{006} %F{000}IP %F{000}1.2.3.4 " "$(prompt_ip left 1 false "$FOLDER")"
+  assertEquals "%K{006} %F{000}IP %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_ip left 1 false "$FOLDER")"
 }
 
 source shunit2/shunit2

--- a/segments/kubecontext/kubecontext.spec
+++ b/segments/kubecontext/kubecontext.spec
@@ -73,7 +73,7 @@ function testKubeContext() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{004} %F{015}⎈ %F{015}minikube/default %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{015}⎈ %F{015}\${(Q)\${:-\"minikube/default\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -83,7 +83,7 @@ function testKubeContextOtherNamespace() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(kubecontext)
 
-  assertEquals "%K{004} %F{015}⎈ %F{015}minikube/kube-system %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{015}⎈ %F{015}\${(Q)\${:-\"minikube/kube-system\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unalias kubectl
@@ -94,7 +94,7 @@ function testKubeContextPrintsNothingIfKubectlNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world kubecontext)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_LEFT_PROMPT_ELEMENTS
   unset P9K_CUSTOM_WORLD

--- a/segments/laravel_version/laravel_version.spec
+++ b/segments/laravel_version/laravel_version.spec
@@ -35,7 +35,7 @@ function testLaravelVersionSegment() {
   P9K_LEFT_PROMPT_ELEMENTS=(laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
-  assertEquals "%K{001} %F{015}x %F{015}5.4.23 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{015}x %F{015}\${(Q)\${:-\"5.4.23\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
   unalias php
 }
 
@@ -47,7 +47,7 @@ function testLaravelVersionSegmentIfArtisanIsNotAvailable() {
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }
@@ -60,7 +60,7 @@ function testLaravelVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world laravel_version)
   source segments/laravel_version/laravel_version.p9k
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }

--- a/segments/load/load.spec
+++ b/segments/load/load.spec
@@ -45,7 +45,7 @@ function testLoadSegmentWorksOnOsx() {
 
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{002} %F{000}L %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L %F{000}\${(Q)\${:-\"1.38\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -65,7 +65,7 @@ function testLoadSegmentWorksOnBsd() {
 
   local __P9K_OS="BSD" # Fake BSD
 
-  assertEquals "%K{002} %F{000}L %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L %F{000}\${(Q)\${:-\"1.38\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -80,7 +80,7 @@ function testLoadSegmentWorksOnLinux() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{002} %F{000}L %F{000}1.38 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L %F{000}\${(Q)\${:-\"1.38\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -98,7 +98,7 @@ function testLoadSegmentNormalState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{002} %F{000}L %F{000}1.00 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{002} %F{000}L %F{000}\${(Q)\${:-\"1.00\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -116,7 +116,7 @@ function testLoadSegmentWarningState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}L %F{000}2.01 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}L %F{000}\${(Q)\${:-\"2.01\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }
@@ -134,7 +134,7 @@ function testLoadSegmentCriticalState() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{001} %F{000}L %F{000}2.81 " "$(prompt_load left 1 false ${FOLDER})"
+  assertEquals "%K{001} %F{000}L %F{000}\${(Q)\${:-\"2.81\"}} " "$(prompt_load left 1 false ${FOLDER})"
 
   unalias nproc
 }

--- a/segments/newline/newline.spec
+++ b/segments/newline/newline.spec
@@ -23,7 +23,7 @@ function testNewlineDoesNotCreateExtraSegmentSeparator() {
 
     local newline=$'\n'
 
-    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k ${newline}%k ${newline}%K{015} %F{000}world2 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}\${(Q)\${:-\"${newline}\"}}%k \${(Q)\${:-\"${newline}\"}}%k \${(Q)\${:-\"${newline}\"}}%K{015} %F{000}\${(Q)\${:-\"world2\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNewlineMakesPreviousSegmentEndWell() {
@@ -36,7 +36,7 @@ function testNewlineMakesPreviousSegmentEndWell() {
 
     local newline=$'\n'
 
-    assertEquals "%K{015} %F{000}world1 %k%F{015}${newline}%k%FNONE%f " "$(__p9k_build_left_prompt)"
+    assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}\${(Q)\${:-\"${newline}\"}}%k%FNONE%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/node_version/node_version.spec
+++ b/segments/node_version/node_version.spec
@@ -20,7 +20,7 @@ function testNodeVersionSegmentPrintsNothingWithoutNode() {
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias node
 }
@@ -32,7 +32,7 @@ function testNodeVersionSegmentWorks() {
     echo "v1.2.3"
   }
 
-  assertEquals "%K{002} %F{015}⬢ %F{015}1.2.3 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{015}⬢ %F{015}\${(Q)\${:-\"1.2.3\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   unfunction node
 }

--- a/segments/nodeenv/nodeenv.spec
+++ b/segments/nodeenv/nodeenv.spec
@@ -26,7 +26,7 @@ function testNodeenvSegmentPrintsNothingWithoutNode() {
   local P9K_CUSTOM_WORLD='echo world'
   alias node="nonode 2>/dev/null"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias node
 }
@@ -39,7 +39,7 @@ function testNodeenvSegmentPrintsNothingIfNodeVirtualEnvIsNotSet() {
     echo "v1.2.3"
   }
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unfunction node
 }
@@ -50,7 +50,7 @@ function testNodeenvSegmentPrintsAtLeastNodeEnvWithoutNode() {
   alias node="nonode 2>/dev/null"
   NODE_VIRTUAL_ENV="node-env"
 
-  assertEquals "%K{000} %F{002}⬢ %F{002}[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}⬢ %F{002}\${(Q)\${:-\"[node-env]\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset NODE_VIRTUAL_ENV
   unalias node
@@ -64,7 +64,7 @@ function testNodeenvSegmentWorks() {
   }
   NODE_VIRTUAL_ENV="node-env"
 
-  assertEquals "%K{000} %F{002}⬢ %F{002}v1.2.3[node-env] %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}⬢ %F{002}\${(Q)\${:-\"v1.2.3[node-env]\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction node
   unset NODE_VIRTUAL_ENV

--- a/segments/nvm/nvm.spec
+++ b/segments/nvm/nvm.spec
@@ -39,7 +39,7 @@ function testNvmSegmentPrintsNothingIfNvmIsNotAvailable() {
   P9K_LEFT_PROMPT_ELEMENTS=(nvm custom_world)
   local P9K_CUSTOM_WORLD='echo world'
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNvmSegmentWorksWithoutHavingADefaultAlias() {
@@ -50,7 +50,7 @@ function testNvmSegmentWorksWithoutHavingADefaultAlias() {
     [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v1.4.0'
   }
 
-  assertEquals "%K{005} %F{000}⬢ %F{000}4.6.0 %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{000}⬢ %F{000}\${(Q)\${:-\"4.6.0\"}} %k%F{005}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
@@ -62,7 +62,7 @@ function testNvmSegmentPrintsNothingWhenOnDefaultVersion() {
     [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v4.6.0'
   }
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testNvmSegmentAppendsSystemWhenUsingSystem() {
@@ -82,7 +82,7 @@ function testNvmSegmentAppendsSystemWhenUsingSystem() {
     [[ ${1} == 'current' ]] && echo 'system' || echo 'v1.4.0'
   }
 
-  assertEquals "%K{005} %F{000}⬢ %F{000}11.3.0 system %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{000}⬢ %F{000}\${(Q)\${:-\"11.3.0 system\"}} %k%F{005}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/php_version/php_version.spec
+++ b/segments/php_version/php_version.spec
@@ -20,7 +20,7 @@ function testPhpVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }
@@ -33,7 +33,7 @@ Copyright (c) 1997-2016 The PHP Group
 Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
 '"
 
-  assertEquals "%K{013} %F{255}PHP %F{255}5.6.27 %k%F{013}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{013} %F{255}PHP %F{255}\${(Q)\${:-\"5.6.27\"}} %k%F{013}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }

--- a/segments/public_ip/public_ip.spec
+++ b/segments/public_ip/public_ip.spec
@@ -48,7 +48,7 @@ function testPublicIpSegmentPrintsNothingByDefaultIfHostIsNotAvailable() {
   # uses an alternative host.
   alias dig='nodig'
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias dig
 }
@@ -62,7 +62,7 @@ function testPublicIpSegmentPrintsNoticeIfNotConnected() {
   # uses an alternative host.
   alias dig='nodig'
 
-  assertEquals "%K{000} %F{015}disconnected %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"disconnected\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unalias dig
 }
@@ -76,7 +76,7 @@ function testPublicIpSegmentWorksWithWget() {
     echo "wget 1.2.3.4"
   }
 
-  assertEquals "%K{000} %F{015}wget 1.2.3.4 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"wget 1.2.3.4\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction wget
   unalias dig
@@ -92,7 +92,7 @@ function testPublicIpSegmentUsesCurlAsFallbackMethodIfWgetIsNotAvailable() {
     echo "curl 1.2.3.4"
   }
 
-  assertEquals "%K{000} %F{015}curl 1.2.3.4 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"curl 1.2.3.4\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction curl
   unalias dig
@@ -109,7 +109,7 @@ function testPublicIpSegmentUsesDigAsFallbackMethodIfWgetAndCurlAreNotAvailable(
   }
 
   # Load Powerlevel9k
-  assertEquals "%K{000} %F{015}dig 1.2.3.4 %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"dig 1.2.3.4\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
   unalias curl
@@ -124,14 +124,14 @@ function testPublicIpSegmentCachesFile() {
     echo "first"
   }
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"first\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   dig() {
     echo "second"
   }
 
   # Segment should not have changed!
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"first\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
 }
@@ -144,15 +144,15 @@ function testPublicIpSegmentRefreshesCachesFileAfterTimeout() {
     echo "first"
   }
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"first\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   sleep 3
   dig() {
     echo "second"
   }
 
-  # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  # Segment should have changed!
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"second\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
 }
@@ -164,7 +164,7 @@ function testPublicIpSegmentRefreshesCachesFileIfEmpty() {
     echo "first"
   }
 
-  assertEquals "%K{000} %F{015}first %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"first\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   # Truncate cache file
   echo "" >! $P9K_PUBLIC_IP_FILE
@@ -173,8 +173,8 @@ function testPublicIpSegmentRefreshesCachesFileIfEmpty() {
     echo "second"
   }
 
-  # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  # Segment should have changed!
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"second\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
 }
@@ -186,7 +186,7 @@ function testPublicIpSegmentWhenGoingOnline() {
   local P9K_PUBLIC_IP_NONE="disconnected"
   alias dig="nodig"
 
-  assertEquals "%K{000} %F{015}disconnected %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"disconnected\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unalias dig
 
@@ -194,8 +194,8 @@ function testPublicIpSegmentWhenGoingOnline() {
     echo "second"
   }
 
-  # Segment should not have changed!
-  assertEquals "%K{000} %F{015}second %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  # Segment should have changed!
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"second\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unfunction dig
 }

--- a/segments/ram/ram.spec
+++ b/segments/ram/ram.spec
@@ -40,7 +40,7 @@ Pages inactive:                         1313411.
 
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{003} %F{000}RAM %F{000}6.15G " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM %F{000}\${(Q)\${:-\"6.15G\"}} " "$(prompt_ram left 1 false ${FOLDER})"
 
   unalias vm_stat
 }
@@ -51,7 +51,7 @@ function testRamSegmentWorksOnBsd() {
 
   local __P9K_OS="BSD" # Fake BSD
 
-  assertEquals "%K{003} %F{000}RAM %F{000}0.29M " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM %F{000}\${(Q)\${:-\"0.29M\"}} " "$(prompt_ram left 1 false ${FOLDER})"
   return 0
 }
 
@@ -61,7 +61,7 @@ function testRamSegmentWorksOnLinux() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}RAM %F{000}0.29G " "$(prompt_ram left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}RAM %F{000}\${(Q)\${:-\"0.29G\"}} " "$(prompt_ram left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/segments/rust_version/rust_version.spec
+++ b/segments/rust_version/rust_version.spec
@@ -36,7 +36,7 @@ function testRust() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
-  assertEquals "%K{208} %F{000}Rust %F{000}0.4.1a-alpha %k%F{208}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{208} %F{000}Rust %F{000}\${(Q)\${:-\"0.4.1a-alpha\"}} %k%F{208}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testRustPrintsNothingIfRustIsNotAvailable() {
@@ -45,7 +45,7 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unset P9K_CUSTOM_WORLD
   unalias rustc

--- a/segments/ssh/ssh.spec
+++ b/segments/ssh/ssh.spec
@@ -24,7 +24,7 @@ function testSshSegmentPrintsNothingIfNoSshConnection() {
   unset SSH_CLIENT
   unset SSH_TTY
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testSshSegmentWorksIfOnlySshClientIsSet() {
@@ -37,7 +37,7 @@ function testSshSegmentWorksIfOnlySshClientIsSet() {
   SSH_CLIENT='ssh-client'
   unset SSH_TTY
 
-  assertEquals "%K{000} %F{003}ssh-icon %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon %F{003}\${(Q)\${:-\"\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_CLIENT
 }
@@ -52,7 +52,7 @@ function testSshSegmentWorksIfOnlySshTtyIsSet() {
   SSH_TTY='ssh-tty'
   unset SSH_CLIENT
 
-  assertEquals "%K{000} %F{003}ssh-icon %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon %F{003}\${(Q)\${:-\"\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_TTY
 }
@@ -67,7 +67,7 @@ function testSshSegmentWorksIfAllNecessaryVariablesAreSet() {
   SSH_CLIENT='ssh-client'
   SSH_TTY='ssh-tty'
 
-  assertEquals "%K{000} %F{003}ssh-icon %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{003}ssh-icon %F{003}\${(Q)\${:-\"\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
   unset SSH_TTY
   unset SSH_CLIENT

--- a/segments/stack_project/stack_project.spec
+++ b/segments/stack_project/stack_project.spec
@@ -62,7 +62,7 @@ function testStackProjectSegment() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(stack_project)
 
-  assertEquals "%K{056} %F{015}λ= %F{015}Stack %k%F{056}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{056} %F{015}λ= %F{015}\${(Q)\${:-\"Stack\"}} %k%F{056}%f " "$(__p9k_build_left_prompt)"
 
   unalias stack
 }
@@ -75,7 +75,7 @@ function testStackProjectSegmentNoStackYaml() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias stack
   unalias __p9k_upsearch
@@ -87,7 +87,7 @@ function testStackProjectSegmentIfStackIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias stack
 }
@@ -98,7 +98,7 @@ function testStackProjectSegmentPrintsNothingIfStackIsNotAvailable() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world stack_project)
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias stack
 }

--- a/segments/status/status.spec
+++ b/segments/status/status.spec
@@ -82,7 +82,7 @@ function testStatusSegmentIntegrated() {
 
   false; __p9k_save_retvals; __p9k_prepare_prompts
 
-  assertEquals "%f%b%k%K{000} %F{001}✘ %F{001}\${(Q)\${:-\"\"}} %k%F{000}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%K{000} %F{001}✘ %F{001} %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/shunit2

--- a/segments/status/status.spec
+++ b/segments/status/status.spec
@@ -25,7 +25,7 @@ function testStatusPrintsNothingIfReturnCodeIsZeroAndVerboseIsUnset() {
   local P9K_STATUS_VERBOSE=false
   local P9K_STATUS_SHOW_PIPESTATUS=false
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
@@ -34,7 +34,7 @@ function testStatusWorksAsExpectedIfReturnCodeIsZeroAndVerboseIsSet() {
   local P9K_STATUS_HIDE_SIGNAME=true
   local P9K_LEFT_PROMPT_ELEMENTS=(status)
 
-  assertEquals "%K{000} %F{002}✔ %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{002}✔ %F{002}\${(Q)\${:-\"\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusInGeneralErrorCase() {
@@ -43,7 +43,7 @@ function testStatusInGeneralErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_SHOW_PIPESTATUS=false
 
-  assertEquals "%K{001} %F{226}↵ %F{226}1 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵ %F{226}\${(Q)\${:-\"1\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testPipestatusInErrorCase() {
@@ -53,7 +53,7 @@ function testPipestatusInErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_SHOW_PIPESTATUS=true
 
-  assertEquals "%K{001} %F{226}↵ %F{226}0|0|1|0 %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵ %F{226}\${(Q)\${:-\"0|0|1|0\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusCrossWinsOverVerbose() {
@@ -63,7 +63,7 @@ function testStatusCrossWinsOverVerbose() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_CROSS=true
 
-  assertEquals "%K{000} %F{001}✘ %k%F{000}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{000} %F{001}✘ %F{001}\${(Q)\${:-\"\"}} %k%F{000}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusShowsSignalNameInErrorCase() {
@@ -73,7 +73,7 @@ function testStatusShowsSignalNameInErrorCase() {
   local P9K_STATUS_VERBOSE=true
   local P9K_STATUS_HIDE_SIGNAME=false
 
-  assertEquals "%K{001} %F{226}↵ %F{226}SIGILL(4) %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{226}↵ %F{226}\${(Q)\${:-\"SIGILL(4)\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStatusSegmentIntegrated() {
@@ -82,7 +82,7 @@ function testStatusSegmentIntegrated() {
 
   false; __p9k_save_retvals; __p9k_prepare_prompts
 
-  assertEquals "%f%b%k%K{000} %F{001}✘ %k%F{000}%f " "${(e)PROMPT}"
+  assertEquals "%f%b%k%K{000} %F{001}✘ %F{001}\${(Q)\${:-\"\"}} %k%F{000}%f " "${(e)PROMPT}"
 }
 
 source shunit2/shunit2

--- a/segments/swap/swap.spec
+++ b/segments/swap/swap.spec
@@ -40,7 +40,7 @@ function testSwapSegmentWorksOnOsx() {
 
   local __P9K_OS="OSX" # Fake OSX
 
-  assertEquals "%K{003} %F{000}SWP %F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}SWP %F{000}\${(Q)\${:-\"1.58G\"}} " "$(prompt_swap left 1 false ${FOLDER})"
 
   unfunction sysctl
 }
@@ -54,7 +54,7 @@ function testSwapSegmentWorksOnLinux() {
 
   local __P9K_OS="Linux" # Fake Linux
 
-  assertEquals "%K{003} %F{000}SWP %F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"
+  assertEquals "%K{003} %F{000}SWP %F{000}\${(Q)\${:-\"0.95G\"}} " "$(prompt_swap left 1 false ${FOLDER})"
 }
 
 source shunit2/shunit2

--- a/segments/swift_version/swift_version.spec
+++ b/segments/swift_version/swift_version.spec
@@ -37,7 +37,7 @@ function testSwiftSegmentPrintsNothingIfSwiftIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   alias swift="noswift"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias swift
 }
@@ -49,7 +49,7 @@ function testSwiftSegmentWorks() {
     echo "Apple Swift version 3.0.1 (swiftlang-800.0.58.6 clang-800.0.42.1)\nTarget: x86_64-apple-macosx10.9"
   }
 
-  assertEquals "%K{005} %F{015}Swift %F{015}3.0.1 %k%F{005}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{005} %F{015}Swift %F{015}\${(Q)\${:-\"3.0.1\"}} %k%F{005}%f " "$(__p9k_build_left_prompt)"
 
   unfunction swift
 }

--- a/segments/symfony2_version/symfony_version.spec
+++ b/segments/symfony2_version/symfony_version.spec
@@ -37,7 +37,7 @@ function testSymfonyVersionSegmentPrintsNothingIfPhpIsNotAvailable() {
   local P9K_CUSTOM_WORLD='echo world'
   alias php="nophp"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }
@@ -50,7 +50,7 @@ function testSymfonyVersionSegmentPrintsNothingIfSymfonyIsNotAvailable() {
   # navigate into a folder that does not contain symfony.
   local P9K_CUSTOM_WORLD='echo world'
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
@@ -65,7 +65,7 @@ function testSymfonyVersionPrintsNothingIfPhpThrowsAnError() {
     Parse error: parse error, expecting `;´ or `{´ in /Users/dr/Privat/vendor/ocramius/proxy-manager/src/ProxyManager/Configuration.php on line 97"
   }
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unfunction php
 }
@@ -81,7 +81,7 @@ function testSymfonyVersionSegmentWorks() {
     echo "Symfony version 3.1.4 - app/dev/debug"
   }
 
-  assertEquals "%K{240} %F{000}SF%f %F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{240} %F{000}SF%f %F{000}\${(Q)\${:-\"3.1.4\"}} %k%F{240}%f " "$(__p9k_build_left_prompt)"
 
   unfunction php
 }
@@ -100,7 +100,7 @@ function testSymfonyVersionSegmentWorksInNestedFolder() {
   mkdir -p src/P9K/AppBundle
   cd src/P9K/AppBundle
 
-  assertEquals "%K{240} %F{000}SF%f %F{000}3.1.4 %k%F{240}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{240} %F{000}SF%f %F{000}\${(Q)\${:-\"3.1.4\"}} %k%F{240}%f " "$(__p9k_build_left_prompt)"
 
   unfunction php
 }

--- a/segments/todo/todo.spec
+++ b/segments/todo/todo.spec
@@ -42,7 +42,7 @@ function testTodoSegmentPrintsNothingIfTodoShIsNotInstalled() {
   local P9K_CUSTOM_WORLD='echo world'
   alias todo.sh="echo"
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 
   unalias todo.sh
 }
@@ -55,7 +55,7 @@ function testTodoSegmentWorksAsExpected() {
   echo 'echo "TODO: 34 of 100 tasks shown";' >> ${FOLDER}/bin/todo.sh
   chmod +x ${FOLDER}/bin/todo.sh
 
-  assertEquals "%K{244} %F{000}☑ %F{000}100 %k%F{244}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{244} %F{000}☑ %F{000}\${(Q)\${:-\"100\"}} %k%F{244}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/vagrant/vagrant.spec
+++ b/segments/vagrant/vagrant.spec
@@ -50,7 +50,7 @@ function testVagrantSegmentPrintsNothingIfVirtualboxIsNotAvailable() {
   # Change path, so that VBoxManage is not found
   local PATH=/bin:/usr/bin
 
-  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentSaysVmIsDownIfVirtualboxIsNotAvailableButVagrantFolderExists() {
@@ -61,7 +61,7 @@ function testVagrantSegmentSaysVmIsDownIfVirtualboxIsNotAvailableButVagrantFolde
   local PATH=/bin:/usr/bin
   mockVagrantFolder "some-id"
 
-  assertEquals "%K{001} %F{000}V %F{000}DOWN %K{015}%F{001} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V %F{000}\${(Q)\${:-\"DOWN\"}} %K{015}%F{001} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsUp() {
@@ -71,7 +71,7 @@ function testVagrantSegmentWorksIfVmIsUp() {
   mockVBoxManage "${vagrantId}"
   mockVagrantFolder "${vagrantId}"
 
-  assertEquals "%K{002} %F{000}V %F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V %F{000}\${(Q)\${:-\"UP\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsDown() {
@@ -81,7 +81,7 @@ function testVagrantSegmentWorksIfVmIsDown() {
   mockVBoxManage "${vagrantId}"
   mockVagrantFolder "another-vm-id"
 
-  assertEquals "%K{001} %F{000}V %F{000}DOWN %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V %F{000}\${(Q)\${:-\"DOWN\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWorksIfVmIsUpFromWithinSubdir() {
@@ -94,7 +94,7 @@ function testVagrantSegmentWorksIfVmIsUpFromWithinSubdir() {
   mkdir -p "subfolder/1/2/3"
   cd subfolder/1/2/3
 
-  assertEquals "%K{002} %F{000}V %F{000}UP %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V %F{000}\${(Q)\${:-\"UP\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVagrantSegmentWithChangedString() {
@@ -104,11 +104,11 @@ function testVagrantSegmentWithChangedString() {
   mockVagrantFolder "${vagrantId}"
 
   local P9K_VAGRANT_DOWN_STRING="Nope"
-  assertEquals "%K{001} %F{000}V %F{000}Nope %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}V %F{000}\${(Q)\${:-\"Nope\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   mockVBoxManage "${vagrantId}"
   local P9K_VAGRANT_UP_STRING="Yep"
-  assertEquals "%K{002} %F{000}V %F{000}Yep %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}V %F{000}\${(Q)\${:-\"Yep\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -298,7 +298,7 @@ function +vi-vcs-icon() {
     remote=$(command git ls-remote --get-url 2> /dev/null)
     vcs_segment_icon=${__P9K_ICONS[VCS_GIT]}
   elif [[ "${hook_com[vcs]}" == "hg" ]]; then
-    remote=$(command hg paths default)
+    remote=$(command hg paths default 2> /dev/null)
     vcs_segment_icon=${__P9K_ICONS[VCS_HG]}
   elif [[ "${hook_com[vcs]}" == "svn" ]]; then
     remote="${svninfo[URL]}" # Set by VCS_INFO

--- a/segments/vcs/vcs_git.spec
+++ b/segments/vcs/vcs_git.spec
@@ -74,7 +74,7 @@ function testColorOverridingForCleanStateWorks() {
   local P9K_VCS_CLEAN_BACKGROUND='white'
   source "${P9K_HOME}/segments/vcs/vcs.p9k"
 
-  assertEquals "%K{015} %F{006} master %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{006}\${(Q)\${:-\" master\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingForModifiedStateWorks() {
@@ -89,7 +89,7 @@ function testColorOverridingForModifiedStateWorks() {
   git commit -m "test" 1>/dev/null
   echo "test" > testfile
 
-  assertEquals "%K{003} %F{001} master ● %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{001}\${(Q)\${:-\" master ●\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingForUntrackedStateWorks() {
@@ -101,7 +101,7 @@ function testColorOverridingForUntrackedStateWorks() {
 
   touch testfile
 
-  assertEquals "%K{003} %F{006}? %F{006} master ? %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{006}? %F{006}\${(Q)\${:-\" master ?\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitIconWorks() {
@@ -109,7 +109,7 @@ function testGitIconWorks() {
   local P9K_VCS_GIT_ICON='Git-icon'
   source "${P9K_HOME}/segments/vcs/vcs.p9k"
 
-  assertEquals "%K{002} %F{000}Git-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}Git-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitlabIconWorks() {
@@ -122,7 +122,7 @@ function testGitlabIconWorks() {
   # sufficient to show the GitLab-specific icon.
   git remote add origin https://gitlab.com/dritter/gitlab-test-project.git
 
-  assertEquals "%K{002} %F{000}GL-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GL-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBitbucketIconWorks() {
@@ -135,7 +135,7 @@ function testBitbucketIconWorks() {
   # sufficient to show the BitBucket-specific icon.
   git remote add origin https://dritter@bitbucket.org/dritter/dr-test.git
 
-  assertEquals "%K{002} %F{000}BB-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}BB-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitHubIconWorks() {
@@ -148,7 +148,7 @@ function testGitHubIconWorks() {
   # sufficient to show the GitHub-specific icon.
   git remote add origin https://github.com/dritter/test.git
 
-  assertEquals "%K{002} %F{000}GH-icon %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}GH-icon %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testUntrackedFilesIconWorks() {
@@ -159,7 +159,7 @@ function testUntrackedFilesIconWorks() {
   # Create untracked file
   touch "i-am-untracked.txt"
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStagedFilesIconWorks() {
@@ -175,7 +175,7 @@ function testStagedFilesIconWorks() {
   echo "xx" >> i-am-added.txt
   git add i-am-added.txt &>/dev/null
 
-  assertEquals "%K{003} %F{000} master + %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}\${(Q)\${:-\" master +\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testUnstagedFilesIconWorks() {
@@ -190,7 +190,7 @@ function testUnstagedFilesIconWorks() {
   git commit -m "Add File" 1>/dev/null
   echo "xx" > i-am-modified.txt
 
-  assertEquals "%K{003} %F{000} master M %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}\${(Q)\${:-\" master M\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testStashIconWorks() {
@@ -206,7 +206,7 @@ function testStashIconWorks() {
   echo "xx" > i-am-modified.txt
   git stash 1>/dev/null
 
-  assertEquals "%K{002} %F{000} master S1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master S1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testTagIconWorks() {
@@ -220,7 +220,7 @@ function testTagIconWorks() {
   git commit -m "Add File" 1>/dev/null
   git tag "v0.0.1"
 
-  assertEquals "%K{002} %F{000} master Tv0.0.1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master Tv0.0.1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testTagIconInDetachedHeadState() {
@@ -239,7 +239,7 @@ function testTagIconInDetachedHeadState() {
   git checkout v0.0.1 &>/dev/null
   local hash=$(git rev-list -n 1 --abbrev-commit --abbrev=8 HEAD)
 
-  assertEquals "%K{002} %F{000} ${hash} Tv0.0.1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" ${hash} Tv0.0.1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testActionHintWorks() {
@@ -260,7 +260,7 @@ function testActionHintWorks() {
   git commit -a -m "Provoke conflict" &>/dev/null
   git pull --no-ff  &>/dev/null
 
-  assertEquals "%K{003} %F{000} master %F{001}| merge 1/1 ↑1 ↓1%f %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}\${(Q)\${:-\" master %F{001}| merge 1/1 ↑1 ↓1%f\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testIncomingHintWorks() {
@@ -280,7 +280,7 @@ function testIncomingHintWorks() {
   cd ../vcs-test2
   git fetch &>/dev/null
 
-  assertEquals "%K{002} %F{000} master I1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master I1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testOutgoingHintWorks() {
@@ -300,7 +300,7 @@ function testOutgoingHintWorks() {
   echo "xx" >> i-am-modified.txt
   git commit -a -m "Modified file" &>/dev/null
 
-  assertEquals "%K{002} %F{000} master O1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master O1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testShorteningCommitHashWorks() {
@@ -318,7 +318,7 @@ function testShorteningCommitHashWorks() {
   # This test needs to call __p9k_vcs_init, where
   # the changeset is truncated.
   __p9k_vcs_init
-  assertEquals "%K{002} %F{000}${hash}  master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\"${hash}  master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testShorteningCommitHashIsNotShownIfShowChangesetIsFalse() {
@@ -335,7 +335,7 @@ function testShorteningCommitHashIsNotShownIfShowChangesetIsFalse() {
   # This test needs to call __p9k_vcs_init, where
   # the changeset is truncated.
   __p9k_vcs_init
-  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameTruncatingShortenLength() {
@@ -348,10 +348,10 @@ function testBranchNameTruncatingShortenLength() {
 
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_LENGTH=3
-  assertEquals "%K{002} %F{000}? %F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" mas… ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameTruncatingMinLength() {
@@ -364,11 +364,11 @@ function testBranchNameTruncatingMinLength() {
 
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_MIN_LENGTH=7
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameTruncatingShortenStrategy() {
@@ -381,11 +381,11 @@ function testBranchNameTruncatingShortenStrategy() {
 
   touch testfile
 
-  assertEquals "%K{002} %F{000}? %F{000} mas… ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" mas… ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_SHORTEN_STRATEGY="truncate_middle"
 
-  assertEquals "%K{002} %F{000}? %F{000} mas…ter ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" mas…ter ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testRemoteBranchNameIdenticalToTag() {
@@ -410,7 +410,7 @@ function testRemoteBranchNameIdenticalToTag() {
 
   git checkout test 1>/dev/null 2>&1
 
-  assertEquals "%K{002} %F{000} test test %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" test test\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testAlwaysShowRemoteBranch() {
@@ -426,10 +426,10 @@ function testAlwaysShowRemoteBranch() {
   git clone . ../vcs-test2 1>/dev/null 2>&1
   cd ../vcs-test2
 
-  assertEquals "%K{002} %F{000} master→origin/master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master→origin/master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='false'
-  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testGitDirClobber() {
@@ -463,7 +463,7 @@ function testGitDirClobber() {
   # so for git this is a repo inside another repo.
   cd vcs-test2
 
-  assertEquals "%K{001} %F{000}✘ clob /tmp/powerlevel9k-test/test-dotfiles  master ✚ ? %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}\${(Q)\${:-\"✘ clob /tmp/powerlevel9k-test/test-dotfiles  master ✚ ?\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unset GIT_DIR
   unset GIT_WORK_TREE
@@ -494,7 +494,7 @@ function testDetectingUntrackedFilesInSubmodulesWork() {
   touch "i-am-untracked.txt"
   cd -
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
@@ -519,7 +519,7 @@ function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
   # Create untracked file
   touch "i-am-untracked.txt"
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectingUntrackedFilesInNestedSubmodulesWork() {
@@ -561,7 +561,7 @@ function testDetectingUntrackedFilesInNestedSubmodulesWork() {
   touch "i-am-untracked.txt"
   cd -
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
@@ -583,7 +583,7 @@ function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
   touch dirty-folder/new-file.txt
   cd clean-folder
 
-  assertEquals "%K{002} %F{000}? %F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}? %F{000}\${(Q)\${:-\" master ?\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameScriptingVulnerability() {
@@ -597,7 +597,7 @@ function testBranchNameScriptingVulnerability() {
   git add . 2>/dev/null
   git commit -m "Initial commit" >/dev/null
 
-  assertEquals '%K{002} %F{000} $(./evil_script.sh) %k%F{002}%f ' "$(__p9k_build_left_prompt)"
+  assertEquals '%K{002} %F{000}${(Q)${:-" \$(./evil_script.sh)"}} %k%F{002}%f ' "$(__p9k_build_left_prompt)"
 }
 
 function testGitSubmoduleWorks() {
@@ -624,7 +624,7 @@ function testGitSubmoduleWorks() {
   local result="$(__p9k_build_left_prompt 2>&1)"
   [[ "$result" =~ ".*(is outside repository)+" ]] && return 1
 
-  assertEquals "%K{002} %F{000} master %k%F{002}%f " "$result"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" master\"}} %k%F{002}%f " "$result"
 }
 
 function testVcsSegmentDoesNotLeakPercentEscapesInGitRepo() {
@@ -640,7 +640,7 @@ function testVcsSegmentDoesNotLeakPercentEscapesInGitRepo() {
   git checkout -b '%E%K{red}' 2>/dev/null
   git tag '%E%F{blue}' >/dev/null
 
-  assertEquals "%K{002} %F{000} %%E%%K{red} %%E%%F{blue} %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" %%E%%K{red} %%E%%F{blue}\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/vcs/vcs_hg.spec
+++ b/segments/vcs/vcs_hg.spec
@@ -45,7 +45,7 @@ function testColorOverridingForCleanStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{015} %F{006} default %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{006}\${(Q)\${:-\" default\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingForModifiedStateWorks() {
@@ -62,7 +62,7 @@ function testColorOverridingForModifiedStateWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{003} %F{001} default ● %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{001}\${(Q)\${:-\" default ●\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 # There is no staging area in mercurial, therefore there are no "untracked"
@@ -79,7 +79,7 @@ function testAddedFilesIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{003} %F{000} default ● %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}\${(Q)\${:-\" default ●\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 # We don't support tagging in mercurial right now..
@@ -97,7 +97,7 @@ function testTagIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{002} %F{000} default Tv0.0.1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" default Tv0.0.1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testTagIconInDetachedHeadState() {
@@ -119,7 +119,7 @@ function testTagIconInDetachedHeadState() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{002} %F{000} ${hash} Tv0.0.1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" ${hash} Tv0.0.1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testActionHintWorks() {
@@ -142,7 +142,7 @@ function testActionHintWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{003} %F{000} default %F{001}| merging%f %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{000}\${(Q)\${:-\" default %F{001}| merging%f\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testShorteningCommitHashWorks() {
@@ -163,7 +163,7 @@ function testShorteningCommitHashWorks() {
   # the changeset is truncated.
   __p9k_vcs_init
 
-  assertEquals "%K{002} %F{000}${hash}  default %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\"${hash}  default\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testShorteningCommitHashIsNotShownIfShowChangesetIsFalse() {
@@ -183,7 +183,7 @@ function testShorteningCommitHashIsNotShownIfShowChangesetIsFalse() {
   # the changeset is truncated.
   __p9k_vcs_init
 
-  assertEquals "%K{002} %F{000} default %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" default\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testMercurialIconWorks() {
@@ -194,7 +194,7 @@ function testMercurialIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{002} %F{000}HG-icon %F{000} default %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}HG-icon %F{000}\${(Q)\${:-\" default\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBookmarkIconWorks() {
@@ -206,7 +206,7 @@ function testBookmarkIconWorks() {
   # Load Powerlevel9k
   source ${P9K_HOME}/segments/vcs/vcs.p9k
 
-  assertEquals "%K{002} %F{000} default Binitial %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" default Binitial\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameScriptingVulnerability() {
@@ -219,7 +219,7 @@ function testBranchNameScriptingVulnerability() {
   hg add . >/dev/null
   hg commit -m "Initial commit" >/dev/null
 
-  assertEquals '%K{002} %F{000} $(./evil_script.sh) %k%F{002}%f ' "$(__p9k_build_left_prompt)"
+  assertEquals '%K{002} %F{000}${(Q)${:-" \$(./evil_script.sh)"}} %k%F{002}%f ' "$(__p9k_build_left_prompt)"
 }
 
 function testVcsSegmentDoesNotLeakPercentEscapesInMercurialRepo() {
@@ -234,7 +234,7 @@ function testVcsSegmentDoesNotLeakPercentEscapesInMercurialRepo() {
 
   hg branch '%E%K{red}' >/dev/null
 
-  assertEquals "%K{002} %F{000} %%E%%K{red} %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\" %%E%%K{red}\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/vcs/vcs_svn.spec
+++ b/segments/vcs/vcs_svn.spec
@@ -53,7 +53,7 @@ function testVcsSegmentDoesNotLeakPercentEscapesInSvnRepo() {
   svn checkout "${REPO_URL}" "${branchFolder}" >/dev/null
   cd "${branchFolder}"
 
-  assertEquals "%K{002} %F{000}svn-repo:1 %k%F{002}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{002} %F{000}\${(Q)\${:-\"svn-repo:1\"}} %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/segments/vi_mode/vi_mode.spec
+++ b/segments/vi_mode/vi_mode.spec
@@ -19,7 +19,7 @@ function testViInsertModeWorks() {
   # Load Powerlevel9k
   source segments/vi_mode/vi_mode.p9k
 
-  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}\${(Q)\${:-\"INSERT\"}} " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViInsertModeWorksWhenLabeledAsMain() {
@@ -28,7 +28,7 @@ function testViInsertModeWorksWhenLabeledAsMain() {
   # Load Powerlevel9k
   source segments/vi_mode/vi_mode.p9k
 
-  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}\${(Q)\${:-\"INSERT\"}} " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViCommandModeWorks() {
@@ -37,7 +37,7 @@ function testViCommandModeWorks() {
   # Load Powerlevel9k
   source segments/vi_mode/vi_mode.p9k
 
-  assertEquals "%K{000} %F{015}NORMAL " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{015}\${(Q)\${:-\"NORMAL\"}} " "$(prompt_vi_mode left 1 false)"
 }
 
 function testViInsertModeStringIsCustomizable() {
@@ -46,7 +46,7 @@ function testViInsertModeStringIsCustomizable() {
   # Load Powerlevel9k
   source segments/vi_mode/vi_mode.p9k
 
-  assertEquals "%K{000} %F{004}INSERT " "$(prompt_vi_mode left 1 false)"
+  assertEquals "%K{000} %F{004}\${(Q)\${:-\"INSERT\"}} " "$(prompt_vi_mode left 1 false)"
 }
 
 source shunit2/shunit2

--- a/segments/vpn_ip/vpn_ip.spec
+++ b/segments/vpn_ip/vpn_ip.spec
@@ -165,7 +165,7 @@ function testVpnIpSegmentWorksOnOsxWithInterfaceSpecified() {
   source segments/vpn_ip/vpn_ip.p9k
   local OS='OSX' # Fake OSX
 
-  assertEquals "%K{006} %F{000}(vpn) %F{000}1.2.3.4 " "$(prompt_vpn_ip left 1 false "$FOLDER")"
+  assertEquals "%K{006} %F{000}(vpn) %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_vpn_ip left 1 false "$FOLDER")"
 }
 
 function testVpnIpSegmentWorksOnLinuxWithInterfaceSpecified() {
@@ -178,7 +178,7 @@ function testVpnIpSegmentWorksOnLinuxWithInterfaceSpecified() {
     source segments/vpn_ip/vpn_ip.p9k
     local OS='Linux' # Fake Linux
 
-    assertEquals "%K{006} %F{000}(vpn) %F{000}1.2.3.4 " "$(prompt_vpn_ip left 1 false "$FOLDER")"
+    assertEquals "%K{006} %F{000}(vpn) %F{000}\${(Q)\${:-\"1.2.3.4\"}} " "$(prompt_vpn_ip left 1 false "$FOLDER")"
 }
 
 # vpn_ip is not capable of handling multiple vpn interfaces ATM.
@@ -193,7 +193,7 @@ function testVpnIpSegmentWorksOnLinuxWithInterfaceSpecified() {
 #     local OS='Linux' # Fake Linux
 
 # setopt xtrace
-#     assertEquals "%K{006} %F{000}(vpn) %F{000}10.0.2.15 " "$(prompt_vpn_ip left 1 false "$FOLDER")"
+#     assertEquals "%K{006} %F{000}(vpn) %F{000}\${(Q)\${:-\"10.0.2.15\"}} " "$(prompt_vpn_ip left 1 false "$FOLDER")"
 #     unsetopt xtrace
 # }
 

--- a/test/core/bold.spec
+++ b/test/core/bold.spec
@@ -27,8 +27,8 @@ function testNoBoldOnregularSegment(){
   local P9K_DATE_ICON="date-icon"
   source segments/date/date.p9k
   
-  assertEquals "%K{015} %F{000}date-icon %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} %D{%d.%m.%y} %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}date-icon %F{000}\${(Q)\${:-\"%D{%d.%m.%y}\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"%D{%d.%m.%y}\"}} %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnRegularSegments() {
@@ -38,8 +38,8 @@ function testBoldOnRegularSegments() {
   local P9K_DATE_BOLD=true
   source segments/date/date.p9k
 
-  assertEquals "%K{015} %F{000}date-icon %F{000}%B%D{%d.%m.%y}%b %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} %B%D{%d.%m.%y}%b %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}date-icon %F{000}\${(Q)\${:-\"%B%D{%d.%m.%y}%b\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"%B%D{%d.%m.%y}%b\"}} %F{000}date-icon%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnRegularSegmentVisualIdentifiers() {
@@ -49,8 +49,8 @@ function testBoldOnRegularSegmentVisualIdentifiers() {
   local P9K_DATE_ICON_BOLD=true
   source segments/date/date.p9k
 
-  assertEquals "%K{015} %F{000}%Bdate-icon%b %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} %D{%d.%m.%y} %F{000}%Bdate-icon%b%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}%Bdate-icon%b %F{000}\${(Q)\${:-\"%D{%d.%m.%y}\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"%D{%d.%m.%y}\"}} %F{000}%Bdate-icon%b%f " "$(__p9k_build_right_prompt)"
 }
 
 # Stateful Segment
@@ -62,8 +62,8 @@ function testNotBoldOnStatefulSegment() {
   local SSH_CLIENT="x"
   source segments/host/host.p9k
 
-  assertEquals "%K{003} %F{000}ssh-icon %F{000}%m %k%F{003}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{003}%K{003}%F{000} %m %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{003} %F{000}ssh-icon %F{000}\${(Q)\${:-\"%m\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} \${(Q)\${:-\"%m\"}} %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnStatefulSegment() {
@@ -75,8 +75,8 @@ function testBoldOnStatefulSegment() {
   local SSH_CLIENT="x"
   source segments/host/host.p9k
 
-  assertEquals "%K{003} %F{000}ssh-icon %F{000}%B%m%b %k%F{003}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{003}%K{003}%F{000} %B%m%b %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{003} %F{000}ssh-icon %F{000}\${(Q)\${:-\"%B%m%b\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} \${(Q)\${:-\"%B%m%b\"}} %F{000}ssh-icon%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnStatefulVisualIdentifiers() {
@@ -88,8 +88,8 @@ function testBoldOnStatefulVisualIdentifiers() {
   local SSH_CLIENT="x"
   source segments/host/host.p9k
 
-  assertEquals "%K{003} %F{000}%Bssh-icon%b %F{000}%m %k%F{003}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{003}%K{003}%F{000} %m %F{000}%Bssh-icon%b%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{003} %F{000}%Bssh-icon%b %F{000}\${(Q)\${:-\"%m\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{003}%K{003}%F{000} \${(Q)\${:-\"%m\"}} %F{000}%Bssh-icon%b%f " "$(__p9k_build_right_prompt)"
 }
 
 # Custom Segment
@@ -99,8 +99,8 @@ function testNotBoldOnCustomSegment() {
   local P9K_CUSTOM_WORLD='echo world'
   local P9K_CUSTOM_WORLD_ICON='CW'
 
-  assertEquals "%K{015} %F{000}CW %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} world %F{000}CW%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}CW %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world\"}} %F{000}CW%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnCustomSegment() {
@@ -110,8 +110,8 @@ function testBoldOnCustomSegment() {
   local P9K_CUSTOM_WORLD_ICON='CW'
   local P9K_CUSTOM_WORLD_BOLD=true
 
-  assertEquals "%K{015} %F{000}CW %F{000}%Bworld%b %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} %Bworld%b %F{000}CW%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}CW %F{000}\${(Q)\${:-\"%Bworld%b\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"%Bworld%b\"}} %F{000}CW%f " "$(__p9k_build_right_prompt)"
 }
 
 function testBoldOnCustomSegmentVisualIdentifiers() {
@@ -121,8 +121,8 @@ function testBoldOnCustomSegmentVisualIdentifiers() {
   local P9K_CUSTOM_WORLD_ICON='CW'
   local P9K_CUSTOM_WORLD_ICON_BOLD=true
 
-  assertEquals "%K{015} %F{000}%BCW%b %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000} world %F{000}%BCW%b%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%K{015} %F{000}%BCW%b %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world\"}} %F{000}%BCW%b%f " "$(__p9k_build_right_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -19,7 +19,7 @@ function testDynamicColoringOfSegmentsWork() {
   local P9K_DATE_BACKGROUND='red'
   source segments/date/date.p9k
 
-  assertEquals "%K{001} %F{000}date-icon %F{000}%D{%d.%m.%y} %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}date-icon %F{000}\${(Q)\${:-\"%D{%d.%m.%y}\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testDynamicColoringOfVisualIdentifiersWork() {
@@ -28,7 +28,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
   local P9K_DATE_ICON_COLOR='green'
   source segments/date/date.p9k
 
-  assertEquals "%K{015} %F{002}date-icon %F{000}%D{%d.%m.%y} %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{002}date-icon %F{000}\${(Q)\${:-\"%D{%d.%m.%y}\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
@@ -39,7 +39,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
   local P9K_DATE_BACKGROUND='yellow'
   source segments/date/date.p9k
 
-  assertEquals "%K{003} %F{002}date-icon %F{001}%D{%d.%m.%y} %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{002}date-icon %F{001}\${(Q)\${:-\"%D{%d.%m.%y}\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingOfStatefulSegment() {
@@ -51,7 +51,7 @@ function testColorOverridingOfStatefulSegment() {
   local SSH_CLIENT="x"
   source segments/host/host.p9k
 
-  assertEquals "%K{001} %F{002}ssh-icon %F{002}%m %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{002}ssh-icon %F{002}\${(Q)\${:-\"%m\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testColorOverridingOfCustomSegment() {
@@ -62,7 +62,7 @@ function testColorOverridingOfCustomSegment() {
   local P9K_CUSTOM_WORLD_FOREGROUND='red'
   local P9K_CUSTOM_WORLD_BACKGROUND='red'
 
-  assertEquals "%K{001} %F{002}CW %F{001}world %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{002}CW %F{001}\${(Q)\${:-\"world\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -23,7 +23,7 @@ function testLeftNormalSegmentsShouldNotBeJoined() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%K{015} %F{000}world1  %F{000}world2  %F{000}world4  %F{000}world6 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}}  %F{000}\${(Q)\${:-\"world2\"}}  %F{000}\${(Q)\${:-\"world4\"}}  %F{000}\${(Q)\${:-\"world6\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftJoinedSegments() {
@@ -32,7 +32,7 @@ function testLeftJoinedSegments() {
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
-  assertEquals "%K{015} %F{000}world1 %F{000}world2 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %F{000}\${(Q)\${:-\"world2\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftTransitiveJoinedSegments() {
@@ -42,7 +42,7 @@ function testLeftTransitiveJoinedSegments() {
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%K{015} %F{000}world1 %F{000}world2 %F{000}world3 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %F{000}\${(Q)\${:-\"world2\"}} %F{000}\${(Q)\${:-\"world3\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
@@ -53,7 +53,7 @@ function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%K{015} %F{000}world1 %F{000}world2 %F{000}world4 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %F{000}\${(Q)\${:-\"world2\"}} %F{000}\${(Q)\${:-\"world4\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithConditionalPredecessor() {
@@ -63,7 +63,7 @@ function testLeftPromotingSegmentWithConditionalPredecessor() {
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%K{015} %F{000}world1  %F{000}world3 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}}  %F{000}\${(Q)\${:-\"world3\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
@@ -74,7 +74,7 @@ function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%K{015} %F{000}world1  %F{000}world4 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}}  %F{000}\${(Q)\${:-\"world4\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
@@ -87,7 +87,7 @@ function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%K{015} %F{000}world1  %F{000}world4 %F{000}world6 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}}  %F{000}\${(Q)\${:-\"world4\"}} %F{000}\${(Q)\${:-\"world6\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testLeftJoiningBuiltinSegmentWorks() {
@@ -96,7 +96,7 @@ function testLeftJoiningBuiltinSegmentWorks() {
   alias php="echo PHP 1.2.3 "
   source segments/php_version/php_version.p9k
 
-  assertEquals "%K{013} %F{255}PHP %F{255}1.2.3 %F{255}PHP %F{255}1.2.3 %k%F{013}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{013} %F{255}PHP %F{255}\${(Q)\${:-\"1.2.3\"}} %F{255}PHP %F{255}\${(Q)\${:-\"1.2.3\"}} %k%F{013}%f " "$(__p9k_build_left_prompt)"
 
   unalias php
 }
@@ -112,7 +112,7 @@ function testRightNormalSegmentsShouldNotBeJoined() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world2 %F{000}%K{015}%F{000} world4 %F{000}%K{015}%F{000} world6 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world2\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world4\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world6\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightJoinedSegments() {
@@ -122,7 +122,7 @@ function testRightJoinedSegments() {
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %K{015}%F{000}\${(Q)\${:-\"world2\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightTransitiveJoinedSegments() {
@@ -133,7 +133,7 @@ function testRightTransitiveJoinedSegments() {
   local P9K_CUSTOM_WORLD2="echo world2"
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 %K{015}%F{000}world3 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %K{015}%F{000}\${(Q)\${:-\"world2\"}} %K{015}%F{000}\${(Q)\${:-\"world3\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightTransitiveJoiningWithConditionalJoinedSegment() {
@@ -145,7 +145,7 @@ function testRightTransitiveJoiningWithConditionalJoinedSegment() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %K{015}%F{000}world2 %K{015}%F{000}world4 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %K{015}%F{000}\${(Q)\${:-\"world2\"}} %K{015}%F{000}\${(Q)\${:-\"world4\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithConditionalPredecessor() {
@@ -156,7 +156,7 @@ function testRightPromotingSegmentWithConditionalPredecessor() {
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD3="echo world3"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world3 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world3\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
@@ -168,7 +168,7 @@ function testRightPromotingSegmentWithJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD3="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD4="echo world4"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world4 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world4\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
@@ -182,7 +182,7 @@ function testRightPromotingSegmentWithDeepJoinedConditionalPredecessor() {
   local P9K_CUSTOM_WORLD5="echo " # Print nothing to simulate unmet conditions
   local P9K_CUSTOM_WORLD6="echo world6"
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world4 %K{015}%F{000}world6 " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world4\"}} %K{015}%F{000}\${(Q)\${:-\"world6\"}} " "$(__p9k_build_right_prompt)"
 }
 
 function testRightJoiningBuiltinSegmentWorks() {
@@ -192,7 +192,7 @@ function testRightJoiningBuiltinSegmentWorks() {
   alias php="echo PHP 1.2.3"
   source segments/php_version/php_version.p9k
 
-  assertEquals "%F{013}%K{013}%F{255} 1.2.3 %F{255}PHP%f %K{013}%F{255}1.2.3 %F{255}PHP%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{013}%K{013}%F{255} \${(Q)\${:-\"1.2.3\"}} %F{255}PHP%f %K{013}%F{255}\${(Q)\${:-\"1.2.3\"}} %F{255}PHP%f " "$(__p9k_build_right_prompt)"
 
   unalias php
 }

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -138,9 +138,9 @@ function testCustomStartEndSymbolsOnEdgeSegments() {
   local P9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL="_]_"
   local P9K_RIGHT_PROMPT_LAST_SEGMENT_END_WHITESPACE="_B_"
 
-  assertEquals "%K{NONE}%F{015}_[_%K{015}_A_%F{000}world1  %F{000}world2 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{NONE}%F{015}_[_%K{015}_A_%F{000}\${(Q)\${:-\"world1\"}}  %F{000}\${(Q)\${:-\"world2\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
   local _right=$(stripEsc "$(__p9k_build_right_prompt)")
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}%K{015}%F{000} world2_B_%K{none}%F{015}_]" "${_right}"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}%K{015}%F{000} \${(Q)\${:-\"world2\"}}_B_%K{none}%F{015}_]" "${_right}"
 }
 
 function testCustomWhitespaceOfSegments() {
@@ -163,8 +163,8 @@ function testCustomWhitespaceOfSegments() {
   local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
   local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[M]_"
 
-  assertEquals "%K{015}_[L]_%F{000}{1}_[M]_%F{000}world1_[L]__[L]_%F{000}world2_[L]__[L]_%F{000}{3}_[M]_%F{000}world3_[L]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000}_[R]_world1_[M]_%F{000}{1}%f_[R]_%F{000}%K{015}%F{000}_[R]_world2_[R]_%F{000}%K{015}%F{000}_[R]_world3_[M]_%F{000}{3}%f_[R]" "$(stripEsc "$(__p9k_build_right_prompt)")"
+  assertEquals "%K{015}_[L]_%F{000}{1}_[M]_%F{000}\${(Q)\${:-\"world1\"}}_[L]__[L]_%F{000}\${(Q)\${:-\"world2\"}}_[L]__[L]_%F{000}{3}_[M]_%F{000}\${(Q)\${:-\"world3\"}}_[L]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000}_[R]_\${(Q)\${:-\"world1\"}}_[M]_%F{000}{1}%f_[R]_%F{000}%K{015}%F{000}_[R]_\${(Q)\${:-\"world2\"}}_[R]_%F{000}%K{015}%F{000}_[R]_\${(Q)\${:-\"world3\"}}_[M]_%F{000}{3}%f_[R]" "$(stripEsc "$(__p9k_build_right_prompt)")"
 }
 
 function testCustomWhitespaceOfLeftAndRightSegments() {
@@ -189,8 +189,8 @@ function testCustomWhitespaceOfLeftAndRightSegments() {
   local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[RM]_"
   local P9K_RIGHT_WHITESPACE_OF_RIGHT_SEGMENTS="_[RR]_"
 
-  assertEquals "%K{015}_[LL]_%F{000}{1}_[LM]_%F{000}world1_[LR]__[LL]_%F{000}world2_[LR]__[LL]_%F{000}{3}_[LM]_%F{000}world3_[LR]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000}_[RL]_world1_[RM]_%F{000}{1}%f_[RR]_%F{000}%K{015}%F{000}_[RL]_world2_[RR]_%F{000}%K{015}%F{000}_[RL]_world3_[RM]_%F{000}{3}%f_[RR]" "$(stripEsc "$(__p9k_build_right_prompt)")"
+  assertEquals "%K{015}_[LL]_%F{000}{1}_[LM]_%F{000}\${(Q)\${:-\"world1\"}}_[LR]__[LL]_%F{000}\${(Q)\${:-\"world2\"}}_[LR]__[LL]_%F{000}{3}_[LM]_%F{000}\${(Q)\${:-\"world3\"}}_[LR]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000}_[RL]_\${(Q)\${:-\"world1\"}}_[RM]_%F{000}{1}%f_[RR]_%F{000}%K{015}%F{000}_[RL]_\${(Q)\${:-\"world2\"}}_[RR]_%F{000}%K{015}%F{000}_[RL]_\${(Q)\${:-\"world3\"}}_[RM]_%F{000}{3}%f_[RR]" "$(stripEsc "$(__p9k_build_right_prompt)")"
 }
 
 function testCustomWhitespaceOfCustomSegments() {
@@ -219,8 +219,8 @@ function testCustomWhitespaceOfCustomSegments() {
   local P9K_CUSTOM_WORLD3_MIDDLE_WHITESPACE="_[M3]_"
   local P9K_CUSTOM_WORLD3_RIGHT_WHITESPACE="_[R3]_"
 
-  assertEquals "%K{015}_[L1]_%F{000}{1}_[M1]_%F{000}world1_[R1]__[L2]_%F{000}world2_[R2]__[L3]_%F{000}{3}_[M3]_%F{000}world3_[R3]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
-  assertEquals "%F{015}%K{015}%F{000}_[L1]_world1_[M1]_%F{000}{1}%f_[R1]_%F{000}%K{015}%F{000}_[L2]_world2_[R2]_%F{000}%K{015}%F{000}_[L3]_world3_[M3]_%F{000}{3}%f_[R3]" "$(stripEsc "$(__p9k_build_right_prompt)")"
+  assertEquals "%K{015}_[L1]_%F{000}{1}_[M1]_%F{000}\${(Q)\${:-\"world1\"}}_[R1]__[L2]_%F{000}\${(Q)\${:-\"world2\"}}_[R2]__[L3]_%F{000}{3}_[M3]_%F{000}\${(Q)\${:-\"world3\"}}_[R3]_%k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%F{015}%K{015}%F{000}_[L1]_\${(Q)\${:-\"world1\"}}_[M1]_%F{000}{1}%f_[R1]_%F{000}%K{015}%F{000}_[L2]_\${(Q)\${:-\"world2\"}}_[R2]_%F{000}%K{015}%F{000}_[L3]_\${(Q)\${:-\"world3\"}}_[M3]_%F{000}{3}%f_[R3]" "$(stripEsc "$(__p9k_build_right_prompt)")"
 }
 
 function testCustomWhitespaceWithIconOnLeft() {
@@ -242,7 +242,7 @@ function testCustomWhitespaceWithIconOnLeft() {
   local P9K_MIDDLE_WHITESPACE_OF_RIGHT_SEGMENTS="_[M]_"
   local P9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS="_[R]_"
 
-  assertEquals "%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[M]_%F{000}world1_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}world2_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[M]_%F{000}world3_[R]" "$(stripEsc "$(__p9k_build_right_prompt)")"
+  assertEquals "%F{015}%K{015}%F{000}_[R]_%F{000}{1}%f_[M]_%F{000}\${(Q)\${:-\"world1\"}}_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}\${(Q)\${:-\"world2\"}}_[R]_%F{000}%K{015}%F{000}_[R]_%F{000}{3}%f_[M]_%F{000}\${(Q)\${:-\"world3\"}}_[R]" "$(stripEsc "$(__p9k_build_right_prompt)")"
 }
 
 source shunit2/shunit2

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -21,7 +21,7 @@ function testOverwritingIconsWork() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}icon-here %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
@@ -31,7 +31,7 @@ function testVisualIdentifierAppearsBeforeSegmentContentOnLeftSegments() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%K{015} %F{000}icon-here %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}icon-here %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
@@ -41,7 +41,7 @@ function testVisualIdentifierAppearsAfterSegmentContentOnRightSegments() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='icon-here'
 
-  assertEquals "%F{015}%K{015}%F{000} world1 %F{000}icon-here%f " "$(__p9k_build_right_prompt)"
+  assertEquals "%F{015}%K{015}%F{000} \${(Q)\${:-\"world1\"}} %F{000}icon-here%f " "$(__p9k_build_right_prompt)"
 }
 
 function testVisualIdentifierPrintsNothingIfNotAvailable() {
@@ -50,7 +50,7 @@ function testVisualIdentifierPrintsNothingIfNotAvailable() {
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1)
   local P9K_CUSTOM_WORLD1='echo world1'
 
-  assertEquals "%K{015} %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testVisualIdentifierWorksWithUnicodeIcon() {
@@ -60,7 +60,7 @@ function testVisualIdentifierWorksWithUnicodeIcon() {
   local P9K_CUSTOM_WORLD1='echo world1'
   local P9K_CUSTOM_WORLD1_ICON='\u2714'
 
-  assertEquals "%K{015} %F{000}✔ %F{000}world1 %k%F{015}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{015} %F{000}✔ %F{000}\${(Q)\${:-\"world1\"}} %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
 
 source shunit2/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -29,7 +29,7 @@ function testJoinedSegments() {
   local P9K_LEFT_PROMPT_ELEMENTS=(dir dir_joined)
   cd /tmp
 
-  assertEquals "%K{004} %F{000}/tmp %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp\"}} %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -40,7 +40,7 @@ function testTransitiveJoinedSegments() {
   source segments/root_indicator/root_indicator.p9k
   cd /tmp
 
-  assertEquals "%K{004} %F{000}/tmp %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp\"}} %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -54,7 +54,7 @@ function testJoiningWithConditionalSegment() {
 
   cd /tmp
 
-  assertEquals "%K{004} %F{000}/tmp  %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}\${(Q)\${:-\"/tmp\"}}  %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -67,7 +67,7 @@ function testDynamicColoringOfSegmentsWork() {
 
   cd /tmp
 
-  assertEquals "%K{001} %F{000}/tmp %k%F{001}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{001} %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -81,7 +81,7 @@ function testDynamicColoringOfVisualIdentifiersWork() {
 
   cd /tmp
 
-  assertEquals "%K{004} %F{002}icon-here %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{002}icon-here %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -101,7 +101,7 @@ function testColoringOfVisualIdentifiersDoesNotOverwriteColoringOfSegment() {
 
   cd /tmp
 
-  assertEquals "%K{003} %F{002}icon-here %F{001}/tmp %k%F{003}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{003} %F{002}icon-here %F{001}\${(Q)\${:-\"/tmp\"}} %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   cd -
 }
@@ -118,7 +118,7 @@ function testOverwritingIconsWork() {
   #cd ~/$testFolder
 
   cd /tmp
-  assertEquals "%K{004} %F{000}icon-here %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
+  assertEquals "%K{004} %F{000}icon-here %F{000}\${(Q)\${:-\"/tmp\"}} %k%F{004}%f " "$(__p9k_build_left_prompt)"
 
   cd -
   # rm -fr ~/$testFolder
@@ -152,7 +152,6 @@ function testNewlineOnRpromptCanBeDisabled() {
   # set +vx;
 
   assertEquals "$expected" "$_real"
-
 }
 
 source shunit2/shunit2

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -6,6 +6,7 @@ setopt shwordsplit
 SHUNIT_PARENT=$0
 
 function setUp() {
+  emulate -L zsh
   export TERM="xterm-256color"
   local -a P9K_RIGHT_PROMPT_ELEMENTS
   P9K_RIGHT_PROMPT_ELEMENTS=()
@@ -16,6 +17,29 @@ function setUp() {
 
   # Unset mode, so that user settings
   # do not interfere with tests
+}
+
+function oneTimeSetUp() {
+  function stripEsc() {
+    local clean_string="" escape_found=false
+    for (( i = 0; i < ${#1}; i++ )); do
+      case ${1[i]}; in
+        "")  clean_string+="<Esc>"; escape_found=true ;; # escape character
+        "[")  if [[ ${escape_found} == true ]]; then
+              escape_found=false
+            else
+              clean_string+="${1[i]}"
+            fi
+            ;;
+        *)    clean_string+="${1[i]}" ;;
+      esac
+    done
+    echo "${clean_string}"
+  }
+}
+
+function oneTimeTearDown() {
+  unfunction stripEsc
 }
 
 function testUsingUnsetVariables() {
@@ -137,9 +161,8 @@ function testNewlineOnRpromptCanBeDisabled() {
   __p9k_prepare_prompts
 
   local nl=$'\n'
-  #               ╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [00m[1B
-  local expected="╭─[39m[0m[49m[107m [30mworld [49m[97m[39m ${nl}╰─ [1A[39m[0m[49m[97m[107m[30m rworld [00m[1B"
-  local _real="$(print -P ${PROMPT}${RPROMPT})"
+  local expected="╭─%f%b%k%K{015} %F{000}\${(Q)\${:-\"world\"}} %k%F{015}%f ${nl}╰─ %{<Esc>1A%}%f%b%k%F{015}%K{015}%F{000} \${(Q)\${:-\"rworld\"}} %{<Esc>00m%}%{<Esc>1B%"
+  local _real=$(stripEsc "${PROMPT}${RPROMPT}")
 
   # use this to debug output with special escape sequences
   # new lines for escape codes that move output one line above
@@ -151,7 +174,7 @@ function testNewlineOnRpromptCanBeDisabled() {
   # echo "\n__3__\n"
   # set +vx;
 
-  assertEquals "$expected" "$_real"
+  assertEquals "${expected}" "${_real}"
 }
 
 source shunit2/shunit2


### PR DESCRIPTION
This is a backport of 5446c1f51e01af8d73e93f4fa6b7b9ba1df7ce8f . I removed the `__p9k_unsafe_PROMPT`, as this is not necessary any more and Romans solution is more flexible. This fixes #1310 