### PR TITLE
[Docs] VCS env vars typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,9 +657,9 @@ customization is provided via:
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-|`POWERLEVEL9K_HIDE_BRANCH_ICON`|`false`|Set to `true` to hide the branch icon from the segment.|
-|`POWERLEVEL9K_SHOW_CHANGESET`|`false`|Set to `true` to display the hash / changeset in the segment.|
-|`POWERLEVEL9K_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
+|`POWERLEVEL9K_VCS_HIDE_BRANCH_ICON`|`false`|Set to `true` to hide the branch icon from the segment.|
+|`POWERLEVEL9K_VCS_SHOW_CHANGESET`|`false`|Set to `true` to display the hash / changeset in the segment.|
+|`POWERLEVEL9K_VCS_CHANGESET_HASH_LENGTH`|`12`|How many characters of the hash / changeset to display in the segment.|
 |`POWERLEVEL9K_VCS_SHOW_SUBMODULE_DIRTY`|`true`|Set to `false` to not reflect submodule status in the top-level repository prompt.|
 |`POWERLEVEL9K_VCS_HIDE_TAGS`|`false`|Set to `true` to stop tags being displayed in the segment.|
 |`POWERLEVEL9K_VCS_GIT_HOOKS`|`(vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname)`|Layout of the segment for git repositories.|


### PR DESCRIPTION
#### Description

It seems like the first few environment variables documented for the VCS prompt element don't have the `_VCS` included. I only tested setting `POWERLEVEL9K_VCS_HIDE_BRANCH_ICON`, but would assume the rest follow the same convention.