### PR TITLE
[Bugfix] Fix failed attempt to open nonexistent `/proc/1/stat`.

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -101,10 +101,14 @@ function __p9k_detect_terminal() {
       fi
       local pid=$$ termtest=''
       while true; do
+        if test "$pid" = "1" -o "$pid" = ""; then
+          __P9K_TERMINAL="unknown"
+          return
+        fi
         proc_stat=(${(@f)$(</proc/${pid}/stat)})
         termtest=${proc_stat[2]//[()]/}
         case "${termtest}" in
-          gnome-terminal|guake|konsole|rxvt|termite|urxvt|xterm|yakuake)
+          gnome-terminal|guake|konsole|rxvt|termite|urxvt|xterm|yakuake|xfce4-terminal)
             __P9K_TERMINAL="${termtest}"
             return
           ;;
@@ -116,10 +120,6 @@ function __p9k_detect_terminal() {
             fi
           ;;
         esac
-        if test "$pid" = "1" -o "$pid" = ""; then
-          __P9K_TERMINAL="unknown"
-          return
-        fi
         pid=${proc_stat[4]}
       done
     fi


### PR DESCRIPTION
Fix failed attempt to open nonexistent `/proc/1/stat`.

Previously, when a terminal is not found, it climbs up the proccess tree
until it tries to open `/proc/1/stat` and fails with
`__p9k_detect_terminal:23: no such file or directory: /proc/1/stat`.

This appears to be harmless, but gives an annoying error whenever
starting zsh.

Sliding the pid check before the
`proc_stat=(${(@f)$(</proc/${pid}/stat)})` solved this problem.

Also adds `xfce4-terminal` to list of terminal emulators.

Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

Btw, I'm liking this new `next` branch. The time between prompts showing up has gone from a sluggish ~0.5s to a wonderful ~0.05s. Thank you!