### PR TITLE
[Bugfix] Make icons appear properly.

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -450,6 +450,9 @@ local NEWLINE='
     repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
     PROMPT="${NEWLINES}${PROMPT}"
   fi
+
+  # Make icons appear properly
+  PROMPT="$(echo -n "${PROMPT}")"
 }
 
 p9k::set_default P9K_IGNORE_TERM_COLORS false


### PR DESCRIPTION
This was originally only happening to the blue bar, but when I rebased this commit against the most recent commit on `next` it had actually regressed!

Anyways, pictures are worth a thousand words.

```
P9K_MULTILINE_LAST_PROMPT_PREFIX_ICON="%K{004}%F{000} %D{\uF017 %H:%M \uF073 %d.%m.%y} %f%k%F{004} %f"
P9K_TIME_FORMAT="%D{\uF017 %H:%M \uF073 %d/%m/%y}"
```

`next` from yesterday:
![](https://imgur.com/wTRhmqH.png)

`next` from today:
![](https://imgur.com/01CH4yY.png)

`next` with this PR:
![](https://imgur.com/5pQZf8P.png)

Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

Edit: Note: I normally only have the blue one, not the white one. I just added it for reference.